### PR TITLE
Use invariant culture to format state display

### DIFF
--- a/src/Jupyter/Visualization/StateDisplayEncoders.cs
+++ b/src/Jupyter/Visualization/StateDisplayEncoders.cs
@@ -217,7 +217,7 @@ namespace Microsoft.Quantum.IQSharp.Jupyter
                     {
                         var (amplitude, basisLabel) = item;
 
-                        return $@"
+                        return FormattableString.Invariant($@"
                             <tr>
                                 <td>$\left|{basisLabel}\right\rangle$</td>
                                 <td>${amplitude.Real:F4} {(amplitude.Imaginary >= 0 ? "+" : "")} {amplitude.Imaginary:F4} i$</td>
@@ -232,7 +232,7 @@ namespace Microsoft.Quantum.IQSharp.Jupyter
                                     ↑
                                 </td>
                             </tr>
-                        ";
+                        ");
                     })
                 );
 


### PR DESCRIPTION
Fixes #123, where user-specific locale settings are affecting the state display output. The fix is to use `FormattableString.Invariant()` for the string interpolation, which will format numeric values according to the invariant culture rather than the user's locale settings.