### PR TITLE
Add AzureClient assembly to manifest

### DIFF
--- a/build/build.ps1
+++ b/build/build.ps1
@@ -39,5 +39,3 @@ if (-not $all_ok)
     throw "At least one project failed to compile. Check the logs."
 }
 
-& "$PSScriptRoot/manifest.ps1"
-

--- a/build/build.ps1
+++ b/build/build.ps1
@@ -39,3 +39,5 @@ if (-not $all_ok)
     throw "At least one project failed to compile. Check the logs."
 }
 
+& "$PSScriptRoot/manifest.ps1"
+

--- a/build/manifest.ps1
+++ b/build/manifest.ps1
@@ -16,5 +16,5 @@
         ".\src\tool\bin\$Env:BUILD_CONFIGURATION\netcoreapp3.1\Microsoft.Quantum.IQSharp.Jupyter.dll",
         ".\src\tool\bin\$Env:BUILD_CONFIGURATION\netcoreapp3.1\Microsoft.Quantum.IQSharp.Kernel.dll",
         ".\src\tool\bin\$Env:BUILD_CONFIGURATION\netcoreapp3.1\Microsoft.Quantum.IQSharp.Web.dll"
-    ) | ForEach-Object { Join-Path $PSScriptRoot (Join-Path ".." $_) };
+    ) | ForEach-Object { Get-Item (Join-Path $PSScriptRoot (Join-Path ".." $_)) };
 } | Write-Output;

--- a/build/manifest.ps1
+++ b/build/manifest.ps1
@@ -16,5 +16,5 @@
         ".\src\tool\bin\$Env:BUILD_CONFIGURATION\netcoreapp3.1\Microsoft.Quantum.IQSharp.Jupyter.dll",
         ".\src\tool\bin\$Env:BUILD_CONFIGURATION\netcoreapp3.1\Microsoft.Quantum.IQSharp.Kernel.dll",
         ".\src\tool\bin\$Env:BUILD_CONFIGURATION\netcoreapp3.1\Microsoft.Quantum.IQSharp.Web.dll"
-    ) | ForEach-Object { Get-Item (Join-Path $PSScriptRoot (Join-Path ".." $_)) };
+    ) | ForEach-Object { Join-Path $PSScriptRoot (Join-Path ".." $_) };
 } | Write-Output;

--- a/build/manifest.ps1
+++ b/build/manifest.ps1
@@ -1,6 +1,9 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
+#!/usr/bin/env pwsh
+#Requires -PSEdition Core
+
 & "$PSScriptRoot/set-env.ps1"
 
 @{
@@ -16,5 +19,5 @@
         ".\src\Tool\bin\$Env:BUILD_CONFIGURATION\netcoreapp3.1\Microsoft.Quantum.IQSharp.Jupyter.dll",
         ".\src\Tool\bin\$Env:BUILD_CONFIGURATION\netcoreapp3.1\Microsoft.Quantum.IQSharp.Kernel.dll",
         ".\src\Tool\bin\$Env:BUILD_CONFIGURATION\netcoreapp3.1\Microsoft.Quantum.IQSharp.Web.dll"
-    ) | ForEach-Object { Get-Item (Join-Path $PSScriptRoot (Join-Path ".." $_)) };
+    ) | ForEach-Object { Get-Item (Join-Path $PSScriptRoot ".." $_) };
 } | Write-Output;

--- a/build/manifest.ps1
+++ b/build/manifest.ps1
@@ -11,6 +11,7 @@
     );
     Assemblies = @(
         ".\src\tool\bin\$Env:BUILD_CONFIGURATION\netcoreapp3.1\Microsoft.Quantum.IQSharp.dll",
+        ".\src\tool\bin\$Env:BUILD_CONFIGURATION\netcoreapp3.1\Microsoft.Quantum.IQSharp.AzureClient.dll",
         ".\src\tool\bin\$Env:BUILD_CONFIGURATION\netcoreapp3.1\Microsoft.Quantum.IQSharp.Core.dll",
         ".\src\tool\bin\$Env:BUILD_CONFIGURATION\netcoreapp3.1\Microsoft.Quantum.IQSharp.Jupyter.dll",
         ".\src\tool\bin\$Env:BUILD_CONFIGURATION\netcoreapp3.1\Microsoft.Quantum.IQSharp.Kernel.dll",

--- a/build/manifest.ps1
+++ b/build/manifest.ps1
@@ -10,11 +10,11 @@
         "Microsoft.Quantum.IQSharp"
     );
     Assemblies = @(
-        ".\src\tool\bin\$Env:BUILD_CONFIGURATION\netcoreapp3.1\Microsoft.Quantum.IQSharp.dll",
-        ".\src\tool\bin\$Env:BUILD_CONFIGURATION\netcoreapp3.1\Microsoft.Quantum.IQSharp.AzureClient.dll",
-        ".\src\tool\bin\$Env:BUILD_CONFIGURATION\netcoreapp3.1\Microsoft.Quantum.IQSharp.Core.dll",
-        ".\src\tool\bin\$Env:BUILD_CONFIGURATION\netcoreapp3.1\Microsoft.Quantum.IQSharp.Jupyter.dll",
-        ".\src\tool\bin\$Env:BUILD_CONFIGURATION\netcoreapp3.1\Microsoft.Quantum.IQSharp.Kernel.dll",
-        ".\src\tool\bin\$Env:BUILD_CONFIGURATION\netcoreapp3.1\Microsoft.Quantum.IQSharp.Web.dll"
+        ".\src\Tool\bin\$Env:BUILD_CONFIGURATION\netcoreapp3.1\Microsoft.Quantum.IQSharp.dll",
+        ".\src\Tool\bin\$Env:BUILD_CONFIGURATION\netcoreapp3.1\Microsoft.Quantum.IQSharp.AzureClient.dll",
+        ".\src\Tool\bin\$Env:BUILD_CONFIGURATION\netcoreapp3.1\Microsoft.Quantum.IQSharp.Core.dll",
+        ".\src\Tool\bin\$Env:BUILD_CONFIGURATION\netcoreapp3.1\Microsoft.Quantum.IQSharp.Jupyter.dll",
+        ".\src\Tool\bin\$Env:BUILD_CONFIGURATION\netcoreapp3.1\Microsoft.Quantum.IQSharp.Kernel.dll",
+        ".\src\Tool\bin\$Env:BUILD_CONFIGURATION\netcoreapp3.1\Microsoft.Quantum.IQSharp.Web.dll"
     ) | ForEach-Object { Get-Item (Join-Path $PSScriptRoot (Join-Path ".." $_)) };
 } | Write-Output;

