### PR TITLE
Avasch01/json serialization

### DIFF
--- a/images/iqsharp-base/Dockerfile
+++ b/images/iqsharp-base/Dockerfile
@@ -93,7 +93,7 @@ ENV PATH=$PATH:${HOME}/dotnet:${HOME}/.dotnet/tools \
 # Install IQ# and the project templates, using the NuGet packages from the
 # build context.
 ARG IQSHARP_VERSION
-RUN dotnet new -i "Microsoft.Quantum.ProjectTemplates::0.8.1907.1701" && \
+RUN dotnet new -i "Microsoft.Quantum.ProjectTemplates::0.8.1908.202-beta" && \
     dotnet tool install \
            --global \
            Microsoft.Quantum.IQSharp \

--- a/src/Core/Core.csproj
+++ b/src/Core/Core.csproj
@@ -34,9 +34,9 @@
     <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Quantum.Compiler" Version="0.8.1907.1701" />
-    <PackageReference Include="Microsoft.Quantum.CsharpGeneration" Version="0.8.1907.1701" />
-    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.8.1907.1701" />
+    <PackageReference Include="Microsoft.Quantum.Compiler" Version="0.8.1908.202-beta" />
+    <PackageReference Include="Microsoft.Quantum.CsharpGeneration" Version="0.8.1908.202-beta" />
+    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.8.1908.202-beta" />
     <PackageReference Include="NuGet.Resolver" Version="5.1.0" />
     <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
   </ItemGroup>

--- a/src/Core/TupleConversion.cs
+++ b/src/Core/TupleConversion.cs
@@ -24,7 +24,8 @@ namespace Microsoft.Quantum.IQSharp
             converters = new JsonConverter[] {
                 new QTupleConverter(),
                 new QVoidConverter(),
-                new UDTConverter()
+                new UDTConverter(),
+                new ResultConverter()
             }.ToImmutableList();
         }
 
@@ -143,6 +144,22 @@ namespace Microsoft.Quantum.IQSharp
             {
                 ["@type"] = "tuple"
             });
+            token.WriteTo(writer);
+        }
+    }
+
+    public class ResultConverter : JsonConverter<Result>
+    {
+        public override Result ReadJson(JsonReader reader, Type objectType, Result existingValue, bool hasExistingValue, JsonSerializer serializer)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override void WriteJson(JsonWriter writer, Result value, JsonSerializer serializer)
+        {
+            // See https://github.com/JamesNK/Newtonsoft.Json/issues/386#issuecomment-421161191
+            // for why this works to pass through.
+            var token = JToken.FromObject(value.GetValue(), serializer);
             token.WriteTo(writer);
         }
     }

--- a/src/Tests/SerializationTests.cs
+++ b/src/Tests/SerializationTests.cs
@@ -20,12 +20,12 @@ namespace Tests.IQSharp
 {
     public class Complex : UDTBase<(double, double)>
     {
-        public Complex((double, double) data) : base(data) {}
+        public Complex((double, double) data) : base(data) { }
     }
 
     public class QubitState : UDTBase<(Complex, Complex)>
     {
-        public QubitState((Complex, Complex) data) : base(data) {}
+        public QubitState((Complex, Complex) data) : base(data) { }
     }
 
     [TestClass]
@@ -96,6 +96,21 @@ namespace Tests.IQSharp
                 new QubitState((new Complex((0.1, 0.2)), new Complex((0.3, 0.4)))),
                 deserialized
             );
+        }
+
+        [TestMethod]
+        public async Task SerializeResultInstance()
+        {
+            {
+                Result result = new ResultConst(ResultValue.One);
+                var token = JToken.Parse(JsonConvert.SerializeObject(result, TupleConverters.Converters));
+                Assert.AreEqual(1, token.Value<int>());
+            }
+            {
+                Result result = new ResultConst(ResultValue.Zero);
+                var token = JToken.Parse(JsonConvert.SerializeObject(result, TupleConverters.Converters));
+                Assert.AreEqual(0, token.Value<int>());
+            }
         }
 
     }

--- a/src/Tool/appsettings.json
+++ b/src/Tool/appsettings.json
@@ -6,15 +6,15 @@
     },
     "AllowedHosts": "*",
     "DefaultPackageVersions": [
-        "Microsoft.Quantum.Standard::0.8.1907.1701",
-        "Microsoft.Quantum.Chemistry::0.8.1907.1701",
-        "Microsoft.Quantum.Chemistry.Jupyter::0.8.1907.1701",
-        "Microsoft.Quantum.Compiler::0.8.1907.1701",
-        "Microsoft.Quantum.CsharpGeneration::0.8.1907.1701",
-        "Microsoft.Quantum.Numerics::0.8.1907.1701",
-        "Microsoft.Quantum.Development.Kit::0.8.1907.1701",
-        "Microsoft.Quantum.Research::0.8.1907.1701",
-        "Microsoft.Quantum.Simulators::0.8.1907.1701",
-        "Microsoft.Quantum.Xunit::0.8.1907.1701"
+        "Microsoft.Quantum.Standard::0.8.1908.202-beta",
+        "Microsoft.Quantum.Chemistry::0.8.1908.202-beta",
+        "Microsoft.Quantum.Chemistry.Jupyter::0.8.1908.202-beta",
+        "Microsoft.Quantum.Compiler::0.8.1908.202-beta",
+        "Microsoft.Quantum.CsharpGeneration::0.8.1908.202-beta",
+        "Microsoft.Quantum.Numerics::0.8.1908.202-beta",
+        "Microsoft.Quantum.Development.Kit::0.8.1908.202-beta",
+        "Microsoft.Quantum.Research::0.8.1908.202-beta",
+        "Microsoft.Quantum.Simulators::0.8.1908.202-beta",
+        "Microsoft.Quantum.Xunit::0.8.1908.202-beta"
     ]
 }


### PR DESCRIPTION
Json serialization is updated to support the Result type properly. This corresponds to the recent change in qsharp runtime.