### PR TITLE
Use OnException event to display stack traces for exceptions.

### DIFF
--- a/src/Core/Core.csproj
+++ b/src/Core/Core.csproj
@@ -34,9 +34,9 @@
     <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Quantum.Compiler" Version="0.10.2003.304-beta" />
-    <PackageReference Include="Microsoft.Quantum.CsharpGeneration" Version="0.10.2003.304-beta" />
-    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.10.2003.304-beta" />
+    <PackageReference Include="Microsoft.Quantum.Compiler" Version="0.10.2003.1102-beta" />
+    <PackageReference Include="Microsoft.Quantum.CsharpGeneration" Version="0.10.2003.1102-beta" />
+    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.10.2003.1102-beta" />
     <PackageReference Include="NuGet.Resolver" Version="5.1.0" />
     <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
   </ItemGroup>

--- a/src/Core/Core.csproj
+++ b/src/Core/Core.csproj
@@ -34,9 +34,9 @@
     <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Quantum.Compiler" Version="0.10.2001.2831" />
-    <PackageReference Include="Microsoft.Quantum.CsharpGeneration" Version="0.10.2001.2831" />
-    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.10.2001.2831" />
+    <PackageReference Include="Microsoft.Quantum.Compiler" Version="0.10.2003.304-beta" />
+    <PackageReference Include="Microsoft.Quantum.CsharpGeneration" Version="0.10.2003.304-beta" />
+    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.10.2003.304-beta" />
     <PackageReference Include="NuGet.Resolver" Version="5.1.0" />
     <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
   </ItemGroup>

--- a/src/Jupyter/Extensions.cs
+++ b/src/Jupyter/Extensions.cs
@@ -9,6 +9,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Jupyter.Core;
 using Microsoft.Jupyter.Core.Protocol;
 using Microsoft.Quantum.IQSharp.Common;
+using Microsoft.Quantum.Simulation.Common;
 using Microsoft.Quantum.Simulation.Core;
 using Microsoft.Quantum.Simulation.Simulators;
 
@@ -97,6 +98,21 @@ namespace Microsoft.Quantum.IQSharp.Jupyter
             ((JupyterDumpRegister<string>)concreteOp).Channel = channel;
             ((JupyterDumpRegister<string>)concreteOp).ConfigurationSource = configurationSource;
 
+            return simulator;
+        }
+
+        public static T WithStackTraceDisplay<T>(this T simulator, IChannel channel)
+        where T: SimulatorBase
+        {
+            simulator.DisableDefaultStackTraceHandling();
+            simulator.OnException += (exception, stackTrace) =>
+            {
+                channel.Display(new DisplayableException
+                {
+                    Exception = exception,
+                    StackTrace = stackTrace
+                });
+            };
             return simulator;
         }
     }

--- a/src/Jupyter/Extensions.cs
+++ b/src/Jupyter/Extensions.cs
@@ -158,7 +158,7 @@ namespace Microsoft.Quantum.IQSharp.Jupyter
         public static T WithStackTraceDisplay<T>(this T simulator, IChannel channel)
         where T: SimulatorBase
         {
-            simulator.DisableDefaultStackTraceHandling();
+            simulator.DisableExceptionPrinting();
             simulator.OnException += (exception, stackTrace) =>
             {
                 channel.Display(new DisplayableException

--- a/src/Jupyter/IQSharpEngine.cs
+++ b/src/Jupyter/IQSharpEngine.cs
@@ -54,6 +54,8 @@ namespace Microsoft.Quantum.IQSharp.Jupyter
             RegisterDisplayEncoder(new StateVectorToTextResultEncoder(configurationSource));
             RegisterDisplayEncoder(new DataTableToHtmlEncoder());
             RegisterDisplayEncoder(new DataTableToTextEncoder());
+            RegisterDisplayEncoder(new DisplayableExceptionToHtmlEncoder());
+            RegisterDisplayEncoder(new DisplayableExceptionToTextEncoder());
             RegisterJsonEncoder(JsonConverters.AllConverters);
 
             RegisterSymbolResolver(this.SymbolsResolver);
@@ -119,3 +121,4 @@ namespace Microsoft.Quantum.IQSharp.Jupyter
         }
     }
 }
