### PR TITLE
Add AzureClient project to iqsharp

### DIFF
--- a/iqsharp.sln
+++ b/iqsharp.sln
@@ -1,17 +1,19 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.26124.0
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29920.165
 MinimumVisualStudioVersion = 15.0.26124.0
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Jupyter", "src\Jupyter\Jupyter.csproj", "{B6F42099-DACD-472F-866C-BEF92DDDF754}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Jupyter", "src\Jupyter\Jupyter.csproj", "{B6F42099-DACD-472F-866C-BEF92DDDF754}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Core", "src\Core\Core.csproj", "{0ACA57A6-A8F6-497C-85D3-D547433BFACB}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Core", "src\Core\Core.csproj", "{0ACA57A6-A8F6-497C-85D3-D547433BFACB}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Tests.IQsharp", "src\Tests\Tests.IQsharp.csproj", "{756BE082-2E89-47F0-A48A-D7E762B0A82E}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Tests.IQsharp", "src\Tests\Tests.IQsharp.csproj", "{756BE082-2E89-47F0-A48A-D7E762B0A82E}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Tool", "src\Tool\Tool.csproj", "{7EB9C7E8-7D40-432E-9857-1DD6301B9F4A}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Tool", "src\Tool\Tool.csproj", "{7EB9C7E8-7D40-432E-9857-1DD6301B9F4A}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Web", "src\Web\Web.csproj", "{6431E92B-12AA-432C-8D53-C9A7A54BA21B}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Web", "src\Web\Web.csproj", "{6431E92B-12AA-432C-8D53-C9A7A54BA21B}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AzureClient", "src\AzureClient\AzureClient.csproj", "{E7B60C94-B666-4024-B53E-D12C142DE8DC}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -21,9 +23,6 @@ Global
 		Release|Any CPU = Release|Any CPU
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{B6F42099-DACD-472F-866C-BEF92DDDF754}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -86,5 +85,23 @@ Global
 		{6431E92B-12AA-432C-8D53-C9A7A54BA21B}.Release|x64.Build.0 = Release|Any CPU
 		{6431E92B-12AA-432C-8D53-C9A7A54BA21B}.Release|x86.ActiveCfg = Release|Any CPU
 		{6431E92B-12AA-432C-8D53-C9A7A54BA21B}.Release|x86.Build.0 = Release|Any CPU
+		{E7B60C94-B666-4024-B53E-D12C142DE8DC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E7B60C94-B666-4024-B53E-D12C142DE8DC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E7B60C94-B666-4024-B53E-D12C142DE8DC}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{E7B60C94-B666-4024-B53E-D12C142DE8DC}.Debug|x64.Build.0 = Debug|Any CPU
+		{E7B60C94-B666-4024-B53E-D12C142DE8DC}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{E7B60C94-B666-4024-B53E-D12C142DE8DC}.Debug|x86.Build.0 = Debug|Any CPU
+		{E7B60C94-B666-4024-B53E-D12C142DE8DC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E7B60C94-B666-4024-B53E-D12C142DE8DC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E7B60C94-B666-4024-B53E-D12C142DE8DC}.Release|x64.ActiveCfg = Release|Any CPU
+		{E7B60C94-B666-4024-B53E-D12C142DE8DC}.Release|x64.Build.0 = Release|Any CPU
+		{E7B60C94-B666-4024-B53E-D12C142DE8DC}.Release|x86.ActiveCfg = Release|Any CPU
+		{E7B60C94-B666-4024-B53E-D12C142DE8DC}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {9B439141-9EFD-47B2-BD10-41BD0C96316A}
 	EndGlobalSection
 EndGlobal

--- a/src/AzureClient/AzureClient.cs
+++ b/src/AzureClient/AzureClient.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.Jupyter.Core;
+using System.Threading.Tasks;
+
+using Microsoft.Identity.Client;
+using Microsoft.Identity.Client.Extensions.Msal;
+using System.Linq;
+using System.IO;
+using Microsoft.Azure.Quantum;
+using Microsoft.Azure.Quantum.Client;
+using Microsoft.Azure.Quantum.Client.Models;
+using Microsoft.Quantum.Runtime;
+
+namespace Microsoft.Quantum.IQSharp.AzureClient
+{
+    /// <inheritdoc/>
+    public class AzureClient : IAzureClient
+    {
+    }
+}

