### PR TITLE
Updating .NET references

### DIFF
--- a/src/Tests/Tests.IQsharp.csproj
+++ b/src/Tests/Tests.IQsharp.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
     <IsPackable>false</IsPackable>
     <NoWarn>1701</NoWarn>

--- a/src/Tool/Tool.csproj
+++ b/src/Tool/Tool.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <PlatformTarget>x64</PlatformTarget>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <RootNamespace>Microsoft.Quantum.IQSharp</RootNamespace>
     <AssemblyName>Microsoft.Quantum.IQSharp</AssemblyName>
   </PropertyGroup>
@@ -42,7 +42,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <FrameworkReference Include="Microsoft.AspNetCore.App" Version="3.0.0" />
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="3.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.0.0" />
     <PackageReference Include="Microsoft.NETCore.Portable.Compatibility" Version="1.0.1" />

--- a/src/Web/Web.csproj
+++ b/src/Web/Web.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
     <RootNamespace>Microsoft.Quantum.IQSharp.Web</RootNamespace>
     <AssemblyName>Microsoft.Quantum.IQSharp.Web</AssemblyName>
@@ -12,7 +12,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <FrameworkReference Include="Microsoft.AspNetCore.App" Version="3.0.0" />
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
   


### PR DESCRIPTION
Updating the .NET references used in project files. Follows the recommendation of skipping explicit version on AspNetCore.App references found [here](https://docs.microsoft.com/en-us/dotnet/core/tools/csproj#recommendation).

See related discussion in #102 