+

--- a/src/Jupyter/Magic/EstimateMagic.cs
+++ b/src/Jupyter/Magic/EstimateMagic.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Quantum.IQSharp.Jupyter
             var symbol = SymbolResolver.Resolve(name) as IQSharpSymbol;
             if (symbol == null) throw new InvalidOperationException($"Invalid operation name: {name}");
 
-            var qsim = new ResourcesEstimator();
+            var qsim = new ResourcesEstimator().WithStackTraceDisplay(channel);
             qsim.DisableLogToConsole();
 
             await symbol.Operation.RunAsync(qsim, args);

--- a/src/Jupyter/Magic/Simulate.cs
+++ b/src/Jupyter/Magic/Simulate.cs
@@ -36,7 +36,9 @@ namespace Microsoft.Quantum.IQSharp.Jupyter
             var symbol = SymbolResolver.Resolve(name) as IQSharpSymbol;
             if (symbol == null) throw new InvalidOperationException($"Invalid operation name: {name}");
 
-            using var qsim = new QuantumSimulator().WithJupyterDisplay(channel, ConfigurationSource);
+            using var qsim = new QuantumSimulator()
+                .WithJupyterDisplay(channel, ConfigurationSource)
+                .WithStackTraceDisplay(channel);
             var value = await symbol.Operation.RunAsync(qsim, args);
             return value.ToExecutionResult();
         }

--- a/src/Jupyter/Magic/ToffoliMagic.cs
+++ b/src/Jupyter/Magic/ToffoliMagic.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Quantum.IQSharp.Jupyter
             var symbol = SymbolResolver.Resolve(name) as IQSharpSymbol;
             if (symbol == null) throw new InvalidOperationException($"Invalid operation name: {name}");
 
-            var qsim = new ToffoliSimulator();
+            var qsim = new ToffoliSimulator().WithStackTraceDisplay(channel);
             qsim.DisableLogToConsole();
             qsim.OnLog += channel.Stdout;
 

--- a/src/Jupyter/Visualization/DisplayableExceptionEncoders.cs
+++ b/src/Jupyter/Visualization/DisplayableExceptionEncoders.cs
@@ -43,10 +43,15 @@ namespace Microsoft.Quantum.IQSharp
             : $"<a href=\"{frame.GetBestSourceLocation()}\">{frame.SourceFile}:{frame.FailedLineNumber}</a>";
     }
 
+    /// <summary>
+    ///      Encodes exceptions augmented with Q# metadata into HTML tables.
+    /// </summary>
     public class DisplayableExceptionToHtmlEncoder : IResultEncoder
     {
+        /// <inheritdoc />
         public string MimeType => MimeTypes.Html;
 
+        /// <inheritdoc />
         public EncodedData? Encode(object displayable)
         {
             if (displayable is DisplayableException ex)
@@ -83,10 +88,17 @@ namespace Microsoft.Quantum.IQSharp
             else return null;
         }
     }
