### PR TITLE
Fix typo in pack.ps1.

### DIFF
--- a/build/pack.ps1
+++ b/build/pack.ps1
@@ -150,7 +150,7 @@ if ($Env:ENABLE_DOCKER -eq "false") {
     Pack-Image -RepoName "iqsharp-base" -Dockerfile '../images/iqsharp-base/Dockerfile'
 }
 
-if (($Env:ENABLE_DOCKER -eq "false") -or ($Env:ENABLE_PYTHON -eq "false")) {\
+if (($Env:ENABLE_DOCKER -eq "false") -or ($Env:ENABLE_PYTHON -eq "false")) {
     Write-Host "##vso[task.logissue type=warning;]Skipping IQ# magic command documentation, either ENABLE_DOCKER or ENABLE_PYTHON was false.";
 } else {
     # If we can, pack docs using the documentation build container.


### PR DESCRIPTION
This PR fixes a one character typo in `pack.ps1` that causes PowerShell to exit when either Docker or Python build steps are disabled, as the `\` command is not defined.