### PR TITLE
Workspace Loader Only Check Top Level Directory

### DIFF
--- a/src/Core/Workspace/Workspace.cs
+++ b/src/Core/Workspace/Workspace.cs
@@ -222,7 +222,7 @@ namespace Microsoft.Quantum.IQSharp
 
                 if (File.Exists(CacheDll)) { File.Delete(CacheDll); }
 
-                files = Directory.EnumerateFiles(Root, "*.qs", SearchOption.AllDirectories).ToArray();
+                files = Directory.EnumerateFiles(Root, "*.qs", SearchOption.TopDirectoryOnly).ToArray();
 
                 if (files.Length > 0)
                 {


### PR DESCRIPTION
Changed the behavior of the workspace loader's file search to only check for qs file in the top level folder.