### PR TITLE
Loading from attributes & other perf related things

### DIFF
--- a/src/Core/AssemblyInfo.cs
+++ b/src/Core/AssemblyInfo.cs
@@ -70,7 +70,7 @@ namespace Microsoft.Quantum.IQSharp
 
             // Parse the assembly headers to find which types are operation or function types.
             var logger = new QSharpLogger(null); 
-            var refs = ProjectManager.LoadReferencedAssemblies(new[] { Location }, d => logger.Log(d), ex => logger.Log(ex));
+            var refs = ProjectManager.LoadReferencedAssemblies(new[] { Location }, d => logger.Log(d), ex => logger.Log(ex), ignoreDllResources:CompilerMetadata.LoadFromCsharp);
 
             var callables = refs.SelectMany(pair => pair.Value.Callables);
 

--- a/src/Core/Compiler/CompilerMetadata.cs
+++ b/src/Core/Compiler/CompilerMetadata.cs
@@ -9,7 +9,7 @@ using System.Reflection;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.Quantum.QsCompiler.CompilationBuilder;
-
+using Microsoft.Quantum.IQSharp.Common;
 
 using QsReferences = Microsoft.Quantum.QsCompiler.CompilationBuilder.References;
 

--- a/src/Core/Compiler/CompilerMetadata.cs
+++ b/src/Core/Compiler/CompilerMetadata.cs
@@ -9,7 +9,7 @@ using System.Reflection;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.Quantum.QsCompiler.CompilationBuilder;
-using Microsoft.Quantum.IQSharp.Common;
+
 
 using QsReferences = Microsoft.Quantum.QsCompiler.CompilationBuilder.References;
 