--- a/src/AzureClient/AzureClient.csproj
+++ b/src/AzureClient/AzureClient.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.1</TargetFramework>
+    <PlatformTarget>x64</PlatformTarget>
+    <RootNamespace>Microsoft.Quantum.IQSharp.AzureClient</RootNamespace>
+    <AssemblyName>Microsoft.Quantum.IQSharp.AzureClient</AssemblyName>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="..\..\build\DelaySign.cs" Link="Properties\DelaySign.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Azure.Quantum.Client" Version="0.11.2004.1014-beta" />
+    <PackageReference Include="Microsoft.Identity.Client" Version="4.10.0" />
+    <PackageReference Include="Microsoft.Identity.Client.Extensions.Msal" Version="2.8.0-preview" />
+    <PackageReference Include="Microsoft.Jupyter.Core" Version="1.3.9214-CI-20200415-173910" />
+    <PackageReference Include="System.Reactive" Version="4.3.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Core\Core.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/AzureClient/Extensions.cs
+++ b/src/AzureClient/Extensions.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Microsoft.Quantum.IQSharp.AzureClient
+{
+    /// <summary>
+    ///      Extension methods to be used with various IQ# and AzureClient objects.
+    /// </summary>
+    public static class Extensions
+    {
+        /// <summary>
+        ///     Adds services required for the AzureClient to a given service collection.
+        /// </summary>
+        public static void AddAzureClient(this IServiceCollection services)
+        {
+            services.AddSingleton<IAzureClient, AzureClient>();
+        }
+    }
+}

--- a/src/AzureClient/IAzureClient.cs
+++ b/src/AzureClient/IAzureClient.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.Jupyter.Core;
+using System.Threading.Tasks;
+
+namespace Microsoft.Quantum.IQSharp.AzureClient
+{
+    /// <summary>
+    /// This service is capable of connecting to Azure Quantum workspace
+    /// and submitting jobs.
+    /// </summary>
+    public interface IAzureClient
+    {
+    }
+}

--- a/src/AzureClient/IAzureClient.cs
+++ b/src/AzureClient/IAzureClient.cs
@@ -12,7 +12,7 @@ using System.Threading.Tasks;
 namespace Microsoft.Quantum.IQSharp.AzureClient
 {
     /// <summary>
-    /// This service is capable of connecting to Azure Quantum workspace
+    /// This service is capable of connecting to Azure Quantum workspaces
     /// and submitting jobs.
     /// </summary>
     public interface IAzureClient

--- a/src/Core/Core.csproj
+++ b/src/Core/Core.csproj
@@ -32,11 +32,11 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Quantum.Compiler" Version="0.10.2003.1102-beta" />
-    <PackageReference Include="Microsoft.Quantum.CsharpGeneration" Version="0.10.2003.1102-beta" />
-    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.10.2003.1102-beta" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.0.0" />
+    <PackageReference Include="Microsoft.Quantum.Compiler" Version="0.11.2004.1014-beta" />
+    <PackageReference Include="Microsoft.Quantum.CsharpGeneration" Version="0.11.2004.1014-beta" />
+    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.11.2004.1014-beta" />
     <PackageReference Include="NuGet.Resolver" Version="5.1.0" />
     <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
   </ItemGroup>

--- a/src/Core/Extensions/String.cs
+++ b/src/Core/Extensions/String.cs
@@ -1,0 +1,38 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Text.RegularExpressions;
+
+namespace Microsoft.Quantum.IQSharp
+{
+    public static partial class Extensions
+    {
+        /// <summary>
+        ///      Removes common indents from each line in a string,
+        ///      similarly to Python's <c>textwrap.dedent()</c> function.
+        /// </summary>
+        public static string Dedent(this string text)
+        {
+            // First, start by finding the length of common indents,
+            // disregarding lines that are only whitespace.
+            var leadingWhitespaceRegex = new Regex(@"^[ \t]*");
+            var minWhitespace = int.MaxValue;
+            foreach (var line in text.Split("\n"))
+            {
+                if (!string.IsNullOrWhiteSpace(line))
+                {
+                    var match = leadingWhitespaceRegex.Match(line);
+                    minWhitespace = match.Success
+                                ? System.Math.Min(minWhitespace, match.Value.Length)
+                                : minWhitespace = 0;
+                }
+            }
+
+            // We can use that to build a new regex that strips
+            // out common indenting.
+            var leftTrimRegex = new Regex(@$"^[ \t]{{{minWhitespace}}}", RegexOptions.Multiline);
+            return leftTrimRegex.Replace(text, "");
+        }
+    }
+}

--- a/src/Jupyter/Extensions.cs
+++ b/src/Jupyter/Extensions.cs
@@ -170,32 +170,5 @@ namespace Microsoft.Quantum.IQSharp.Jupyter
             };
             return simulator;
         }
