### PR TITLE
Add remaining AzureClient magic commands

### DIFF
--- a/src/AzureClient/AzureClient.csproj
+++ b/src/AzureClient/AzureClient.csproj
@@ -13,7 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Quantum.Client" Version="0.11.2005.1420-beta" />
+    <PackageReference Include="Microsoft.Azure.Quantum.Client" Version="0.11.2005.1924-beta" />
     <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.21" />
     <PackageReference Include="Microsoft.Rest.ClientRuntime.Azure" Version="3.3.19" />
     <PackageReference Include="System.Reactive" Version="4.3.2" />

--- a/src/AzureClient/AzureEnvironment.cs
+++ b/src/AzureClient/AzureEnvironment.cs
@@ -1,0 +1,107 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#nullable enable
+
+using Microsoft.Quantum.Simulation.Common;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Text;
+
+namespace Microsoft.Quantum.IQSharp.AzureClient
+{
+    internal class AzureEnvironment
+    {
+        public string ClientId { get; private set; } = string.Empty;
+        public string Authority { get; private set; } = string.Empty;
+        public List<string> Scopes { get; private set; } = new List<string>();
+        public Uri? BaseUri { get; private set; }
+
+        public static AzureEnvironment Create(string environment, string subscriptionId)
+        {
+            if (string.IsNullOrEmpty(environment))
+            {
+                return Production();
+            }
+
+            if (environment.Equals("dogfood", StringComparison.OrdinalIgnoreCase))
+            {
+                return Dogfood(subscriptionId);
+            }
+
+            if (environment.Equals("canary", StringComparison.OrdinalIgnoreCase))
+            {
+                return Canary();
+            }
+
+            return Production();
+        }
+
+        private static AzureEnvironment Production()
+        {
+            return new AzureEnvironment()
+            {
+                ClientId = "84ba0947-6c53-4dd2-9ca9-b3694761521b",      // QDK client ID
+                Authority = "https://login.microsoftonline.com/common",
+                Scopes = new List<string>() { "https://quantum.microsoft.com/Jobs.ReadWrite" },
+                BaseUri = new Uri("https://app-jobscheduler-prod.azurewebsites.net/"),
+            };
+        }
+
+        private static AzureEnvironment Dogfood(string subscriptionId)
+        {
+            return new AzureEnvironment()
+            {
+                ClientId = "46a998aa-43d0-4281-9cbb-5709a507ac36",      // QDK dogfood client ID
+                Authority = GetDogfoodAuthority(subscriptionId),
+                Scopes = new List<string>() { "api://dogfood.azure-quantum/Jobs.ReadWrite" },
+                BaseUri = new Uri("https://app-jobscheduler-test.azurewebsites.net/"),
+            };
+        }
+
+        private static AzureEnvironment Canary()
+        {
+            var canary = Production();
+            canary.BaseUri = new Uri("https://app-jobs-canarysouthcentralus.azurewebsites.net/");
+            return canary;
+        }
+
+        private static string GetDogfoodAuthority(string subscriptionId)
+        {
+            var armBaseUrl = "https://api-dogfood.resources.windows-int.net";
+            var requestUrl = $"{armBaseUrl}/subscriptions/{subscriptionId}?api-version=2018-01-01";
+
+            WebResponse? response = null;
+            try
+            {
+                response = WebRequest.Create(requestUrl).GetResponse();
+            }
+            catch (WebException webException)
+            {
+                response = webException.Response;
+            }
+
+            try
+            {
+                var authHeader = response.Headers["WWW-Authenticate"];
+                var headerParts = authHeader.Substring("Bearer ".Length).Split(',');
+                foreach (var headerPart in headerParts)
+                {
+                    var parts = headerPart.Split("=", 2);
+                    if (parts[0] == "authorization_uri")
+                    {
+                        var quotedAuthority = parts[1];
+                        return quotedAuthority[1..^1];
+                    }
+                }
+            }
+            catch (Exception e)
+            {
+            }
+
+            throw new InvalidOperationException($"Failed to construct dogfood authority for subscription ID {subscriptionId}.");
+        }
+    }
+}

--- a/src/AzureClient/AzureEnvironment.cs
+++ b/src/AzureClient/AzureEnvironment.cs
@@ -82,12 +82,13 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
                         return quotedAuthority[1..^1];
                     }
                 }
-            }
-            catch (Exception)
-            {
-            }
 
-            throw new InvalidOperationException($"Failed to construct dogfood authority for subscription ID {subscriptionId}.");
+                throw new InvalidOperationException($"Dogfood authority not found in ARM header response for subscription ID {subscriptionId}.");
+            }
+            catch (Exception ex)
+            {
+                throw new InvalidOperationException($"Failed to construct dogfood authority for subscription ID {subscriptionId}.", ex);
+            }
         }
     }
 }

