### PR TITLE
Crazy4pi314/display encoder bug

### DIFF
--- a/src/Jupyter/Visualization/StateDisplayEncoders.cs
+++ b/src/Jupyter/Visualization/StateDisplayEncoders.cs
@@ -61,7 +61,13 @@ namespace Microsoft.Quantum.IQSharp.Jupyter
         ) => convention switch
             {
                 BasisStateLabelingConvention.Bitstring =>
-                    System.Convert.ToString(index, 2).PadLeft(NQubits, '0'),
+                    String.Concat(
+                        System
+                            .Convert
+                            .ToString(index, 2)
+                            .PadLeft(NQubits, '0')
+                            .Reverse()
+                    ),
                 BasisStateLabelingConvention.BigEndian =>
                     System.Convert.ToInt64(
                         String.Concat(

--- a/src/Jupyter/Visualization/StateDisplayEncoders.cs
+++ b/src/Jupyter/Visualization/StateDisplayEncoders.cs
@@ -26,6 +26,12 @@ namespace Microsoft.Quantum.IQSharp.Jupyter
     {
         public IEnumerable<int>? QubitIds { get; set; }
         public int NQubits { get; set; }
+        
+        /// <remarks>
+        ///     These amplitudes represent the computational basis states
+        ///     labeled in little-endian order, as per the behavior of 
+        ///     <see cref="Microsoft.Quantum.Simulation.Simulators.QuantumSimulator.StateDumper.Dump" />.
+        /// </remarks>
         public Complex[]? Amplitudes { get; set; }
 
         public IEnumerable<(Complex, string)> SignificantAmplitudes(

--- a/src/Jupyter/Visualization/StateDisplayEncoders.cs
+++ b/src/Jupyter/Visualization/StateDisplayEncoders.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Quantum.IQSharp.Jupyter
             {
                 BasisStateLabelingConvention.Bitstring =>
                     System.Convert.ToString(index, 2).PadLeft(NQubits, '0'),
-                BasisStateLabelingConvention.LittleEndian =>
+                BasisStateLabelingConvention.BigEndian =>
                     System.Convert.ToInt64(
                         String.Concat(
                             System.Convert.ToString(index, 2).PadLeft(NQubits, '0').Reverse()
@@ -70,7 +70,7 @@ namespace Microsoft.Quantum.IQSharp.Jupyter
                         fromBase: 2
                     )
                     .ToString(),
-                BasisStateLabelingConvention.BigEndian =>
+                BasisStateLabelingConvention.LittleEndian =>
                     index.ToString(),
                 _ => throw new ArgumentException($"Invalid basis state labeling convention {convention}.")
             };

--- a/src/Tests/DisplayConverterTests.cs
+++ b/src/Tests/DisplayConverterTests.cs
@@ -1,0 +1,84 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.Quantum.IQSharp.Jupyter;
+using System.Linq;
+using System.Collections.Generic;
+
+namespace Tests.IQSharp
+{
+
+    internal static class DisplayExtensions
+    {
+        internal static IEnumerable<(T, string)> WhereLabelIs<T>(
+            this IEnumerable<(T, string)> source,
+            string label
+        ) =>
+            source.Where(
+                item =>
+                {
+                    var (data, currentLabel) = item;
+                    return label == currentLabel;
+                }
+            );
+    }
+
+    [TestClass]
+    public class DisplayConverterTests
+    {
+        private readonly DisplayableState testState = new DisplayableState
+        {
+            QubitIds = new[] {0, 1, 2},
+            NQubits = 3,
+            Amplitudes = Enumerable
+                .Range(0, 8)
+                .Select(idx => new System.Numerics.Complex(0, idx))
+                .ToArray()
+        };
+
+        [TestMethod]
+        public void TestBigEndianLabels()
+        {
+            var testItem = testState
+                .SignificantAmplitudes(
+                    BasisStateLabelingConvention.BigEndian,
+                    false,
+                    0
+                )
+                .WhereLabelIs("6")
+                .Single();
+            Assert.AreEqual(testItem.Item1.Imaginary, 3.0);
+        }
+
+        [TestMethod]
+        public void TestLittleEndianLabels()
+        {
+            var testItem = testState
+                .SignificantAmplitudes(
+                    BasisStateLabelingConvention.LittleEndian,
+                    false,
+                    0
+                )
+                .WhereLabelIs("6")
+                .Single();
+            Assert.AreEqual(testItem.Item1.Imaginary, 6.0);
+        }
+
+        [TestMethod]
+        public void TestBitstringLabels()
+        {
+            var testItem = testState
+                .SignificantAmplitudes(
+                    BasisStateLabelingConvention.Bitstring,
+                    false,
+                    0
+                )
+                .WhereLabelIs("011")
+                .Single();
+            Assert.AreEqual(testItem.Item1.Imaginary, 6.0);
+        }
+
+    }
+
+}


### PR DESCRIPTION
This PR addresses a bug that I found while playing around with Q# kernel Jupyter notebooks where the output from `DumpRegister` was not correct for the encoding specified. Basically the simulator passes things indexed as little-endian and what was currently written for the `DisplayableState` class assumed big-endian. Also this adds the start of some testing that can help check that the display will be in the correct encoding.

- Sample that illustrated the problem in the first place:
```
open Microsoft.Quantum.Arithmetic;
open Microsoft.Quantum.Diagnostics;

operation DumpMultiplyExample() : Unit {
    using (qubits = Qubit[3]) {
        let register = LittleEndian(qubits);
        ApplyXorInPlace(1, register);
        DumpRegister((), register!);
        
        ResetAll(qubits);
    }
}

%config dump.basisStateLabelingConvention = "bitstring"
```

- Screenshot from current package we expect that this should return an amplitude of `1.0` at the index `100`:

![image](https://user-images.githubusercontent.com/6486256/74615397-35daa880-50d5-11ea-8bb5-5ced0f58ca76.png)



- Screenshot from post-fix:

![image](https://user-images.githubusercontent.com/6486256/74615293-49d1da80-50d4-11ea-8343-d8570e1aaec3.png)

