### PR TITLE
Improved diagnostics when loading magic symbols, fix error message when magic missing

### DIFF
--- a/src/Core/Compiler/CompilerService.cs
+++ b/src/Core/Compiler/CompilerService.cs
@@ -42,7 +42,10 @@ namespace Microsoft.Quantum.IQSharp
             var sources = new Dictionary<Uri, string>() { { uri, $"namespace {ns.Value} {{ {source} }}" } }.ToImmutableDictionary();
             var loadOptions = new CompilationLoader.Configuration();
             var loaded = new CompilationLoader(_ => sources, _ => QsReferences.Empty, loadOptions);
-            return loaded.VerifiedCompilation?.SyntaxTree[ns].Elements;
+            if (loaded.VerifiedCompilation == null) { return ImmutableArray<QsNamespaceElement>.Empty; }
+            return loaded.VerifiedCompilation.SyntaxTree.TryGetValue(ns, out var tree)
+                   ? tree.Elements
+                   : ImmutableArray<QsNamespaceElement>.Empty;
         }
 
         /// <summary> 

--- a/src/Jupyter/IQSharpEngine.cs
+++ b/src/Jupyter/IQSharpEngine.cs
@@ -99,6 +99,7 @@ namespace Microsoft.Quantum.IQSharp.Jupyter
             }
             catch (Exception e)
             {
+                Logger.LogWarning(e, "Exception while executing mundane input: {Input}", input);
                 channel.Stderr(e.Message);
                 return ExecuteStatus.Error.ToExecutionResult();
             }

--- a/src/Jupyter/Jupyter.csproj
+++ b/src/Jupyter/Jupyter.csproj
@@ -22,7 +22,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Jupyter.Core" Version="1.2.7575-CI-20200121-190301" />
+    <PackageReference Include="Microsoft.Jupyter.Core" Version="1.2.29857" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Jupyter/Jupyter.csproj
+++ b/src/Jupyter/Jupyter.csproj
@@ -22,7 +22,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Jupyter.Core" Version="1.2.29857" />
+    <PackageReference Include="Microsoft.Jupyter.Core" Version="1.2.29939" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Jupyter/MagicResolver.cs
+++ b/src/Jupyter/MagicResolver.cs
@@ -101,7 +101,13 @@ namespace Microsoft.Quantum.IQSharp.Jupyter
 
             var magicTypes = assm.Assembly
                 .GetTypes()
-                .Where(t => t.IsClass && !t.IsAbstract && t.IsSubclassOf(typeof(MagicSymbol)));
+                .Where(t =>
+                {
+                    if (!t.IsClass && t.IsAbstract) { return false; }
+                    var matched = t.IsSubclassOf(typeof(MagicSymbol));
+                    this.logger.LogDebug("Class {Class} subclass of MagicSymbol? {Matched}", t.FullName, matched);
+                    return matched;
+                });
 
             var allMagic = new List<MagicSymbol>();
             foreach(var t in magicTypes)


### PR DESCRIPTION
This PR arises from work in diagnosing problems with #85, and adds new diagnostic messages when loading magic symbols from NuGet packages and when unexpected exceptions occur during mundane execution. These new diagnostics led to identifying the root cause of "key not present in dictionary" errors when magic symbols are missing, such that this PR includes a fix for that case. To avoid merge conflicts, this PR should go in after #60 completes.