+
+    /// <summary>
+    ///      Encodes exceptions augmented with Q# metadata into plain text
+    ///      tables.
+    /// </summary>
     public class DisplayableExceptionToTextEncoder : IResultEncoder
     {
+        /// <inheritdoc />
         public string MimeType => MimeTypes.PlainText;
 
+        /// <inheritdoc />
         public EncodedData? Encode(object displayable)
         {
             if (displayable is DisplayableException ex)

--- a/src/Jupyter/Visualization/DisplayableExceptionEncoders.cs
+++ b/src/Jupyter/Visualization/DisplayableExceptionEncoders.cs
@@ -1,0 +1,111 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+#nullable enable
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Data;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using Microsoft.Jupyter.Core;
+using Microsoft.Quantum.QsCompiler.SyntaxTree;
+using Microsoft.Quantum.Simulation.Common;
+using Microsoft.Quantum.Simulation.Core;
+using Microsoft.Quantum.Simulation.Simulators;
+
+namespace Microsoft.Quantum.IQSharp
+{
+    internal struct DisplayableException
+    {
+        public Exception Exception;
+        public IEnumerable<StackFrame> StackTrace;
+
+        public string Header =>
+            $"Unhandled exception. {Exception.GetType().FullName}: {Exception.Message}";
+    }
+
+    internal static class StackFrameExtensions
+    {
+        internal static string ToFriendlyName(this ICallable callable)
+        {
+            var fullName = callable.FullName;
+            return fullName.StartsWith(Snippets.SNIPPETS_NAMESPACE)
+            ? fullName.Substring(Snippets.SNIPPETS_NAMESPACE.Length + 1)
+            : fullName;
+        }
+
+        internal static string ToSourceLink(this StackFrame frame) =>
+            Regex.Match(frame.SourceFile, "snippet_[0-9]*.qs$").Success
+            ? "(notebook)"
+            : $"<a href=\"{frame.GetBestSourceLocation()}\">{frame.SourceFile}:{frame.FailedLineNumber}</a>";
+    }
+
+    public class DisplayableExceptionToHtmlEncoder : IResultEncoder
+    {
+        public string MimeType => MimeTypes.Html;
+
+        public EncodedData? Encode(object displayable)
+        {
+            if (displayable is DisplayableException ex)
+            {
+                var rows = ex
+                    .StackTrace
+                    .Select(frame => $@"
+                        <tr>
+                            <td>{frame.ToSourceLink()}</td>
+                            <td>{frame.Callable.ToFriendlyName()}</td>
+                        </tr>
+                    ");
+                var table = $@"
+                    <details>
+                        <summary>
+                            Unhandled exception of type {ex.Exception.GetType().FullName}: {ex.Exception.Message}
+                        </summary>
+                        <table>
+                            <thead>
+                                <tr>
+                                    <th>Source</th>
+                                    <th>Callable</th>
+                                </tr>
+                            </thead>
+
+                            <tbody>
+                                {String.Join("\n", rows)}
+                            </tbody>
+                        </table>
+                    </details>
+                ";
+                return table.ToEncodedData();
+            }
+            else return null;
+        }
+    }
+    public class DisplayableExceptionToTextEncoder : IResultEncoder
+    {
+        public string MimeType => MimeTypes.PlainText;
+
+        public EncodedData? Encode(object displayable)
+        {
+            if (displayable is DisplayableException ex)
+            {
+                var builder = new StringBuilder();
+                builder.AppendLine(ex.Header);
+                var first = true;
+                foreach (var frame in ex.StackTrace)
+                {
+                    builder.AppendLine(
+                        (first ? " ---> " : "   at ") +
+                        frame.ToStringWithBestSourceLocation()
+                    );
+                    first = false;
+                }
+                return builder.ToString().ToEncodedData();
+            }
+            else return null;
+        }
+    }
+
+}

--- a/src/Tool/appsettings.json
+++ b/src/Tool/appsettings.json
@@ -6,18 +6,18 @@
     },
     "AllowedHosts": "*",
   "DefaultPackageVersions": [
-    "Microsoft.Quantum.Compiler::0.10.2001.2831",
+    "Microsoft.Quantum.Compiler::0.10.2003.304-beta",
 
-    "Microsoft.Quantum.CsharpGeneration::0.10.2001.2831",
-    "Microsoft.Quantum.Development.Kit::0.10.2001.2831",
-    "Microsoft.Quantum.Simulators::0.10.2001.2831",
-    "Microsoft.Quantum.Xunit::0.10.2001.2831",
+    "Microsoft.Quantum.CsharpGeneration::0.10.2003.304-beta",
+    "Microsoft.Quantum.Development.Kit::0.10.2003.304-beta",
+    "Microsoft.Quantum.Simulators::0.10.2003.304-beta",
+    "Microsoft.Quantum.Xunit::0.10.2003.304-beta",
 
-    "Microsoft.Quantum.Standard::0.10.2001.2831",
-    "Microsoft.Quantum.Chemistry::0.10.2001.2831",
-    "Microsoft.Quantum.Chemistry.Jupyter::0.10.2001.2831",
-    "Microsoft.Quantum.Numerics::0.10.2001.2831",
+    "Microsoft.Quantum.Standard::0.10.2003.304-beta",
+    "Microsoft.Quantum.Chemistry::0.10.2003.304-beta",
+    "Microsoft.Quantum.Chemistry.Jupyter::0.10.2003.304-beta",
+    "Microsoft.Quantum.Numerics::0.10.2003.304-beta",
 
-    "Microsoft.Quantum.Research::0.10.2001.2831"
+    "Microsoft.Quantum.Research::0.10.2003.304-beta"
   ]
 }

--- a/src/Tool/appsettings.json
+++ b/src/Tool/appsettings.json
@@ -6,18 +6,18 @@
     },
     "AllowedHosts": "*",
   "DefaultPackageVersions": [
-    "Microsoft.Quantum.Compiler::0.10.2003.304-beta",
+    "Microsoft.Quantum.Compiler::0.10.2003.1102-beta",
 
-    "Microsoft.Quantum.CsharpGeneration::0.10.2003.304-beta",
-    "Microsoft.Quantum.Development.Kit::0.10.2003.304-beta",
-    "Microsoft.Quantum.Simulators::0.10.2003.304-beta",
-    "Microsoft.Quantum.Xunit::0.10.2003.304-beta",
+    "Microsoft.Quantum.CsharpGeneration::0.10.2003.1102-beta",
+    "Microsoft.Quantum.Development.Kit::0.10.2003.1102-beta",
+    "Microsoft.Quantum.Simulators::0.10.2003.1102-beta",
+    "Microsoft.Quantum.Xunit::0.10.2003.1102-beta",
 
-    "Microsoft.Quantum.Standard::0.10.2003.304-beta",
-    "Microsoft.Quantum.Chemistry::0.10.2003.304-beta",
-    "Microsoft.Quantum.Chemistry.Jupyter::0.10.2003.304-beta",
-    "Microsoft.Quantum.Numerics::0.10.2003.304-beta",
+    "Microsoft.Quantum.Standard::0.10.2003.1102-beta",
+    "Microsoft.Quantum.Chemistry::0.10.2003.1102-beta",
+    "Microsoft.Quantum.Chemistry.Jupyter::0.10.2003.1102-beta",
+    "Microsoft.Quantum.Numerics::0.10.2003.1102-beta",
 
-    "Microsoft.Quantum.Research::0.10.2003.304-beta"
+    "Microsoft.Quantum.Research::0.10.2003.1102-beta"
   ]
 }


### PR DESCRIPTION
This PR uses the `OnException` event introduced by https://github.com/microsoft/qsharp-runtime/pull/157 to format exception stack traces as an HTML details element, making it easier to hide extraneous information while still allowing interested users to drill down through stack traces.

Collapsed:
![image](https://user-images.githubusercontent.com/31516/75836665-742fc300-5d77-11ea-9fb9-5dd3865f1c44.png)

Expanded:
![image](https://user-images.githubusercontent.com/31516/75836643-65491080-5d77-11ea-9478-06b94f24d20b.png)

When stack traces contain more useful information (e.g.: source locations for library functions and operations), that information is formatted as a hyperlink using @vadym-kl's logic for finding best source locations added in https://github.com/microsoft/qsharp-runtime/pull/79.

This PR is marked as draft in lieu of API docs (#98) and feedback on the UI design, as well as the completion of https://github.com/microsoft/qsharp-runtime/pull/157.