--- a/src/AzureClient/AzureEnvironment.cs
+++ b/src/AzureClient/AzureEnvironment.cs
@@ -12,6 +12,8 @@ using System.Text;
 
 namespace Microsoft.Quantum.IQSharp.AzureClient
 {
+    internal enum AzureEnvironmentType { Production, Canary, Dogfood };
+
     internal class AzureEnvironment
     {
         public string ClientId { get; private set; } = string.Empty;
@@ -23,11 +25,25 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
         {
         }
 
-        public static AzureEnvironment Create(string environment, string subscriptionId) =>
-            string.IsNullOrEmpty(environment) ? Production()
-            : environment.Equals("dogfood", StringComparison.OrdinalIgnoreCase) ? Dogfood(subscriptionId)
-            : environment.Equals("canary", StringComparison.OrdinalIgnoreCase) ? Canary()
-            : Production();
+        public static AzureEnvironment Create(string environment, string subscriptionId)
+        {
+            if (Enum.TryParse(environment, true, out AzureEnvironmentType environmentType))
+            {
+                switch (environmentType)
+                {
+                    case AzureEnvironmentType.Production:
+                        return Production();
+                    case AzureEnvironmentType.Canary:
+                        return Canary();
+                    case AzureEnvironmentType.Dogfood:
+                        return Dogfood(subscriptionId);
+                    default:
+                        throw new InvalidOperationException("Unexpected EnvironmentType value.");
+                }
+            }
+
+            return Production();
+        }
 
         private static AzureEnvironment Production() =>
             new AzureEnvironment()

--- a/src/AzureClient/IAzureClient.cs
+++ b/src/AzureClient/IAzureClient.cs
@@ -65,8 +65,10 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
     {
         /// <summary>
         /// Connects to the specified Azure Quantum workspace, first logging into Azure if necessary.
-        /// Returns the list of execution targets available in the Azure Quantum workspace.
         /// </summary>
+        /// <returns>
+        /// The list of execution targets available in the Azure Quantum workspace.
+        /// </returns>
         public Task<ExecutionResult> ConnectAsync(
             IChannel channel,
             string subscriptionId,
@@ -76,15 +78,21 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
             bool refreshCredentials = false);
 
         /// <summary>
-        /// Returns the list of execution targets available in the Azure Quantum workspace,
-        /// or an error if the Azure Quantum workspace connection has not yet been created.
+        /// Gets the current connection status to an Azure Quantum workspace.
         /// </summary>
+        /// <returns>
+        /// The list of execution targets available in the Azure Quantum workspace,
+        /// or an error if the Azure Quantum workspace connection has not yet been created.
+        /// </returns>
         public Task<ExecutionResult> GetConnectionStatusAsync(
             IChannel channel);
 
         /// <summary>
         /// Submits the specified Q# operation as a job to the currently active target.
         /// </summary>
+        /// <returns>
+        /// Details of the submitted job, or an error if submission failed.
+        /// </returns>
         public Task<ExecutionResult> SubmitJobAsync(
             IChannel channel,
             IOperationResolver operationResolver,
@@ -94,6 +102,9 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
         /// Executes the specified Q# operation as a job to the currently active target
         /// and waits for execution to complete before returning.
         /// </summary>
+        /// <returns>
+        /// The result of the executed job, or an error if execution failed.
+        /// </returns>
         public Task<ExecutionResult> ExecuteJobAsync(
             IChannel channel,
             IOperationResolver operationResolver,
@@ -102,34 +113,50 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
         /// <summary>
         /// Sets the specified target for job submission.
         /// </summary>
+        /// <returns>
+        /// Success if the target is valid, or an error if the target cannot be set.
+        /// </returns>
         public Task<ExecutionResult> SetActiveTargetAsync(
             IChannel channel,
             string targetName);
 
         /// <summary>
-        /// Returns the specified target for job submission.
+        /// Gets the currently specified target for job submission.
         /// </summary>
+        /// <returns>
+        /// The target name.
+        /// </returns>
         public Task<ExecutionResult> GetActiveTargetAsync(
             IChannel channel);
 
         /// <summary>
-        /// Returns the job result corresponding to the given job ID,
-        /// or for the most recently-submitted job if no job ID is provided.
+        /// Gets the result of a specified job.
         /// </summary>
+        /// <returns>
+        /// The job result corresponding to the given job ID,
+        /// or for the most recently-submitted job if no job ID is provided.
+        /// </returns>
         public Task<ExecutionResult> GetJobResultAsync(
             IChannel channel,
             string jobId);
 
         /// <summary>
-        /// Returns the job status corresponding to the given job ID.
+        /// Gets the status of a specified job.
         /// </summary>
+        /// <returns>
+        /// The job status corresponding to the given job ID,
+        /// or for the most recently-submitted job if no job ID is provided.
+        /// </returns>
         public Task<ExecutionResult> GetJobStatusAsync(
             IChannel channel, 
             string jobId);
 
         /// <summary>
-        /// Returns a list of all jobs in the current workspace.
+        /// Gets a list of all jobs in the current Azure Quantum workspace.
         /// </summary>
+        /// <returns>
+        /// A list of all jobs in the current workspace.
+        /// </returns>
         public Task<ExecutionResult> GetJobListAsync(
             IChannel channel);
     }

--- a/src/AzureClient/IAzureClient.cs
+++ b/src/AzureClient/IAzureClient.cs
@@ -73,7 +73,7 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
             string resourceGroupName,
             string workspaceName,
             string storageAccountConnectionString,
-            bool forceLogin = false);
+            bool refreshCredentials = false);
 
         /// <summary>
         /// Returns the list of execution targets available in the Azure Quantum workspace,

--- a/src/AzureClient/IAzureClient.cs
+++ b/src/AzureClient/IAzureClient.cs
@@ -65,6 +65,7 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
     {
         /// <summary>
         /// Connects to the specified Azure Quantum workspace, first logging into Azure if necessary.
+        /// Returns the list of execution targets available in the Azure Quantum workspace.
         /// </summary>
         public Task<ExecutionResult> ConnectAsync(
             IChannel channel,
@@ -75,15 +76,25 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
             bool forceLogin = false);
 
         /// <summary>
-        /// Prints a string describing the current connection status.
+        /// Returns the list of execution targets available in the Azure Quantum workspace,
+        /// or an error if the Azure Quantum workspace connection has not yet been created.
         /// </summary>
-        public Task<ExecutionResult> PrintConnectionStatusAsync(
+        public Task<ExecutionResult> GetConnectionStatusAsync(
             IChannel channel);
 
         /// <summary>
         /// Submits the specified Q# operation as a job to the currently active target.
         /// </summary>
         public Task<ExecutionResult> SubmitJobAsync(
+            IChannel channel,
+            IOperationResolver operationResolver,
+            string operationName);
+
+        /// <summary>
+        /// Executes the specified Q# operation as a job to the currently active target
+        /// and waits for execution to complete before returning.
+        /// </summary>
+        public Task<ExecutionResult> ExecuteJobAsync(
             IChannel channel,
             IOperationResolver operationResolver,
             string operationName);
@@ -96,22 +107,30 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
             string targetName);
 
         /// <summary>
-        /// Prints the list of targets currently provisioned in the current workspace.
+        /// Returns the specified target for job submission.
         /// </summary>
-        public Task<ExecutionResult> PrintTargetListAsync(
+        public Task<ExecutionResult> GetActiveTargetAsync(
             IChannel channel);
 
         /// <summary>
-        /// Prints the job status corresponding to the given job ID.
+        /// Returns the job result corresponding to the given job ID,
+        /// or for the most recently-submitted job if no job ID is provided.
         /// </summary>
-        public Task<ExecutionResult> PrintJobStatusAsync(
+        public Task<ExecutionResult> GetJobResultAsync(
+            IChannel channel,
+            string jobId);
+
+        /// <summary>
+        /// Returns the job status corresponding to the given job ID.
+        /// </summary>
+        public Task<ExecutionResult> GetJobStatusAsync(
             IChannel channel, 
             string jobId);
 
         /// <summary>
-        /// Prints a list of all jobs in the current workspace.
+        /// Returns a list of all jobs in the current workspace.
         /// </summary>
-        public Task<ExecutionResult> PrintJobListAsync(
+        public Task<ExecutionResult> GetJobListAsync(
             IChannel channel);
     }
 }

--- a/src/AzureClient/Magic/ConnectMagic.cs
+++ b/src/AzureClient/Magic/ConnectMagic.cs
@@ -37,6 +37,9 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
                             This magic command allows for connecting to an Azure Quantum workspace
                             as specified by a valid subscription ID, resource group name, workspace name,
                             and storage account connection string.
+
+                            If the connection is successful, a list of the available execution targets
+                            in the Azure Quantum workspace will be displayed.
                         ".Dedent(),
                     Examples = new[]
                         {
@@ -44,7 +47,8 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
                                 Print information about the current connection:
                                 ```
                                 In []: %connect
-                                Out[]: Connected to WORKSPACE_NAME
+                                Out[]: Connected to Azure Quantum workspace WORKSPACE_NAME.
+                                       <list of targets available in the Azure Quantum workspace>
                                 ```
                             ".Dedent(),
 
@@ -55,7 +59,8 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
                                                 {ParameterNameResourceGroupName}=RESOURCE_GROUP_NAME
                                                 {ParameterNameWorkspaceName}=WORKSPACE_NAME
                                                 {ParameterNameStorageAccountConnectionString}=CONNECTION_STRING
-                                Out[]: Connected to WORKSPACE_NAME
+                                Out[]: Connected to Azure Quantum workspace WORKSPACE_NAME.
+                                       <list of targets available in the Azure Quantum workspace>
                                 ```
                             ".Dedent(),
 
@@ -69,7 +74,8 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
                                                 {ParameterNameStorageAccountConnectionString}=CONNECTION_STRING
                                 Out[]: To sign in, use a web browser to open the page https://microsoft.com/devicelogin
                                         and enter the code [login code] to authenticate.
-                                        Connected to WORKSPACE_NAME
+                                       Connected to Azure Quantum workspace WORKSPACE_NAME.
+                                       <list of targets available in the Azure Quantum workspace>
                                 ```
                                 Use the `{ParameterNameLogin}` option if you want to bypass any saved or cached
                                 credentials when connecting to Azure.
@@ -88,7 +94,7 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
             var storageAccountConnectionString = inputParameters.DecodeParameter<string>(ParameterNameStorageAccountConnectionString);
             if (string.IsNullOrEmpty(storageAccountConnectionString))
             {
-                return await AzureClient.PrintConnectionStatusAsync(channel);
+                return await AzureClient.GetConnectionStatusAsync(channel);
             }
 
             var subscriptionId = inputParameters.DecodeParameter<string>(ParameterNameSubscriptionId);

--- a/src/AzureClient/Magic/ConnectMagic.cs
+++ b/src/AzureClient/Magic/ConnectMagic.cs
@@ -17,19 +17,22 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
     /// </summary>
     public class ConnectMagic : AzureClientMagicBase
     {
-        private const string
-            ParameterNameLogin = "login",
-            ParameterNameStorageAccountConnectionString = "storageAccountConnectionString",
-            ParameterNameSubscriptionId = "subscriptionId",
-            ParameterNameResourceGroupName = "resourceGroupName",
-            ParameterNameWorkspaceName = "workspaceName";
+        private const string ParameterNameRefresh = "refresh";
+        private const string ParameterNameStorageAccountConnectionString = "storageAccountConnectionString";
+        private const string ParameterNameSubscriptionId = "subscriptionId";
+        private const string ParameterNameResourceGroupName = "resourceGroupName";
+        private const string ParameterNameWorkspaceName = "workspaceName";
 
         /// <summary>
-        ///     Constructs a new magic command given an IAzureClient object.
+        /// Initializes a new instance of the <see cref="ConnectMagic"/> class.
         /// </summary>
-        public ConnectMagic(IAzureClient azureClient) :
-            base(azureClient,
-                "connect",
+        /// <param name="azureClient">
+        /// The <see cref="IAzureClient"/> object to use for Azure functionality.
+        /// </param>
+        public ConnectMagic(IAzureClient azureClient)
+            : base(
+                azureClient,
+                "azure.connect",
                 new Documentation
                 {
                     Summary = "Connects to an Azure workspace or displays current connection status.",
@@ -46,7 +49,7 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
                             @"
                                 Print information about the current connection:
                                 ```
-                                In []: %connect
+                                In []: %azure.connect
                                 Out[]: Connected to Azure Quantum workspace WORKSPACE_NAME.
                                        <list of targets available in the Azure Quantum workspace>
                                 ```
@@ -55,7 +58,7 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
                             $@"
                                 Connect to an Azure Quantum workspace:
                                 ```
-                                In []: %connect {ParameterNameSubscriptionId}=SUBSCRIPTION_ID
+                                In []: %azure.connect {ParameterNameSubscriptionId}=SUBSCRIPTION_ID
                                                 {ParameterNameResourceGroupName}=RESOURCE_GROUP_NAME
                                                 {ParameterNameWorkspaceName}=WORKSPACE_NAME
                                                 {ParameterNameStorageAccountConnectionString}=CONNECTION_STRING
@@ -67,7 +70,7 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
                             $@"
                                 Connect to an Azure Quantum workspace and force a credential prompt:
                                 ```
-                                In []: %connect {ParameterNameLogin}
+                                In []: %azure.connect {ParameterNameRefresh}
                                                 {ParameterNameSubscriptionId}=SUBSCRIPTION_ID
                                                 {ParameterNameResourceGroupName}=RESOURCE_GROUP_NAME
                                                 {ParameterNameWorkspaceName}=WORKSPACE_NAME
@@ -77,10 +80,10 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
                                        Connected to Azure Quantum workspace WORKSPACE_NAME.
                                        <list of targets available in the Azure Quantum workspace>
                                 ```
-                                Use the `{ParameterNameLogin}` option if you want to bypass any saved or cached
+                                Use the `{ParameterNameRefresh}` option if you want to bypass any saved or cached
                                 credentials when connecting to Azure.
-                            ".Dedent()
-                        }
+                            ".Dedent(),
+                        },
                 }) {}
 
         /// <summary>
@@ -100,14 +103,14 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
             var subscriptionId = inputParameters.DecodeParameter<string>(ParameterNameSubscriptionId);
             var resourceGroupName = inputParameters.DecodeParameter<string>(ParameterNameResourceGroupName);
             var workspaceName = inputParameters.DecodeParameter<string>(ParameterNameWorkspaceName);
-            var forceLogin = inputParameters.DecodeParameter<bool>(ParameterNameLogin, defaultValue: false);
+            var refreshCredentials = inputParameters.DecodeParameter<bool>(ParameterNameRefresh, defaultValue: false);
             return await AzureClient.ConnectAsync(
                 channel,
                 subscriptionId,
                 resourceGroupName,
                 workspaceName,
                 storageAccountConnectionString,
-                forceLogin);
+                refreshCredentials);
         }
     }
 }

--- a/src/AzureClient/Magic/ExecuteMagic.cs
+++ b/src/AzureClient/Magic/ExecuteMagic.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Jupyter.Core;
+using Microsoft.Quantum.IQSharp.Jupyter;
 
 namespace Microsoft.Quantum.IQSharp.AzureClient
 {
@@ -16,6 +17,8 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
     /// </summary>
     public class ExecuteMagic : AzureClientMagicBase
     {
+        private const string ParameterNameOperationName = "operationName";
+
         /// <summary>
         ///      Gets the symbol resolver used by this magic command to find
         ///      operations or functions to be simulated.
@@ -61,14 +64,14 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
             this.OperationResolver = operationResolver;
 
         /// <summary>
-        ///     Executes a new job to an Azure Quantum workspace given a Q# operation
+        ///     Executes a new job in an Azure Quantum workspace given a Q# operation
         ///     name that is present in the current Q# Jupyter workspace, and
         ///     waits for the job to complete before returning.
         /// </summary>
         public override async Task<ExecutionResult> RunAsync(string input, IChannel channel)
         {
-            Dictionary<string, string> keyValuePairs = ParseInputParameters(input);
-            var operationName = keyValuePairs.Keys.FirstOrDefault();
+            var inputParameters = ParseInputParameters(input, firstParameterInferredName: ParameterNameOperationName);
+            var operationName = inputParameters.DecodeParameter<string>(ParameterNameOperationName);
             return await AzureClient.ExecuteJobAsync(channel, OperationResolver, operationName);
         }
     }

--- a/src/AzureClient/Magic/ExecuteMagic.cs
+++ b/src/AzureClient/Magic/ExecuteMagic.cs
@@ -1,0 +1,69 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Jupyter.Core;
+
+namespace Microsoft.Quantum.IQSharp.AzureClient
+{
+    /// <summary>
+    ///     A magic command that can be used to submit jobs to an Azure Quantum workspace.
+    /// </summary>
+    public class ExecuteMagic : AzureClientMagicBase
+    {
+        /// <summary>
+        ///      The symbol resolver used by this magic command to find
+        ///      operations or functions to be simulated.
+        /// </summary>
+        public IOperationResolver OperationResolver { get; }
+
+        /// <summary>
+        ///     Constructs a new magic command given a resolver used to find
+        ///     operations and functions and an IAzureClient object.
+        /// </summary>
+        public ExecuteMagic(IOperationResolver operationResolver, IAzureClient azureClient) :
+            base(azureClient,
+                "execute",
+                new Documentation
+                {
+                    Summary = "Executes a job in an Azure Quantum workspace.",
+                    Description = @"
+                        This magic command allows for executing a job in an Azure Quantum workspace
+                        corresponding to the Q# operation provided as an argument, and it waits
+                        for the job to complete before returning.
+
+                        The Azure Quantum workspace must previously have been initialized
+                        using the %connect magic command.
+                    ".Dedent(),
+                    Examples = new[]
+                    {
+                        @"
+                            Execute an operation in the current Azure Quantum workspace:
+                            ```
+                            In []: %execute OPERATION_NAME
+                            Out[]: Executing job on target TARGET_NAME...
+                                   <job results displayed here after execution completes>
+                            ```
+                        ".Dedent(),
+                    }
+                }) =>
+            this.OperationResolver = operationResolver;
+
+        /// <summary>
+        ///     Executes a new job to an Azure Quantum workspace given a Q# operation
+        ///     name that is present in the current Q# Jupyter workspace, and
+        ///     waits for the job to complete before returning.
+        /// </summary>
+        public override async Task<ExecutionResult> RunAsync(string input, IChannel channel)
+        {
+            Dictionary<string, string> keyValuePairs = ParseInputParameters(input);
+            var operationName = keyValuePairs.Keys.FirstOrDefault();
+            return await AzureClient.ExecuteJobAsync(channel, OperationResolver, operationName);
+        }
+    }
+}

--- a/src/AzureClient/Magic/ExecuteMagic.cs
+++ b/src/AzureClient/Magic/ExecuteMagic.cs
@@ -17,18 +17,24 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
     public class ExecuteMagic : AzureClientMagicBase
     {
         /// <summary>
-        ///      The symbol resolver used by this magic command to find
+        ///      Gets the symbol resolver used by this magic command to find
         ///      operations or functions to be simulated.
         /// </summary>
         public IOperationResolver OperationResolver { get; }
 
         /// <summary>
-        ///     Constructs a new magic command given a resolver used to find
-        ///     operations and functions and an IAzureClient object.
+        /// Initializes a new instance of the <see cref="ExecuteMagic"/> class.
         /// </summary>
-        public ExecuteMagic(IOperationResolver operationResolver, IAzureClient azureClient) :
-            base(azureClient,
-                "execute",
+        /// <param name="operationResolver">
+        /// The <see cref="IOperationResolver"/> object used to find and resolve operations.
+        /// </param>
+        /// <param name="azureClient">
+        /// The <see cref="IAzureClient"/> object to use for Azure functionality.
+        /// </param>
+        public ExecuteMagic(IOperationResolver operationResolver, IAzureClient azureClient)
+            : base(
+                azureClient,
+                "azure.execute",
                 new Documentation
                 {
                     Summary = "Executes a job in an Azure Quantum workspace.",
@@ -38,19 +44,19 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
                         for the job to complete before returning.
 
                         The Azure Quantum workspace must previously have been initialized
-                        using the %connect magic command.
+                        using the %azure.connect magic command.
                     ".Dedent(),
                     Examples = new[]
                     {
                         @"
                             Execute an operation in the current Azure Quantum workspace:
                             ```
-                            In []: %execute OPERATION_NAME
+                            In []: %azure.execute OPERATION_NAME
                             Out[]: Executing job on target TARGET_NAME...
                                    <job results displayed here after execution completes>
                             ```
                         ".Dedent(),
-                    }
+                    },
                 }) =>
             this.OperationResolver = operationResolver;
 

--- a/src/AzureClient/Magic/JobsMagic.cs
+++ b/src/AzureClient/Magic/JobsMagic.cs
@@ -52,9 +52,7 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
         /// <summary>
         ///     Lists all jobs in the active workspace.
         /// </summary>
-        public override async Task<ExecutionResult> RunAsync(string input, IChannel channel)
-        {
-            return await AzureClient.GetJobListAsync(channel);
-        }
+        public override async Task<ExecutionResult> RunAsync(string input, IChannel channel) =>
+            await AzureClient.GetJobListAsync(channel);
     }
 }

--- a/src/AzureClient/Magic/JobsMagic.cs
+++ b/src/AzureClient/Magic/JobsMagic.cs
@@ -1,0 +1,53 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Jupyter.Core;
+using Microsoft.Quantum.IQSharp.Jupyter;
+
+namespace Microsoft.Quantum.IQSharp.AzureClient
+{
+    /// <summary>
+    ///     A magic command that can be used to list jobs in an Azure Quantum workspace.
+    /// </summary>
+    public class JobsMagic : AzureClientMagicBase
+    {
+        /// <summary>
+        ///     Constructs a new magic command given an IAzureClient object.
+        /// </summary>
+        public JobsMagic(IAzureClient azureClient) :
+            base(azureClient,
+                "jobs",
+                new Documentation
+                {
+                    Summary = "Displays a list of jobs in the current Azure Quantum workspace.",
+                    Description = @"
+                        This magic command allows for displaying the list of jobs in the current 
+                        Azure Quantum workspace.
+                    ".Dedent(),
+                    Examples = new[]
+                    {
+                        @"
+                            Print status about a specific job:
+                            ```
+                            In []: %jobs
+                            Out[]: <list of jobs in the workspace>
+                            ```
+                        ".Dedent()
+                    }
+                }) {}
+
+        /// <summary>
+        ///     Lists all jobs in the active workspace.
+        /// </summary>
+        public override async Task<ExecutionResult> RunAsync(string input, IChannel channel)
+        {
+            return await AzureClient.GetJobListAsync(channel);
+        }
+    }
+}

--- a/src/AzureClient/Magic/JobsMagic.cs
+++ b/src/AzureClient/Magic/JobsMagic.cs
@@ -18,28 +18,35 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
     public class JobsMagic : AzureClientMagicBase
     {
         /// <summary>
-        ///     Constructs a new magic command given an IAzureClient object.
+        /// Initializes a new instance of the <see cref="JobsMagic"/> class.
         /// </summary>
-        public JobsMagic(IAzureClient azureClient) :
-            base(azureClient,
-                "jobs",
+        /// <param name="azureClient">
+        /// The <see cref="IAzureClient"/> object to use for Azure functionality.
+        /// </param>
+        public JobsMagic(IAzureClient azureClient)
+            : base(
+                azureClient,
+                "azure.jobs",
                 new Documentation
                 {
                     Summary = "Displays a list of jobs in the current Azure Quantum workspace.",
                     Description = @"
                         This magic command allows for displaying the list of jobs in the current 
                         Azure Quantum workspace.
+
+                        The Azure Quantum workspace must previously have been initialized
+                        using the %azure.connect magic command.
                     ".Dedent(),
                     Examples = new[]
                     {
                         @"
                             Print status about a specific job:
                             ```
-                            In []: %jobs
+                            In []: %azure.jobs
                             Out[]: <list of jobs in the workspace>
                             ```
-                        ".Dedent()
-                    }
+                        ".Dedent(),
+                    },
                 }) {}
 
         /// <summary>

--- a/src/AzureClient/Magic/JobsMagic.cs
+++ b/src/AzureClient/Magic/JobsMagic.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
                     Examples = new[]
                     {
                         @"
-                            Print status about a specific job:
+                            Print the list of jobs:
                             ```
                             In []: %azure.jobs
                             Out[]: <list of jobs in the workspace>

--- a/src/AzureClient/Magic/OutputMagic.cs
+++ b/src/AzureClient/Magic/OutputMagic.cs
@@ -1,0 +1,71 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Jupyter.Core;
+using Microsoft.Quantum.IQSharp.Jupyter;
+
+namespace Microsoft.Quantum.IQSharp.AzureClient
+{
+    /// <summary>
+    ///     A magic command that can be used to connect to display the results of an Azure Quantum job.
+    /// </summary>
+    public class OutputMagic : AzureClientMagicBase
+    {
+        private const string
+            ParameterNameJobId = "jobId";
+
+        /// <summary>
+        ///     Constructs a new magic command given an IAzureClient object.
+        /// </summary>
+        public OutputMagic(IAzureClient azureClient) :
+            base(azureClient,
+                "output",
+                new Documentation
+                {
+                    Summary = "Displays results for jobs in the current Azure Quantum workspace.",
+                    Description = @"
+                        This magic command allows for displaying the results of jobs in the current 
+                        Azure Quantum workspace. If a valid job ID is provided as an argument, and the
+                        job has completed, the output of that job will be displayed. If no job ID is
+                        provided, the job ID from the most recent call to `%aq submit` will be used.
+                        
+                        If the job has not yet completed, an error message will be displayed.
+                    ".Dedent(),
+                    Examples = new[]
+                    {
+                        @"
+                            Print results of a specific job:
+                            ```
+                            In []: %output JOB_ID
+                            Out[]: <job results of specified job>
+                            ```
+                        ".Dedent(),
+
+                        @"
+                            Print results of the most recently-submitted job:
+                            ```
+                            In []: %output
+                            Out[]: <job results of most recently-submitted job>
+                            ```
+                        ".Dedent()
+                    }
+                }) {}
+
+        /// <summary>
+        ///     Displays the output of a given completed job ID, if provided,
+        ///     or all jobs submitted in the current session.
+        /// </summary>
+        public override async Task<ExecutionResult> RunAsync(string input, IChannel channel)
+        {
+            var inputParameters = ParseInputParameters(input, firstParameterInferredName: ParameterNameJobId);
+            string jobId = inputParameters.DecodeParameter<string>(ParameterNameJobId);
+            return await AzureClient.GetJobResultAsync(channel, jobId);
+        }
+    }
+}

--- a/src/AzureClient/Magic/OutputMagic.cs
+++ b/src/AzureClient/Magic/OutputMagic.cs
@@ -17,32 +17,39 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
     /// </summary>
     public class OutputMagic : AzureClientMagicBase
     {
-        private const string
-            ParameterNameJobId = "jobId";
+        private const string ParameterNameJobId = "jobId";
 
         /// <summary>
-        ///     Constructs a new magic command given an IAzureClient object.
+        /// Initializes a new instance of the <see cref="OutputMagic"/> class.
         /// </summary>
-        public OutputMagic(IAzureClient azureClient) :
-            base(azureClient,
-                "output",
+        /// <param name="azureClient">
+        /// The <see cref="IAzureClient"/> object to use for Azure functionality.
+        /// </param>
+        public OutputMagic(IAzureClient azureClient)
+            : base(
+                azureClient,
+                "azure.output",
                 new Documentation
                 {
                     Summary = "Displays results for jobs in the current Azure Quantum workspace.",
                     Description = @"
-                        This magic command allows for displaying the results of jobs in the current 
+                        This magic command allows for displaying results of jobs in the current 
                         Azure Quantum workspace. If a valid job ID is provided as an argument, and the
                         job has completed, the output of that job will be displayed. If no job ID is
-                        provided, the job ID from the most recent call to `%aq submit` will be used.
+                        provided, the job ID from the most recent call to `%azure.submit` or
+                        `%azure.execute` will be used.
                         
                         If the job has not yet completed, an error message will be displayed.
+
+                        The Azure Quantum workspace must previously have been initialized
+                        using the %azure.connect magic command.
                     ".Dedent(),
                     Examples = new[]
                     {
                         @"
                             Print results of a specific job:
                             ```
-                            In []: %output JOB_ID
+                            In []: %azure.output JOB_ID
                             Out[]: <job results of specified job>
                             ```
                         ".Dedent(),
@@ -50,11 +57,11 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
                         @"
                             Print results of the most recently-submitted job:
                             ```
-                            In []: %output
+                            In []: %azure.output
                             Out[]: <job results of most recently-submitted job>
                             ```
-                        ".Dedent()
-                    }
+                        ".Dedent(),
+                    },
                 }) {}
 
         /// <summary>

--- a/src/AzureClient/Magic/StatusMagic.cs
+++ b/src/AzureClient/Magic/StatusMagic.cs
@@ -57,18 +57,13 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
 
         /// <summary>
         ///     Displays the status corresponding to a given job ID, if provided,
-        ///     or all jobs in the active workspace.
+        ///     or the most recently-submitted job in the current session.
         /// </summary>
         public override async Task<ExecutionResult> RunAsync(string input, IChannel channel)
         {
             var inputParameters = ParseInputParameters(input, firstParameterInferredName: ParameterNameJobId);
-            if (inputParameters.ContainsKey(ParameterNameJobId))
-            {
-                string jobId = inputParameters.DecodeParameter<string>(ParameterNameJobId);
-                return await AzureClient.PrintJobStatusAsync(channel, jobId);
-            }
-
-            return await AzureClient.PrintJobListAsync(channel);
+            string jobId = inputParameters.DecodeParameter<string>(ParameterNameJobId);
+            return await AzureClient.GetJobStatusAsync(channel, jobId);
         }
     }
 }

--- a/src/AzureClient/Magic/StatusMagic.cs
+++ b/src/AzureClient/Magic/StatusMagic.cs
@@ -17,42 +17,49 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
     /// </summary>
     public class StatusMagic : AzureClientMagicBase
     {
-        private const string
-            ParameterNameJobId = "jobId";
+        private const string ParameterNameJobId = "jobId";
 
         /// <summary>
-        ///     Constructs a new magic command given an IAzureClient object.
+        /// Initializes a new instance of the <see cref="StatusMagic"/> class.
         /// </summary>
-        public StatusMagic(IAzureClient azureClient) :
-            base(azureClient,
-                "status",
+        /// <param name="azureClient">
+        /// The <see cref="IAzureClient"/> object to use for Azure functionality.
+        /// </param>
+        public StatusMagic(IAzureClient azureClient)
+            : base(
+                azureClient,
+                "azure.status",
                 new Documentation
                 {
                     Summary = "Displays status for jobs in the current Azure Quantum workspace.",
                     Description = @"
                         This magic command allows for displaying status of jobs in the current 
                         Azure Quantum workspace. If a valid job ID is provided as an argument, the
-                        detailed status of that job will be displayed; otherwise, a list of all jobs
-                        created in the current session will be displayed.
+                        detailed status of that job will be displayed. If no job ID is
+                        provided, the job ID from the most recent call to `%azure.submit` or
+                        `%azure.execute` will be used.
+
+                        The Azure Quantum workspace must previously have been initialized
+                        using the %azure.connect magic command.
                     ".Dedent(),
                     Examples = new[]
                     {
                         @"
-                            Print status about a specific job:
+                            Print status of a specific job:
                             ```
-                            In []: %status JOB_ID
-                            Out[]: JOB_ID: <job status>
+                            In []: %azure.status JOB_ID
+                            Out[]: <job status of specified job>
                             ```
                         ".Dedent(),
 
                         @"
-                            Print status about all jobs created in the current session:
+                            Print status of the most recently-submitted job:
                             ```
-                            In []: %status
-                            Out[]: <status for each job>
+                            In []: %azure.status
+                            Out[]: <job status of most recently-submitted job>
                             ```
-                        ".Dedent()
-                    }
+                        ".Dedent(),
+                    },
                 }) {}
 
         /// <summary>

--- a/src/AzureClient/Magic/SubmitMagic.cs
+++ b/src/AzureClient/Magic/SubmitMagic.cs
@@ -17,18 +17,24 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
     public class SubmitMagic : AzureClientMagicBase
     {
         /// <summary>
-        ///      The symbol resolver used by this magic command to find
+        ///      Gets the symbol resolver used by this magic command to find
         ///      operations or functions to be simulated.
         /// </summary>
         public IOperationResolver OperationResolver { get; }
 
         /// <summary>
-        ///     Constructs a new magic command given a resolver used to find
-        ///     operations and functions and an IAzureClient object.
+        /// Initializes a new instance of the <see cref="SubmitMagic"/> class.
         /// </summary>
-        public SubmitMagic(IOperationResolver operationResolver, IAzureClient azureClient) :
-            base(azureClient,
-                "submit",
+        /// <param name="operationResolver">
+        /// The <see cref="IOperationResolver"/> object used to find and resolve operations.
+        /// </param>
+        /// <param name="azureClient">
+        /// The <see cref="IAzureClient"/> object to use for Azure functionality.
+        /// </param>
+        public SubmitMagic(IOperationResolver operationResolver, IAzureClient azureClient)
+            : base(
+                azureClient,
+                "azure.submit",
                 new Documentation
                 {
                     Summary = "Submits a job to an Azure Quantum workspace.",
@@ -37,18 +43,18 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
                         corresponding to the Q# operation provided as an argument.
 
                         The Azure Quantum workspace must previously have been initialized
-                        using the %connect magic command.
+                        using the %azure.connect magic command.
                     ".Dedent(),
                     Examples = new[]
                     {
                         @"
                             Submit an operation as a new job to the current Azure Quantum workspace:
                             ```
-                            In []: %submit OPERATION_NAME
+                            In []: %azure.submit OPERATION_NAME
                             Out[]: Submitted job JOB_ID
                             ```
                         ".Dedent(),
-                    }
+                    },
                 }) =>
             this.OperationResolver = operationResolver;
 

--- a/src/AzureClient/Magic/SubmitMagic.cs
+++ b/src/AzureClient/Magic/SubmitMagic.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Jupyter.Core;
+using Microsoft.Quantum.IQSharp.Jupyter;
 
 namespace Microsoft.Quantum.IQSharp.AzureClient
 {
@@ -16,6 +17,8 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
     /// </summary>
     public class SubmitMagic : AzureClientMagicBase
     {
+        private const string ParameterNameOperationName = "operationName";
+
         /// <summary>
         ///      Gets the symbol resolver used by this magic command to find
         ///      operations or functions to be simulated.
@@ -64,8 +67,8 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
         /// </summary>
         public override async Task<ExecutionResult> RunAsync(string input, IChannel channel)
         {
-            Dictionary<string, string> keyValuePairs = ParseInputParameters(input);
-            var operationName = keyValuePairs.Keys.FirstOrDefault();
+            var inputParameters = ParseInputParameters(input, firstParameterInferredName: ParameterNameOperationName);
+            var operationName = inputParameters.DecodeParameter<string>(ParameterNameOperationName);
             return await AzureClient.SubmitJobAsync(channel, OperationResolver, operationName);
         }
     }

--- a/src/AzureClient/Magic/TargetMagic.cs
+++ b/src/AzureClient/Magic/TargetMagic.cs
@@ -70,7 +70,7 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
                 return await AzureClient.SetActiveTargetAsync(channel, targetName);
             }
 
-            return await AzureClient.PrintTargetListAsync(channel);
+            return await AzureClient.GetActiveTargetAsync(channel);
         }
     }
 }

--- a/src/AzureClient/Magic/TargetMagic.cs
+++ b/src/AzureClient/Magic/TargetMagic.cs
@@ -17,15 +17,18 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
     /// </summary>
     public class TargetMagic : AzureClientMagicBase
     {
-        private const string
-            ParameterNameTargetName = "name";
+        private const string ParameterNameTargetName = "name";
 
         /// <summary>
-        ///     Constructs a new magic command given an IAzureClient object.
+        /// Initializes a new instance of the <see cref="TargetMagic"/> class.
         /// </summary>
-        public TargetMagic(IAzureClient azureClient) :
-            base(azureClient,
-                "target",
+        /// <param name="azureClient">
+        /// The <see cref="IAzureClient"/> object to use for Azure functionality.
+        /// </param>
+        public TargetMagic(IAzureClient azureClient)
+            : base(
+                azureClient,
+                "azure.target",
                 new Documentation
                 {
                     Summary = "Views or sets the target for job submission to an Azure Quantum workspace.",
@@ -34,7 +37,7 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
                         to an Azure Quantum workspace, or viewing the list of all available targets.
 
                         The Azure Quantum workspace must previously have been initialized
-                        using the %connect magic command, and the specified target must be
+                        using the %azure.connect magic command, and the specified target must be
                         available in the workspace.   
                     ".Dedent(),
                     Examples = new[]
@@ -42,18 +45,18 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
                         @"
                             Set the current target for job submission:
                             ```
-                            In []: %target TARGET_NAME
+                            In []: %azure.target TARGET_NAME
                             Out[]: Active target is now TARGET_NAME
                             ```
                         ".Dedent(),
                         @"
                             View the current target and all available targets in the current Azure Quantum workspace:
                             ```
-                            In []: %target
-                            Out[]: <list of available targets>
+                            In []: %azure.target
+                            Out[]: <current target and list of available targets>
                             ```
                         ".Dedent(),
-                    }
+                    },
                 })
         {
         }

--- a/src/Core/Core.csproj
+++ b/src/Core/Core.csproj
@@ -34,9 +34,9 @@
     <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="3.0.0" />
-    <PackageReference Include="Microsoft.Quantum.Compiler" Version="0.11.2005.1420-beta" />
-    <PackageReference Include="Microsoft.Quantum.CsharpGeneration" Version="0.11.2005.1420-beta" />
-    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.11.2005.1420-beta" />
+    <PackageReference Include="Microsoft.Quantum.Compiler" Version="0.11.2005.1924-beta" />
+    <PackageReference Include="Microsoft.Quantum.CsharpGeneration" Version="0.11.2005.1924-beta" />
+    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.11.2005.1924-beta" />
     <PackageReference Include="NuGet.Resolver" Version="5.1.0" />
     <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
   </ItemGroup>

--- a/src/Tests/AzureClientMagicTests.cs
+++ b/src/Tests/AzureClientMagicTests.cs
@@ -50,17 +50,18 @@ namespace Tests.IQSharp
                    workspaceName={workspaceName}
                    storageAccountConnectionString={storageAccountConnectionString}");
             Assert.AreEqual(azureClient.LastAction, AzureClientAction.Connect);
-            Assert.IsFalse(azureClient.ForceLogin);
+            Assert.IsFalse(azureClient.RefreshCredentials);
             Assert.AreEqual(azureClient.ConnectionString, storageAccountConnectionString);
 
             // valid input with forced login
             connectMagic.Test(
-                @$"login subscriptionId={subscriptionId}
+                @$"refresh
+                   subscriptionId={subscriptionId}
                    resourceGroupName={resourceGroupName}
                    workspaceName={workspaceName}
                    storageAccountConnectionString={storageAccountConnectionString}");
 
-            Assert.IsTrue(azureClient.ForceLogin);
+            Assert.IsTrue(azureClient.RefreshCredentials);
         }
 
         [TestMethod]
@@ -172,7 +173,7 @@ namespace Tests.IQSharp
     {
         internal AzureClientAction LastAction = AzureClientAction.None;
         internal string ConnectionString = string.Empty;
-        internal bool ForceLogin = false;
+        internal bool RefreshCredentials = false;
         internal string ActiveTargetName = string.Empty;
         internal List<string> SubmittedJobs = new List<string>();
         internal List<string> ExecutedJobs = new List<string>();
@@ -203,11 +204,11 @@ namespace Tests.IQSharp
             return ExecuteStatus.Ok.ToExecutionResult();
         }
 
-        public async Task<ExecutionResult> ConnectAsync(IChannel channel, string subscriptionId, string resourceGroupName, string workspaceName, string storageAccountConnectionString, bool forceLogin)
+        public async Task<ExecutionResult> ConnectAsync(IChannel channel, string subscriptionId, string resourceGroupName, string workspaceName, string storageAccountConnectionString, bool refreshCredentials)
         {
             LastAction = AzureClientAction.Connect;
             ConnectionString = storageAccountConnectionString;
-            ForceLogin = forceLogin;
+            RefreshCredentials = refreshCredentials;
             return ExecuteStatus.Ok.ToExecutionResult();
         }
 

--- a/src/Tests/AzureClientMagicTests.cs
+++ b/src/Tests/AzureClientMagicTests.cs
@@ -55,8 +55,7 @@ namespace Tests.IQSharp
 
             // valid input with forced login
             connectMagic.Test(
-                @$"refresh
-                   subscriptionId={subscriptionId}
+                @$"refresh subscriptionId={subscriptionId}
                    resourceGroupName={resourceGroupName}
                    workspaceName={workspaceName}
                    storageAccountConnectionString={storageAccountConnectionString}");

--- a/src/Tests/AzureClientTests.cs
+++ b/src/Tests/AzureClientTests.cs
@@ -33,8 +33,8 @@ namespace Tests.IQSharp
             var result = azureClient.SetActiveTargetAsync(new MockChannel(), targetName).GetAwaiter().GetResult();
             Assert.IsTrue(result.Status == ExecuteStatus.Ok);
 
-            result = azureClient.PrintTargetListAsync(new MockChannel()).GetAwaiter().GetResult();
-            Assert.IsTrue(result.Status == ExecuteStatus.Error);
+            result = azureClient.GetActiveTargetAsync(new MockChannel()).GetAwaiter().GetResult();
+            Assert.IsTrue(result.Status == ExecuteStatus.Ok);
         }
     }
 }

--- a/src/Tests/IQsharpEngineTests.cs
+++ b/src/Tests/IQsharpEngineTests.cs
@@ -450,10 +450,13 @@ namespace Tests.IQSharp
             Assert.IsNull(symbol);
 
             // AzureClient-provided commands
-            Assert.IsNotNull(resolver.Resolve("%connect"));
-            Assert.IsNotNull(resolver.Resolve("%status"));
-            Assert.IsNotNull(resolver.Resolve("%submit"));
-            Assert.IsNotNull(resolver.Resolve("%target"));
+            Assert.IsNotNull(resolver.Resolve("%azure.connect"));
+            Assert.IsNotNull(resolver.Resolve("%azure.target"));
+            Assert.IsNotNull(resolver.Resolve("%azure.submit"));
+            Assert.IsNotNull(resolver.Resolve("%azure.execute"));
+            Assert.IsNotNull(resolver.Resolve("%azure.status"));
+            Assert.IsNotNull(resolver.Resolve("%azure.output"));
+            Assert.IsNotNull(resolver.Resolve("%azure.jobs"));
         }
     }
 }

--- a/src/Tool/appsettings.json
+++ b/src/Tool/appsettings.json
@@ -6,18 +6,18 @@
     },
     "AllowedHosts": "*",
   "DefaultPackageVersions": [
-    "Microsoft.Quantum.Compiler::0.11.2005.1420-beta",
+    "Microsoft.Quantum.Compiler::0.11.2005.1924-beta",
 
-    "Microsoft.Quantum.CsharpGeneration::0.11.2005.1420-beta",
-    "Microsoft.Quantum.Development.Kit::0.11.2005.1420-beta",
-    "Microsoft.Quantum.Simulators::0.11.2005.1420-beta",
-    "Microsoft.Quantum.Xunit::0.11.2005.1420-beta",
+    "Microsoft.Quantum.CsharpGeneration::0.11.2005.1924-beta",
+    "Microsoft.Quantum.Development.Kit::0.11.2005.1924-beta",
+    "Microsoft.Quantum.Simulators::0.11.2005.1924-beta",
+    "Microsoft.Quantum.Xunit::0.11.2005.1924-beta",
 
-    "Microsoft.Quantum.Standard::0.11.2005.1420-beta",
-    "Microsoft.Quantum.Chemistry::0.11.2005.1420-beta",
-    "Microsoft.Quantum.Chemistry.Jupyter::0.11.2005.1420-beta",
-    "Microsoft.Quantum.Numerics::0.11.2005.1420-beta",
+    "Microsoft.Quantum.Standard::0.11.2005.1924-beta",
+    "Microsoft.Quantum.Chemistry::0.11.2005.1924-beta",
+    "Microsoft.Quantum.Chemistry.Jupyter::0.11.2005.1924-beta",
+    "Microsoft.Quantum.Numerics::0.11.2005.1924-beta",
 
-    "Microsoft.Quantum.Research::0.11.2005.1420-beta"
+    "Microsoft.Quantum.Research::0.11.2005.1924-beta"
   ]
 }


### PR DESCRIPTION
This PR primarily includes the code to add the remaining AzureClient magic commands: `execute`, `jobs`, and `output`.

It also includes a few related/supporting changes:
- Rename all AzureClient magic commands to `%azure.*`
- Rename `login` parameter to `refresh` for magic `%azure.connect` 
- Add `AzureEnvironment` class with support for Dogfood, Canary, or Production environments
- Retrieve and cache provisioned provider list when connecting to the workspace
- Add a number of TODO comments to indicate work that will be tracked and completed before merging to master
