### PR TITLE
Improvements to CodeMirror syntax highlighting rules

### DIFF
--- a/src/Kernel/client/kernel.ts
+++ b/src/Kernel/client/kernel.ts
@@ -70,12 +70,6 @@ function defineQSharpMode() {
             beginWord: true,
         },
         {
-            // Azure magic commands
-            token: "builtin",
-            regex: String.raw`(%azure\.(connect|execute|jobs|output|status|submit|target))\b`,
-            beginWord: true,
-        },
-        {
             // chemistry magic commands
             token: "builtin",
             regex: String.raw`(%chemistry\.(broombridge|encode|fh\.add_terms|fh\.load|inputstate\.load))\b`,

--- a/src/Kernel/client/kernel.ts
+++ b/src/Kernel/client/kernel.ts
@@ -11,54 +11,106 @@ import { Telemetry, ClientInfo } from "./telemetry.js";
 
 function defineQSharpMode() {
     console.log("Loading IQ# kernel-specific extension...");
+
+    let rules = [
+        {
+            token: "comment",
+            regex: /(\/\/).*/,
+            beginWord: false,
+        },
+        {
+            token: "string",
+            regex: String.raw`^\"(?:[^\"\\]|\\[\s\S])*(?:\"|$)`,
+            beginWord: false,
+        },
+        {
+            token: "keyword",
+            regex: String.raw`(namespace|open|as|operation|function|body|adjoint|newtype|controlled)\b`,
+            beginWord: true,
+        },
+        {
+            token: "keyword",
+            regex: String.raw`(if|elif|else|repeat|until|fixup|for|in|return|fail|within|apply)\b`,
+            beginWord: true,
+        },
+        {
+            token: "keyword",
+            regex: String.raw`(Adjoint|Controlled|Adj|Ctl|is|self|auto|distribute|invert|intrinsic)\b`,
+            beginWord: true,
+        },
+        {
+            token: "keyword",
+            regex: String.raw`(let|set|w\/|new|not|and|or|using|borrowing|newtype|mutable)\b`,
+            beginWord: true,
+        },
+        {
+            token: "meta",
+            regex: String.raw`(Int|BigInt|Double|Bool|Qubit|Pauli|Result|Range|String|Unit)\b`,
+            beginWord: true,
+        },
+        {
+            token: "atom",
+            regex: String.raw`(true|false|Pauli(I|X|Y|Z)|One|Zero)\b`,
+            beginWord: true,
+        },
+        {
+            token: "builtin",
+            regex: String.raw`(X|Y|Z|H|HY|S|T|SWAP|CNOT|CCNOT|MultiX|R|RFrac|Rx|Ry|Rz|R1|R1Frac|Exp|ExpFrac|Measure|M|MultiM)\b`,
+            beginWord: true,
+        },
+        {
+            token: "builtin",
+            regex: String.raw`(Message|Length|Assert|AssertProb|AssertEqual)\b`,
+            beginWord: true,
+        },
+        {
+            // built-in magic commands
+            token: "builtin",
+            regex: String.raw`(%(config|estimate|lsmagic|package|performance|simulate|toffoli|version|who|workspace))\b`,
+            beginWord: true,
+        },
+        {
+            // Azure magic commands
+            token: "builtin",
+            regex: String.raw`(%azure\.(connect|execute|jobs|output|status|submit|target))\b`,
+            beginWord: true,
+        },
+        {
+            // chemistry magic commands
+            token: "builtin",
+            regex: String.raw`(%chemistry\.(broombridge|encode|fh\.add_terms|fh\.load|inputstate\.load))\b`,
+            beginWord: true,
+        },
+        {
+            // katas magic commands
+            token: "builtin",
+            regex: String.raw`(%(?:check_kata|kata))\b`,
+            beginWord: true,
+        },
+    ];
+
+    let simpleRules = []
+    for (let rule of rules) {
+        simpleRules.push({
+            "token": rule.token,
+            "regex": new RegExp(rule.regex, "g"),
+            "sol": rule.beginWord
+        });
+        if (rule.beginWord) {
+            // Need an additional rule due to the fact that CodeMirror simple mode doesn't work with ^ token
+            simpleRules.push({
+                "token": rule.token,
+                "regex": new RegExp(String.raw`\W` + rule.regex, "g"),
+                "sol": false
+            });
+        }
+    }
+
     // NB: The TypeScript definitions for CodeMirror don't currently understand
     //     the simple mode plugin.
     let codeMirror: any = window.CodeMirror;
     codeMirror.defineSimpleMode('qsharp', {
-        start: [
-            {
-                token: "comment",
-                // include % to support kata special commands
-                regex: /(\/\/|%kata|%version|%simulate|%package|%workspace|%check_kata).*/
-            },
-            {
-                token: "string",
-                regex: /^\"(?:[^\"\\]|\\[\s\S])*(?:\"|$)/
-            },
-            {
-                // a group of keywords that can typically occur in the beginning of the line but not in the end of a phrase
-                token: "keyword",
-                regex: /(^|\W)(?:namespace|open|as|operation|function|body|adjoint|newtype|controlled)\b/
-            },
-            {
-                token: "keyword",
-                regex: /\W(?:if|elif|else|repeat|until|fixup|for|in|return|fail|within|apply)\b/
-            },
-            {
-                token: "keyword",
-                regex: /\W(?:Adjoint|Controlled|Adj|Ctl|is|self|auto|distribute|invert|intrinsic)\b/
-            },
-            {
-                token: "keyword",
-                regex: /\W(?:let|set|w\/|new|not|and|or|using|borrowing|newtype|mutable)\b/
-            },
-            {
-                token: "meta",
-                regex: /[^\w(\s]*(?:Int|BigInt|Double|Bool|Qubit|Pauli|Result|Range|String|Unit)\b/
-            },
-            {
-                token: "atom",
-                regex: /\W(?:true|false|Pauli(I|X|Y|Z)|One|Zero)\b/
-            },
-            {
-                token: "builtin",
-                regex: /(\\n|\W)(?:X|Y|Z|H|HY|S|T|SWAP|CNOT|CCNOT|MultiX|R|RFrac|Rx|Ry|Rz|R1|R1Frac|Exp|ExpFrac|Measure|M|MultiM)\b/
-            },
-            {
-                token: "builtin",
-                regex: /(\\n|\W)(?:Message|Length|Assert|AssertProb|AssertEqual)\b/
-            }
-        ]
+        start: simpleRules
     });
     codeMirror.defineMIME("text/x-qsharp", "qsharp");
 }

--- a/src/Kernel/client/kernel.ts
+++ b/src/Kernel/client/kernel.ts
@@ -78,7 +78,7 @@ function defineQSharpMode() {
         {
             // katas magic commands
             token: "builtin",
-            regex: String.raw`(%(?:check_kata|kata))\b`,
+            regex: String.raw`(%(check_kata|kata))\b`,
             beginWord: true,
         },
     ];


### PR DESCRIPTION
This PR partially addresses #77 by updating CodeMirror syntax highlighting rules:
- The main improvement here is to use the `sol` property for [CodeMirror simple mode](https://codemirror.net/demo/simplemode.html) rules, which works around a limitation that prevents the standard `^` start-of-line regex marker from working as expected.
- This PR also changes the syntax highlighting for magic commands such that only the magic command token itself is highlighted as a "builtin" token, and not as a "comment" (which highlights the full line). This is in response to recent behavioral changes such that magic command arguments can span multiple lines, and the "comment" style doesn't play nicely with multi-line arguments.

The remaining bug from #77 is that a single non-word character immediately preceding a keyword still gets highlighted as part of the keyword. This is existing behavior, and I haven't found a way to fix this within the confines of CodeMirror simple mode. We would have to implement a custom mode, which would give us a lot more flexibility but would also be a much larger task.

But despite this remaining bug, the changes here fix the more glaring issues such as portions of non-keywords being highlighted, or failure to highlight keywords that are at the beginning of a line, as reported in the issue.
