### PR TITLE
Add VSLS requirements to iqsharp-base.

### DIFF
--- a/images/iqsharp-base/Dockerfile
+++ b/images/iqsharp-base/Dockerfile
@@ -42,6 +42,13 @@ RUN wget -qO- https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor 
     apt-get -y install dotnet-sdk-3.0 && \
     apt-get clean && rm -rf /var/lib/apt/lists/
 
+# Install prerequisites needed for integration with Live Share and VS Online.
+# TODO: Consider splitting this out into a new "extended" IQ# image.
+RUN wget -O /tmp/vsls-reqs https://aka.ms/vsls-linux-prereq-script && \
+    chmod +x /tmp/vsls-reqs && /tmp/vsls-reqs && \
+    rm /tmp/vsls-reqs && \
+    apt-get clean && rm -rf /var/lib/apt/lists/
+
 # create user with a home directory
 # Required for mybinder.org
 ARG NB_USER=jovyan


### PR DESCRIPTION
This PR adds the Linux prerequisites for VS Live Share and VS Online documented at https://docs.microsoft.com/en-us/visualstudio/liveshare/reference/linux#install-linux-prerequisites to the iqsharp-base image. This makes it easier to use the iqsharp-base image and images derived from this image with remote development and with Visual Studio Online, reducing the startup time for those services substantially.