### PR TITLE
Update Microsoft.Identity.Client package versions

### DIFF
--- a/src/AzureClient/AzureClient.csproj
+++ b/src/AzureClient/AzureClient.csproj
@@ -13,8 +13,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Identity.Client" Version="4.10.0" />
-    <PackageReference Include="Microsoft.Identity.Client.Extensions.Msal" Version="2.8.0-preview" />
+    <PackageReference Include="Microsoft.Identity.Client" Version="4.14.0" />
+    <PackageReference Include="Microsoft.Identity.Client.Extensions.Msal" Version="2.10.0-preview" />
     <PackageReference Include="System.Reactive" Version="4.3.2" />
   </ItemGroup>
 


### PR DESCRIPTION
The end-to-end CI build for `feature/azure-quantum-preview` is currently broken because another package started requiring newer versions of these `Microsoft.Identity.Client` packages via `Microsoft.Azure.Quantum.Client`. Updating the versions here to address this problem.