### PR TITLE
Add kernel ready event.

### DIFF
--- a/src/Tool/Telemetry.cs
+++ b/src/Tool/Telemetry.cs
@@ -64,6 +64,7 @@ namespace Microsoft.Quantum.IQSharp
                 references.PackageLoaded += (_, info) => TelemetryLogger.LogEvent(info.AsTelemetryEvent());
             eventService.OnServiceInitialized<IExecutionEngine>().On += (executionEngine) =>
             {
+                TelemetryLogger.LogEvent("SessionReady".AsTelemetryEvent());
                 if (executionEngine is BaseEngine engine)
                 {
                     engine.MagicExecuted += (_, info) => TelemetryLogger.LogEvent(info.AsTelemetryEvent());

--- a/src/Tool/Telemetry.cs
+++ b/src/Tool/Telemetry.cs
@@ -36,7 +36,9 @@ namespace Microsoft.Quantum.IQSharp
 
             eventService.OnKernelStarted().On += (kernelApp) =>
             {
-                TelemetryLogger.LogEvent("SessionStart".AsTelemetryEvent());
+                TelemetryLogger.LogEvent(
+                    "SessionStart".AsTelemetryEvent().WithTimeSinceStart()
+                );
             };
             eventService.OnKernelStopped().On += (kernelApp) =>
             {
@@ -64,7 +66,9 @@ namespace Microsoft.Quantum.IQSharp
                 references.PackageLoaded += (_, info) => TelemetryLogger.LogEvent(info.AsTelemetryEvent());
             eventService.OnServiceInitialized<IExecutionEngine>().On += (executionEngine) =>
             {
-                TelemetryLogger.LogEvent("SessionReady".AsTelemetryEvent());
+                TelemetryLogger.LogEvent(
+                    "SessionReady".AsTelemetryEvent().WithTimeSinceStart()
+                );
                 if (executionEngine is BaseEngine engine)
                 {
                     engine.MagicExecuted += (_, info) => TelemetryLogger.LogEvent(info.AsTelemetryEvent());
@@ -136,15 +140,15 @@ namespace Microsoft.Quantum.IQSharp
         public static string WithTelemetryNamespace(this string name) =>
             $"Quantum.IQSharp.{name}";
 
-        public static EventProperties AsTelemetryEvent(this string name)
-        {
-            var evt = new EventProperties() { Name = name.WithTelemetryNamespace() };
+        public static EventProperties AsTelemetryEvent(this string name) =>
+            new EventProperties() { Name = name.WithTelemetryNamespace() };
 
+        public static EventProperties WithTimeSinceStart(this EventProperties evt)
+        {
             evt.SetProperty(
                 "TimeSinceStart".WithTelemetryNamespace(),
                 DateTime.UtcNow - System.Diagnostics.Process.GetCurrentProcess().StartTime.ToUniversalTime()
             );
-
             return evt;
         }
 

--- a/src/Tool/Telemetry.cs
+++ b/src/Tool/Telemetry.cs
@@ -32,12 +32,15 @@ namespace Microsoft.Quantum.IQSharp
             Logger.LogDebug($"DeviceId: {GetDeviceId()}.");
 
             TelemetryLogger = CreateLogManager(config);
-            InitTelemetryLogger(TelemetryLogger, config);
+            InitTelemetryLogger(TelemetryLogger, config);            
+            TelemetryLogger.LogEvent(
+                "SessionStart".AsTelemetryEvent().WithTimeSinceStart()
+            );
 
             eventService.OnKernelStarted().On += (kernelApp) =>
             {
                 TelemetryLogger.LogEvent(
-                    "SessionStart".AsTelemetryEvent().WithTimeSinceStart()
+                    "TelemetryStarted".AsTelemetryEvent().WithTimeSinceStart()
                 );
             };
             eventService.OnKernelStopped().On += (kernelApp) =>
@@ -67,7 +70,7 @@ namespace Microsoft.Quantum.IQSharp
             eventService.OnServiceInitialized<IExecutionEngine>().On += (executionEngine) =>
             {
                 TelemetryLogger.LogEvent(
-                    "SessionReady".AsTelemetryEvent().WithTimeSinceStart()
+                    "ExecutionEngineInitialized".AsTelemetryEvent().WithTimeSinceStart()
                 );
                 if (executionEngine is BaseEngine engine)
                 {

--- a/src/Tool/Telemetry.cs
+++ b/src/Tool/Telemetry.cs
@@ -136,8 +136,17 @@ namespace Microsoft.Quantum.IQSharp
         public static string WithTelemetryNamespace(this string name) =>
             $"Quantum.IQSharp.{name}";
 
-        public static EventProperties AsTelemetryEvent(this string name) =>
-            new EventProperties() { Name = name.WithTelemetryNamespace() };
+        public static EventProperties AsTelemetryEvent(this string name)
+        {
+            var evt = new EventProperties() { Name = name.WithTelemetryNamespace() };
+
+            evt.SetProperty(
+                "TimeSinceStart".WithTelemetryNamespace(),
+                DateTime.UtcNow - System.Diagnostics.Process.GetCurrentProcess().StartTime.ToUniversalTime()
+            );
+
+            return evt;
+        }
 
         public static EventProperties AsTelemetryEvent(this ReloadedEventArgs info)
         {

--- a/src/Tool/Telemetry.cs
+++ b/src/Tool/Telemetry.cs
@@ -34,18 +34,18 @@ namespace Microsoft.Quantum.IQSharp
             TelemetryLogger = CreateLogManager(config);
             InitTelemetryLogger(TelemetryLogger, config);            
             TelemetryLogger.LogEvent(
-                "SessionStart".AsTelemetryEvent().WithTimeSinceStart()
+                "TelemetryStarted".AsTelemetryEvent().WithTimeSinceStart()
             );
 
             eventService.OnKernelStarted().On += (kernelApp) =>
             {
                 TelemetryLogger.LogEvent(
-                    "TelemetryStarted".AsTelemetryEvent().WithTimeSinceStart()
+                    "KernelStarted".AsTelemetryEvent().WithTimeSinceStart()
                 );
             };
             eventService.OnKernelStopped().On += (kernelApp) =>
             {
-                TelemetryLogger.LogEvent("SessionEnd".AsTelemetryEvent());
+                TelemetryLogger.LogEvent("KernelStopped".AsTelemetryEvent());
                 LogManager.UploadNow();
                 LogManager.Teardown();
             };

--- a/src/Tool/Telemetry.cs
+++ b/src/Tool/Telemetry.cs
@@ -147,9 +147,11 @@ namespace Microsoft.Quantum.IQSharp
         {
             evt.SetProperty(
                 "TimeSinceStart".WithTelemetryNamespace(),
+                // The "c" format converts using the "constant" format, which
+                // is stable across .NET cultures and versions.
                 (
                     DateTime.UtcNow - System.Diagnostics.Process.GetCurrentProcess().StartTime.ToUniversalTime()
-                ).ToString("o") // ← Format as ISO 8601.
+                ).ToString("c")
             );
             return evt;
         }

--- a/src/Tool/Telemetry.cs
+++ b/src/Tool/Telemetry.cs
@@ -147,7 +147,9 @@ namespace Microsoft.Quantum.IQSharp
         {
             evt.SetProperty(
                 "TimeSinceStart".WithTelemetryNamespace(),
-                DateTime.UtcNow - System.Diagnostics.Process.GetCurrentProcess().StartTime.ToUniversalTime()
+                (
+                    DateTime.UtcNow - System.Diagnostics.Process.GetCurrentProcess().StartTime.ToUniversalTime()
+                ).ToString("o") // ← Format as ISO 8601.
             );
             return evt;
         }


### PR DESCRIPTION
This PR fires a new event when the kernel is ready, such that the time between `SessionStart` and `SessionReady` allows for measuring the approximate time required to start the kernel.