-
-        /// <summary>
-        ///      Removes common indents from each line in a string,
-        ///      similarly to Python's <c>textwrap.dedent()</c> function.
-        /// </summary>
-        internal static string Dedent(this string text)
-        {
-            // First, start by finding the length of common indents,
-            // disregarding lines that are only whitespace.
-            var leadingWhitespaceRegex = new Regex(@"^[ \t]*");
-            var minWhitespace = int.MaxValue;
-            foreach (var line in text.Split("\n"))
-            {
-                if (!string.IsNullOrWhiteSpace(line))
-                {
-                    var match = leadingWhitespaceRegex.Match(line);
-                    minWhitespace = match.Success
-                                ? System.Math.Min(minWhitespace, match.Value.Length)
-                                : minWhitespace = 0;
-                }
-            }
-            
-            // We can use that to build a new regex that strips
-            // out common indenting.
-            var leftTrimRegex = new Regex(@$"^[ \t]{{{minWhitespace}}}", RegexOptions.Multiline);
-            return leftTrimRegex.Replace(text, "");
-        }
     }
 }

--- a/src/Jupyter/Jupyter.csproj
+++ b/src/Jupyter/Jupyter.csproj
@@ -22,11 +22,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Jupyter.Core" Version="1.3.52077" />
+    <PackageReference Include="Microsoft.Jupyter.Core" Version="1.3.9214-CI-20200415-173910" />
     <PackageReference Include="System.Reactive" Version="4.3.2" />
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\AzureClient\AzureClient.csproj" />
     <ProjectReference Include="..\Core\Core.csproj" />
   </ItemGroup>
 

--- a/src/Jupyter/Magic/Resolution/MagicResolver.cs
+++ b/src/Jupyter/Magic/Resolution/MagicResolver.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Jupyter.Core;
+using Microsoft.Quantum.IQSharp.AzureClient;
 using Microsoft.Quantum.IQSharp.Common;
 
 using Newtonsoft.Json;
@@ -22,7 +23,7 @@ namespace Microsoft.Quantum.IQSharp.Jupyter
     /// </summary>
     public class MagicSymbolResolver : IMagicSymbolResolver
     {
-        private AssemblyInfo kernelAssembly;
+        private AssemblyInfo[] kernelAssemblies;
         private Dictionary<AssemblyInfo, MagicSymbol[]> cache;
         private IServiceProvider services;
         private IReferences references;
@@ -38,7 +39,10 @@ namespace Microsoft.Quantum.IQSharp.Jupyter
             this.cache = new Dictionary<AssemblyInfo, MagicSymbol[]>();
             this.logger = logger;
 
-            this.kernelAssembly = new AssemblyInfo(typeof(MagicSymbolResolver).Assembly);
+            this.kernelAssemblies = new[] {
+                new AssemblyInfo(typeof(MagicSymbolResolver).Assembly),
+                new AssemblyInfo(typeof(AzureClient.AzureClient).Assembly)
+            };
             this.services = services;
             this.references = services.GetService<IReferences>();
         }
