### PR TITLE
Suppressing credential scan alert for the telemetry Azure Function key

### DIFF
--- a/src/Jupyter/client/telemetry.ts
+++ b/src/Jupyter/client/telemetry.ts
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+//[SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine", Justification="This function access is supposed to be public.")]
 const CLIENT_INFO_API_URL = 'https://iqsharp-telemetry.azurewebsites.net/api/GetClientInfo?code=1kIsLwHdwLlH9n5LflhgVlafZaTH122yPK/3xezIjCQqC87MJrkdyQ==';
 
 /*


### PR DESCRIPTION
Suppress credential scan alert for the telemetry Azure Function key, which is supposed to be public.