### PR TITLE
Set IQ# HostingEnvironment to "build-agent"

### DIFF
--- a/build/ci.yml
+++ b/build/ci.yml
@@ -6,7 +6,7 @@ variables:
   Build.Major: 0
   Build.Minor: 11
   Drops.Dir: $(Build.ArtifactStagingDirectory)/drops
-  IQSharp.Hosting.Env: 'build-agent'
+  IQSharp.Hosting.Env: 'build-agent-iqsharp'
 
 jobs:
 - job: "iqsharp"

--- a/build/ci.yml
+++ b/build/ci.yml
@@ -6,6 +6,7 @@ variables:
   Build.Major: 0
   Build.Minor: 11
   Drops.Dir: $(Build.ArtifactStagingDirectory)/drops
+  IQSharp.Hosting.Env: 'build-agent'
 
 jobs:
 - job: "iqsharp"


### PR DESCRIPTION
This PR sets IQ# HostingEnvironment to "build-agent" in order to identify telemetry coming from CI processes.