### PR TITLE
Get the HTTP Server to work

### DIFF
--- a/src/Tool/Startup.cs
+++ b/src/Tool/Startup.cs
@@ -4,7 +4,6 @@
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
 using Microsoft.Quantum.IQSharp.Jupyter;
 
 namespace Microsoft.Quantum.IQSharp
@@ -24,13 +23,21 @@ namespace Microsoft.Quantum.IQSharp
             services.AddIQSharp();
             services.AddIQSharpKernel();
 
-            services.AddMvc();
+            var assembly = typeof(PackagesController).Assembly;
+            services.AddControllers()
+                .AddApplicationPart(assembly);
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
         public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
         {
-            app.UseMvc();
+            app.UseRouting();
+
+            app.UseEndpoints(endpoints =>
+            {
+                endpoints.MapControllers();
+            });
+
         }
     }
 }

--- a/src/Web/AbstractOperationsController.cs
+++ b/src/Web/AbstractOperationsController.cs
@@ -20,6 +20,8 @@ namespace Microsoft.Quantum.IQSharp
 {
     public abstract class AbstractOperationsController : ControllerBase
     {
+        // TODO: This class may be exposing many more actions than required. Investigate making these protected or using [NonAction].
+
         // The list of operations available in the workspace.
         public abstract IEnumerable<OperationInfo> Operations { get; }
 
@@ -27,6 +29,7 @@ namespace Microsoft.Quantum.IQSharp
         /// Simulates the execution of the given operation using the given arguments
         /// to formulate an input tuple.
         /// </summary>
+        [NonAction]
         public async Task<object> Simulate(string id, IDictionary<string, string> args, Action<string> logger) =>
             await IfReady(async () =>
             {
@@ -45,6 +48,7 @@ namespace Microsoft.Quantum.IQSharp
         /// Returns an estimation of how many resources are needed to run the given operation on a quantum computer
         /// with the given arguments.
         /// </summary>
+        [NonAction]
         public async Task<Dictionary<string, double>> Estimate(string id, IDictionary<string, string> args, Action<string> logger) =>
             await IfReady(async () =>
             {
@@ -62,6 +66,7 @@ namespace Microsoft.Quantum.IQSharp
         /// If an Exception is caught, it returns an error response with the Exception as the
         /// corresponding error message.
         /// </summary>
+        [NonAction]
         public virtual async Task<Response<T>> AsResponse<T>(Func<Action<string>, Task<T>> action)
         {
             try


### PR DESCRIPTION
HTTP Server wasn't working for a bunch of reasons:
- Even though using .NET Core 3.0, it was using the .NET Core 2.2 routing setup.
- Controllers weren't being registered as they are in a different assembly.
- Endpoint generation was failing when trying to make actions out of complex method signatures that should probably be protected instead.

Fixed each of these. Got it working for myself now, running with `server` works.