### PR TITLE
Update iqsharp-base to .NET Core SDK 3.1

### DIFF
--- a/images/iqsharp-base/Dockerfile
+++ b/images/iqsharp-base/Dockerfile
@@ -44,7 +44,7 @@ RUN wget -qO- https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor 
     chown root:root /etc/apt/trusted.gpg.d/microsoft.asc.gpg && \
     chown root:root /etc/apt/sources.list.d/microsoft-prod.list && \
     apt-get -y update && \
-    apt-get -y install dotnet-sdk-3.0 && \
+    apt-get -y install dotnet-sdk-3.1 && \
     apt-get clean && rm -rf /var/lib/apt/lists/
 
 # Install prerequisites needed for integration with Live Share and VS Online.


### PR DESCRIPTION
Now that .NET Core SDK 3.0 is EOL, this PR updates iqsharp-base to use .NET Core SDK 3.1 instead.