@@ -50,7 +54,10 @@ namespace Microsoft.Quantum.IQSharp.Jupyter
         /// </summary>
         private IEnumerable<AssemblyInfo> RelevantAssemblies()
         {
-            yield return this.kernelAssembly;
+            foreach (var asm in this.kernelAssemblies)
+            {
+                yield return asm;
+            }
 
             foreach (var asm in references.Assemblies)
             {
@@ -80,7 +87,7 @@ namespace Microsoft.Quantum.IQSharp.Jupyter
 
             foreach (var magic in FindAllMagicSymbols())
             {
-                if (symbolName.StartsWith(magic.Name))
+                if (symbolName == magic.Name)
                 {
                     this.logger.LogDebug($"Using magic {magic.Name}");
                     return magic;

--- a/src/Jupyter/Magic/Resolution/MagicResolver.cs
+++ b/src/Jupyter/Magic/Resolution/MagicResolver.cs
@@ -39,7 +39,8 @@ namespace Microsoft.Quantum.IQSharp.Jupyter
             this.cache = new Dictionary<AssemblyInfo, MagicSymbol[]>();
             this.logger = logger;
 
-            this.kernelAssemblies = new[] {
+            this.kernelAssemblies = new[]
+            {
                 new AssemblyInfo(typeof(MagicSymbolResolver).Assembly),
                 new AssemblyInfo(typeof(AzureClient.AzureClient).Assembly)
             };

--- a/src/Tests/AzureClientTests.cs
+++ b/src/Tests/AzureClientTests.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#nullable enable
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.Quantum.IQSharp.AzureClient;
+using System.Linq;
+using System.Collections.Generic;
+
+namespace Tests.IQSharp
+{
+    [TestClass]
+    public class AzureClientTests
+    {
+        [TestMethod]
+        public void TestNothing()
+        {
+            Assert.IsTrue(true);
+        }
+    }
+}

--- a/src/Tests/HttpServerIntegrationTests.cs
+++ b/src/Tests/HttpServerIntegrationTests.cs
@@ -9,9 +9,8 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using Tests.IQSharp;
 
-namespace Tests.IQsharp
+namespace Tests.IQSharp
 {
     [TestClass]
     public class HttpServerIntegrationTests

--- a/src/Tool/Startup.cs
+++ b/src/Tool/Startup.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Quantum.IQSharp.Jupyter;
+using Microsoft.Quantum.IQSharp.AzureClient;
 using System;
 
 namespace Microsoft.Quantum.IQSharp
@@ -24,6 +25,7 @@ namespace Microsoft.Quantum.IQSharp
             services.AddSingleton(typeof(ITelemetryService), GetTelemetryServiceType());
             services.AddIQSharp();
             services.AddIQSharpKernel();
+            services.AddAzureClient();
 
             var assembly = typeof(PackagesController).Assembly;
             services.AddControllers()

--- a/src/Tool/Tool.csproj
+++ b/src/Tool/Tool.csproj
@@ -36,6 +36,7 @@
   </ItemGroup>
   
   <ItemGroup>
+    <ProjectReference Include="..\AzureClient\AzureClient.csproj" />
     <ProjectReference Include="..\Jupyter\Jupyter.csproj" />
     <ProjectReference Include="..\Core\Core.csproj" />
     <ProjectReference Include="..\Web\Web.csproj" />

--- a/src/Tool/appsettings.json
+++ b/src/Tool/appsettings.json
@@ -9,7 +9,7 @@
     "Microsoft.Quantum.Compiler::0.11.2004.1014-beta",
 
     "Microsoft.Quantum.CsharpGeneration::0.11.2004.1014-beta",
-    "Microsoft.Quantum.SDK::0.11.2004.1014-beta",
+    "Microsoft.Quantum.Development.Kit::0.11.2004.1014-beta",
     "Microsoft.Quantum.Simulators::0.11.2004.1014-beta",
     "Microsoft.Quantum.Xunit::0.11.2004.1014-beta",
 

--- a/src/Tool/appsettings.json
+++ b/src/Tool/appsettings.json
@@ -6,18 +6,18 @@
     },
     "AllowedHosts": "*",
   "DefaultPackageVersions": [
-    "Microsoft.Quantum.Compiler::0.10.2003.1102-beta",
+    "Microsoft.Quantum.Compiler::0.11.2004.1014-beta",
 
-    "Microsoft.Quantum.CsharpGeneration::0.10.2003.1102-beta",
-    "Microsoft.Quantum.Development.Kit::0.10.2003.1102-beta",
-    "Microsoft.Quantum.Simulators::0.10.2003.1102-beta",
-    "Microsoft.Quantum.Xunit::0.10.2003.1102-beta",
+    "Microsoft.Quantum.CsharpGeneration::0.11.2004.1014-beta",
+    "Microsoft.Quantum.SDK::0.11.2004.1014-beta",
+    "Microsoft.Quantum.Simulators::0.11.2004.1014-beta",
+    "Microsoft.Quantum.Xunit::0.11.2004.1014-beta",
 
-    "Microsoft.Quantum.Standard::0.10.2003.1102-beta",
-    "Microsoft.Quantum.Chemistry::0.10.2003.1102-beta",
-    "Microsoft.Quantum.Chemistry.Jupyter::0.10.2003.1102-beta",
-    "Microsoft.Quantum.Numerics::0.10.2003.1102-beta",
+    "Microsoft.Quantum.Standard::0.11.2004.1014-beta",
+    "Microsoft.Quantum.Chemistry::0.11.2004.1014-beta",
+    "Microsoft.Quantum.Chemistry.Jupyter::0.11.2004.1014-beta",
+    "Microsoft.Quantum.Numerics::0.11.2004.1014-beta",
 
-    "Microsoft.Quantum.Research::0.10.2003.1102-beta"
+    "Microsoft.Quantum.Research::0.11.2004.1014-beta"
   ]
 }


### PR DESCRIPTION
This PR adds a new `AzureClient` project to `iqsharp`.

The `Jupyter` project references this new project and uses its assembly as an additional source of magic commands.

This change also involves updating references to import version 0.11.2004.1014-beta of the various QDK packages.