### PR TITLE
Lock iqsharp-base version of Debian to Stretch.

### DIFF
--- a/images/iqsharp-base/Dockerfile
+++ b/images/iqsharp-base/Dockerfile
@@ -1,5 +1,5 @@
 # The same image used by mybinder.org
-FROM python:3.7-slim
+FROM python:3.7-slim-stretch
 
 # install the notebook package
 RUN pip install --no-cache --upgrade pip && \


### PR DESCRIPTION
This PR fixes the version of Debian used in the FROM line for the iqsharp-base image to stretch, rather than allowing iqsharp-base to upgrade implicitly.