@@ -17,6 +17,8 @@ namespace Microsoft.Quantum.IQSharp
 {
     public class CompilerMetadata
     {
+        internal static readonly bool LoadFromCsharp = true; // todo: we should make this properly configurable
+
         private IEnumerable<String> Paths { get; }
 
         /// <summary>
@@ -94,7 +96,7 @@ namespace Microsoft.Quantum.IQSharp
         /// Calculates Q# metadata needed for all the Assemblies and their dependencies.
         /// </summary>
         private static QsReferences QsInit(IEnumerable<string> paths) =>
-            new QsReferences(ProjectManager.LoadReferencedAssemblies(paths), null);
+            new QsReferences(ProjectManager.LoadReferencedAssemblies(paths, ignoreDllResources:CompilerMetadata.LoadFromCsharp), null);
 
         public CompilerMetadata WithAssemblies(params AssemblyInfo[] assemblies)
         {

--- a/src/Core/Compiler/CompilerService.cs
+++ b/src/Core/Compiler/CompilerService.cs
@@ -90,12 +90,12 @@ namespace Microsoft.Quantum.IQSharp
         private static QsCompiler.SyntaxTree.QsNamespace[] BuildQsSyntaxTree(ImmutableDictionary<Uri, string> sources, QsReferences references, QSharpLogger logger, string dllName)
         {
             var outFolder = Path.GetDirectoryName(dllName);
-            var outFile = Path.Combine(outFolder, Path.GetFileNameWithoutExtension(dllName) + ".bson");
+            var project = Path.Combine(outFolder, Path.GetFileNameWithoutExtension(dllName));
             var loadOptions = new QsCompiler.CompilationLoader.Configuration
             {
                 GenerateFunctorSupport = true,
                 BuildOutputFolder = ".",
-                ProjectName = outFile
+                ProjectName = project
             };
             var loaded = new QsCompiler.CompilationLoader(_ => sources, _ => references, loadOptions, logger);
             return loaded.GeneratedSyntaxTree?.ToArray();

--- a/src/Core/Compiler/CompilerService.cs
+++ b/src/Core/Compiler/CompilerService.cs
@@ -11,7 +11,6 @@ using System.Text;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.Emit;
 using Microsoft.Quantum.IQSharp.Common;
 using Microsoft.Quantum.QsCompiler.CompilationBuilder;
 using Microsoft.Quantum.QsCompiler.CsharpGeneration;

--- a/src/Core/Compiler/CompilerService.cs
+++ b/src/Core/Compiler/CompilerService.cs
@@ -16,7 +16,6 @@ using Microsoft.Quantum.QsCompiler;
 using Microsoft.Quantum.QsCompiler.CompilationBuilder;
 using Microsoft.Quantum.QsCompiler.CsharpGeneration;
 using Microsoft.Quantum.QsCompiler.DataTypes;
-using Microsoft.Quantum.QsCompiler.Diagnostics;
 using Microsoft.Quantum.QsCompiler.Serialization;
 using Microsoft.Quantum.QsCompiler.SyntaxTree;
 using Microsoft.Quantum.QsCompiler.Transformations.BasicTransformations;
@@ -32,17 +31,6 @@ namespace Microsoft.Quantum.IQSharp
     /// </summary>
     public class CompilerService : ICompilerService
     {
-        //private QSharpLogger Logger;
-        //private readonly CompilationUnitManager CompilationManager;
-        //private ImmutableHashSet<Uri> LoadedFileManagers;
-        //private ImmutableHashSet<NonNullable<string>> LoadedReferences;
-        //
-        //public CompilerService()
-        //{
-        //    this.Logger = new QSharpLogger(null);
-        //    this.CompilationManager = new CompilationUnitManager(ex => this.Logger?.Log(ex));
-        //}
-
         /// <summary>
         /// Compiles the given Q# code and returns the list of elements found in it.
         /// The compiler does this on a best effort, so it will return the elements even if the compilation fails.
@@ -50,17 +38,6 @@ namespace Microsoft.Quantum.IQSharp
         public IEnumerable<QsNamespaceElement> IdentifyElements(string source)
         {
             var uri = new Uri(Path.GetFullPath("__CODE_SNIPPET__.qs"));
-
-            // TODO: we should adapt the ICompilerService interface 
-            // to have IdentifyElements only return an IEnumerable<QsQuanlifiedName>, and then we can use the code below:
-            //
-            //var nsName = NonNullable<string>.New(Snippets.SNIPPETS_NAMESPACE);
-            //var content = $"namespace {nsName.Value} {{ {source} }}";
-            //var fileManager = CompilationUnitManager.InitializeFileManager(uri, content);
-            //var definedCallables = fileManager.GetCallableDeclarations();
-            //var definedTypes = fileManager.GetTypeDeclarations();
-            //return definedCallables.Concat(definedTypes).Select(decl => new QsQualifiedName(nsName, decl.Item1));
-
             var ns = NonNullable<string>.New(Snippets.SNIPPETS_NAMESPACE);
             var sources = new Dictionary<Uri, string>() { { uri, $"namespace {ns.Value} {{ {source} }}" } }.ToImmutableDictionary();
             var loadOptions = new CompilationLoader.Configuration();
@@ -78,32 +55,6 @@ namespace Microsoft.Quantum.IQSharp
         /// </summary> 
         private QsCompilation UpdateCompilation(ImmutableDictionary<Uri, string> sources, QsReferences references = null, QSharpLogger logger = null)
         {
-            //this.Logger = logger;
-            //var currentSources = this.LoadedFileManagers ?? ImmutableHashSet<Uri>.Empty;
-            //var currentReferences = this.LoadedReferences ?? ImmutableHashSet<NonNullable<string>>.Empty;
-            //var updatedRefs = references != null && currentReferences.SymmetricExcept(references.Declarations.Keys).Any();
-            //
-            //// update source files 
-            //var files = CompilationUnitManager.InitializeFileManagers(sources, onException: ex => this.Logger?.Log(ex));
-            //this.CompilationManager.TryRemoveSourceFilesAsync(currentSources.Except(sources.Keys), suppressVerification: true);
-            //this.CompilationManager.AddOrUpdateSourceFilesAsync(files, suppressVerification: updatedRefs);
-            //this.LoadedFileManagers = sources.Keys.ToImmutableHashSet();
-            //
-            //// update references
-            //if (updatedRefs) this.CompilationManager.UpdateReferencesAsync(references);
-            //var compilation = this.CompilationManager.Build();
-            //this.LoadedReferences = compilation.References;
-            //
-            //// generate functor support and log diagnostics
-            //var diagnostics = compilation.Diagnostics();
-            //this.Logger?.Log(diagnostics.ToArray());
-            //if (!CodeGeneration.GenerateFunctorSpecializations(compilation.BuiltCompilation, out var built))
-            //{
-            //    this.Logger?.Log(Errors.LoadError(ErrorCode.FunctorGenerationFailed, new string[0], null));
-            //}
-            //
-            //return built;
-
             var loadOptions = new CompilationLoader.Configuration
             {
                 GenerateFunctorSupport = true,

--- a/src/Core/Compiler/ICompilerService.cs
+++ b/src/Core/Compiler/ICompilerService.cs
@@ -1,10 +1,9 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System;
 using System.Collections.Generic;
-using System.Text;
 using Microsoft.Quantum.IQSharp.Common;
+using Microsoft.Quantum.QsCompiler.SyntaxTree;
 
 namespace Microsoft.Quantum.IQSharp
 {
@@ -24,9 +23,10 @@ namespace Microsoft.Quantum.IQSharp
         AssemblyInfo BuildFiles(string[] files, CompilerMetadata metadatas, QSharpLogger logger, string dllName);
 
         /// <summary>
-        /// Compiles the given Q# code and returns the list of elements found in it.
-        /// The compiler does this on a best effort, so it will return the elements even if the compilation fails.
-        /// </summary>
-        IEnumerable<QsCompiler.SyntaxTree.QsNamespaceElement> IdentifyElements(string source);
+        /// Returns the names of all declared callables and types. 
+        /// The compiler does this on a best effort, so it will return the elements even if the compilation fails. 
+        /// The compiler does this on a best effort, and in particular without relying on any context and/or type information, 
+        /// so it will return the elements even if the compilation fails.
+        IEnumerable<QsNamespaceElement> IdentifyElements(string source);
     }
 }

--- a/src/Core/Core.csproj
+++ b/src/Core/Core.csproj
@@ -34,9 +34,9 @@
     <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Quantum.Compiler" Version="0.10.1911.1602-beta" />
-    <PackageReference Include="Microsoft.Quantum.CsharpGeneration" Version="0.10.1911.1602-beta" />
-    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.10.1911.1602-beta" />
+    <PackageReference Include="Microsoft.Quantum.Compiler" Version="0.10.1911.1606-beta" />
+    <PackageReference Include="Microsoft.Quantum.CsharpGeneration" Version="0.10.1911.1606-beta" />
+    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.10.1911.1606-beta" />
     <PackageReference Include="NuGet.Resolver" Version="5.1.0" />
     <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
   </ItemGroup>

--- a/src/Core/Core.csproj
+++ b/src/Core/Core.csproj
@@ -34,9 +34,9 @@
     <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Quantum.Compiler" Version="0.10.1911.1401-alpha" />
-    <PackageReference Include="Microsoft.Quantum.CsharpGeneration" Version="0.10.1911.1402-alpha" />
-    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.10.1911.1402-alpha" />
+    <PackageReference Include="Microsoft.Quantum.Compiler" Version="0.10.1911.1703-alpha" />
+    <PackageReference Include="Microsoft.Quantum.CsharpGeneration" Version="0.10.1911.1704-alpha" />
+    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.10.1911.1704-alpha" />
     <PackageReference Include="NuGet.Resolver" Version="5.1.0" />
     <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
   </ItemGroup>

--- a/src/Core/Core.csproj
+++ b/src/Core/Core.csproj
@@ -34,9 +34,9 @@
     <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Quantum.Compiler" Version="0.10.1911.1603" />
-    <PackageReference Include="Microsoft.Quantum.CsharpGeneration" Version="0.10.1911.1603" />
-    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.10.1911.1603" />
+    <PackageReference Include="Microsoft.Quantum.Compiler" Version="0.10.1911.1602-beta" />
+    <PackageReference Include="Microsoft.Quantum.CsharpGeneration" Version="0.10.1911.1602-beta" />
+    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.10.1911.1602-beta" />
     <PackageReference Include="NuGet.Resolver" Version="5.1.0" />
     <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
   </ItemGroup>

--- a/src/Core/Core.csproj
+++ b/src/Core/Core.csproj
@@ -34,9 +34,9 @@
     <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Quantum.Compiler" Version="0.10.1911.1703-alpha" />
-    <PackageReference Include="Microsoft.Quantum.CsharpGeneration" Version="0.10.1911.1704-alpha" />
-    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.10.1911.1704-alpha" />
+    <PackageReference Include="Microsoft.Quantum.Compiler" Version="0.10.1911.1603" />
+    <PackageReference Include="Microsoft.Quantum.CsharpGeneration" Version="0.10.1911.1603" />
+    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.10.1911.1603" />
     <PackageReference Include="NuGet.Resolver" Version="5.1.0" />
     <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
   </ItemGroup>

--- a/src/Core/Extensions/Qsharp.cs
+++ b/src/Core/Extensions/Qsharp.cs
@@ -57,7 +57,7 @@ namespace Microsoft.Quantum.IQSharp
         /// <summary>
         ///      Formats a qualified name using dotted-name syntax.
         /// <summary>
-        internal static string ToFullName(this QsQualifiedName name) =>
+        public static string ToFullName(this QsQualifiedName name) =>
             name?.Namespace.Value + "." + name?.Name.Value;
 
         /// <summary>

--- a/src/Core/References/References.cs
+++ b/src/Core/References/References.cs
@@ -5,16 +5,12 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
-using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.Loader;
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using Microsoft.Quantum.IQSharp.Common;
-using Newtonsoft.Json.Linq;
 
 
 namespace Microsoft.Quantum.IQSharp

--- a/src/Core/Snippets/Snippet.cs
+++ b/src/Core/Snippets/Snippet.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Quantum.IQSharp
 
         /// <summary>
         ///     The compiler needs an actual URI for each piece of Q# code
-        //      that it is going to compile.
+        ///      that it is going to compile.
         /// </summary>
         [JsonIgnore]
         public Uri Uri => new Uri(Path.GetFullPath(Path.Combine("/", $"snippet_{id}.qs")));

--- a/src/Core/Snippets/Snippets.cs
+++ b/src/Core/Snippets/Snippets.cs
@@ -154,7 +154,7 @@ namespace Microsoft.Quantum.IQSharp
                 Snippet populate(Snippet s) =>
                     new Snippet()
                     {
-                        id = string.IsNullOrWhiteSpace(s.id) ? System.Guid.NewGuid().ToString() : s.id,
+                        id = string.IsNullOrWhiteSpace(s.id) ? Guid.NewGuid().ToString() : s.id,
                         code = s.code,
                         warnings = logger.Logs.Where(m => m.Source == s.Uri.AbsolutePath).Select(logger.Format).ToArray(),
                         Elements = assembly?.SyntaxTree?

--- a/src/Tool/appsettings.json
+++ b/src/Tool/appsettings.json
@@ -6,18 +6,18 @@
     },
     "AllowedHosts": "*",
   "DefaultPackageVersions": [
-    "Microsoft.Quantum.Compiler::0.10.1911.1401-alpha",
+    "Microsoft.Quantum.Compiler::0.10.1911.1603",
 
-    "Microsoft.Quantum.CsharpGeneration::0.10.1911.1402-alpha",
-    "Microsoft.Quantum.Development.Kit::0.10.1911.1402-alpha",
-    "Microsoft.Quantum.Simulators::0.10.1911.1402-alpha",
-    "Microsoft.Quantum.Xunit::0.10.1911.1402-alpha",
+    "Microsoft.Quantum.CsharpGeneration::0.10.1911.1603",
+    "Microsoft.Quantum.Development.Kit::0.10.1911.1603",
+    "Microsoft.Quantum.Simulators::0.10.1911.1603",
+    "Microsoft.Quantum.Xunit::0.10.1911.1603",
 
-    "Microsoft.Quantum.Standard::0.10.1911.1401-alpha",
-    "Microsoft.Quantum.Chemistry::0.10.1911.1401-alpha",
-    "Microsoft.Quantum.Chemistry.Jupyter::0.10.1911.1401-alpha",
-    "Microsoft.Quantum.Numerics::0.10.1911.1401-alpha",
+    "Microsoft.Quantum.Standard::0.10.1911.1603",
+    "Microsoft.Quantum.Chemistry::0.10.1911.1603",
+    "Microsoft.Quantum.Chemistry.Jupyter::0.10.1911.1603",
+    "Microsoft.Quantum.Numerics::0.10.1911.1603",
 
-    "Microsoft.Quantum.Research::0.10.1911.1401-alpha"
+    "Microsoft.Quantum.Research::0.10.1911.1603"
   ]
 }

--- a/src/Tool/appsettings.json
+++ b/src/Tool/appsettings.json
@@ -6,18 +6,18 @@
     },
     "AllowedHosts": "*",
   "DefaultPackageVersions": [
-    "Microsoft.Quantum.Compiler::0.10.1911.1603",
+    "Microsoft.Quantum.Compiler::0.10.1911.1602-beta",
 
-    "Microsoft.Quantum.CsharpGeneration::0.10.1911.1603",
-    "Microsoft.Quantum.Development.Kit::0.10.1911.1603",
-    "Microsoft.Quantum.Simulators::0.10.1911.1603",
-    "Microsoft.Quantum.Xunit::0.10.1911.1603",
+    "Microsoft.Quantum.CsharpGeneration::0.10.1911.1602-beta",
+    "Microsoft.Quantum.Development.Kit::0.10.1911.1602-beta",
+    "Microsoft.Quantum.Simulators::0.10.1911.1602-beta",
+    "Microsoft.Quantum.Xunit::0.10.1911.1602-beta",
 
-    "Microsoft.Quantum.Standard::0.10.1911.1603",
-    "Microsoft.Quantum.Chemistry::0.10.1911.1603",
-    "Microsoft.Quantum.Chemistry.Jupyter::0.10.1911.1603",
-    "Microsoft.Quantum.Numerics::0.10.1911.1603",
+    "Microsoft.Quantum.Standard::0.10.1911.1602-beta",
+    "Microsoft.Quantum.Chemistry::0.10.1911.1602-beta",
+    "Microsoft.Quantum.Chemistry.Jupyter::0.10.1911.1602-beta",
+    "Microsoft.Quantum.Numerics::0.10.1911.1602-beta",
 
-    "Microsoft.Quantum.Research::0.10.1911.1603"
+    "Microsoft.Quantum.Research::0.10.1911.1602-beta"
   ]
 }

--- a/src/Tool/appsettings.json
+++ b/src/Tool/appsettings.json
@@ -6,18 +6,18 @@
     },
     "AllowedHosts": "*",
   "DefaultPackageVersions": [
-    "Microsoft.Quantum.Compiler::0.10.1911.1602-beta",
+    "Microsoft.Quantum.Compiler::0.10.1911.1606-beta",
 
-    "Microsoft.Quantum.CsharpGeneration::0.10.1911.1602-beta",
-    "Microsoft.Quantum.Development.Kit::0.10.1911.1602-beta",
-    "Microsoft.Quantum.Simulators::0.10.1911.1602-beta",
-    "Microsoft.Quantum.Xunit::0.10.1911.1602-beta",
+    "Microsoft.Quantum.CsharpGeneration::0.10.1911.1606-beta",
+    "Microsoft.Quantum.Development.Kit::0.10.1911.1606-beta",
+    "Microsoft.Quantum.Simulators::0.10.1911.1606-beta",
+    "Microsoft.Quantum.Xunit::0.10.1911.1606-beta",
 
-    "Microsoft.Quantum.Standard::0.10.1911.1602-beta",
-    "Microsoft.Quantum.Chemistry::0.10.1911.1602-beta",
-    "Microsoft.Quantum.Chemistry.Jupyter::0.10.1911.1602-beta",
-    "Microsoft.Quantum.Numerics::0.10.1911.1602-beta",
+    "Microsoft.Quantum.Standard::0.10.1911.1606-beta",
+    "Microsoft.Quantum.Chemistry::0.10.1911.1606-beta",
+    "Microsoft.Quantum.Chemistry.Jupyter::0.10.1911.1606-beta",
+    "Microsoft.Quantum.Numerics::0.10.1911.1606-beta",
 
-    "Microsoft.Quantum.Research::0.10.1911.1602-beta"
+    "Microsoft.Quantum.Research::0.10.1911.1606-beta"
   ]
 }


### PR DESCRIPTION
For notebooks running on classical hardware, loading references based on attributes is a lot faster. I hence added an override switch in the compiler. 
I also added the in-memory resource generation. 