--- a/build/manifest.ps1
+++ b/build/manifest.ps1
@@ -1,5 +1,5 @@
-#!/usr/bin/env pwsh
-#Requires -PSEdition Core
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
 
 & "$PSScriptRoot/set-env.ps1"
 
@@ -16,5 +16,5 @@
         ".\src\tool\bin\$Env:BUILD_CONFIGURATION\netcoreapp3.1\Microsoft.Quantum.IQSharp.Jupyter.dll",
         ".\src\tool\bin\$Env:BUILD_CONFIGURATION\netcoreapp3.1\Microsoft.Quantum.IQSharp.Kernel.dll",
         ".\src\tool\bin\$Env:BUILD_CONFIGURATION\netcoreapp3.1\Microsoft.Quantum.IQSharp.Web.dll"
-    ) | ForEach-Object { Get-Item (Join-Path $PSScriptRoot ".." $_) };
+    ) | ForEach-Object { Get-Item (Join-Path $PSScriptRoot (Join-Path ".." $_)) };
 } | Write-Output;

--- a/build/steps.yml
+++ b/build/steps.yml
@@ -24,6 +24,11 @@ steps:
 - pwsh: .\build.ps1
   displayName: "Building IQ#"
   workingDirectory: '$(System.DefaultWorkingDirectory)/build'
+  
+- pwsh: .\manifest.ps1
+  displayName: "List built assemblies"
+  workingDirectory: '$(System.DefaultWorkingDirectory)/build'
+  condition: succeededOrFailed()
 
 - pwsh: .\test.ps1
   displayName: "Testing IQ#"

--- a/build/steps.yml
+++ b/build/steps.yml
@@ -21,6 +21,11 @@ steps:
 ##
 # Build, test & pack
 ##
+- pwsh: .\manifest.ps1
+  displayName: "List built assemblies"
+  workingDirectory: '$(System.DefaultWorkingDirectory)/build'
+  condition: succeededOrFailed()
+
 - pwsh: .\build.ps1
   displayName: "Building IQ#"
   workingDirectory: '$(System.DefaultWorkingDirectory)/build'

--- a/build/steps.yml
+++ b/build/steps.yml
@@ -21,14 +21,14 @@ steps:
 ##
 # Build, test & pack
 ##
+- pwsh: .\build.ps1
+  displayName: "Building IQ#"
+  workingDirectory: '$(System.DefaultWorkingDirectory)/build'
+  
 - pwsh: .\manifest.ps1
   displayName: "List built assemblies"
   workingDirectory: '$(System.DefaultWorkingDirectory)/build'
   condition: succeededOrFailed()
-
-- pwsh: .\build.ps1
-  displayName: "Building IQ#"
-  workingDirectory: '$(System.DefaultWorkingDirectory)/build'
 
 - pwsh: .\test.ps1
   displayName: "Testing IQ#"

--- a/build/steps.yml
+++ b/build/steps.yml
@@ -24,11 +24,6 @@ steps:
 - pwsh: .\build.ps1
   displayName: "Building IQ#"
   workingDirectory: '$(System.DefaultWorkingDirectory)/build'
-  
-- pwsh: .\manifest.ps1
-  displayName: "List built assemblies"
-  workingDirectory: '$(System.DefaultWorkingDirectory)/build'
-  condition: succeededOrFailed()
 
 - pwsh: .\test.ps1
   displayName: "Testing IQ#"


### PR DESCRIPTION
Adding `Microsoft.Quantum.IQSharp.AzureClient.dll` to the `manifest.ps1` script. Also adds `manifest.ps1` to the CI script, and fixes the case of the file paths so that the CI passes (`tool` -> `Tool`).

This PR is targeting the `feature/azure-quantum-preview` branch, since that's the only place this assembly exists at the moment.