### PR TITLE
Validate and load packages for Azure execution targets

### DIFF
--- a/src/AzureClient/AzureClient.cs
+++ b/src/AzureClient/AzureClient.cs
@@ -277,6 +277,8 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
 
             // Set the active target and load the package.
             ActiveTarget = executionTarget;
+
+            channel.Stdout($"Loading package {ActiveTarget.PackageName} and dependencies...");
             await references.AddPackage(ActiveTarget.PackageName);
 
             return $"Active target is now {ActiveTarget.TargetName}".ToExecutionResult();

--- a/src/AzureClient/AzureClient.cs
+++ b/src/AzureClient/AzureClient.cs
@@ -201,10 +201,9 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
             {
                 channel.Stdout($"Submitting {operationName} to target {ActiveTarget.TargetName}...");
                 var job = await machine.SubmitAsync(entryPointInfo, entryPointInput);
+                channel.Stdout($"Job {job.Id} submitted successfully.");
+
                 MostRecentJobId = job.Id;
-                channel.Stdout("Job submission successful.");
-                channel.Stdout($"To check the status, run:\n    %azure.status {MostRecentJobId}");
-                channel.Stdout($"To see the results, run:\n    %azure.output {MostRecentJobId}");
 
                 // TODO: Add encoder for IQuantumMachineJob rather than calling ToJupyterTable() here.
                 return job.ToJupyterTable().ToExecutionResult();
@@ -314,9 +313,8 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
 
             if (!job.Succeeded || string.IsNullOrEmpty(job.Details.OutputDataUri))
             {
-                channel.Stderr($"Job ID {jobId} has not completed. Displaying the status instead.");
-                // TODO: Add encoder for CloudJob rather than calling ToJupyterTable() here directly.
-                return job.Details.ToJupyterTable().ToExecutionResult();
+                channel.Stderr($"Job ID {jobId} has not completed. To check the status, use:\n   %azure.status {jobId}");
+                return AzureClientError.JobNotCompleted.ToExecutionResult();
             }
 
             var stream = new MemoryStream();
@@ -363,8 +361,8 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
                 return AzureClientError.JobNotFound.ToExecutionResult();
             }
 
-            // TODO: Add encoder for CloudJob rather than calling ToJupyterTable() here directly.
-            return job.Details.ToJupyterTable().ToExecutionResult();
+            // TODO: Add encoder for CloudJob which calls ToJupyterTable() for display.
+            return job.Details.ToExecutionResult();
         }
 
         /// <inheritdoc/>

--- a/src/AzureClient/AzureClient.cs
+++ b/src/AzureClient/AzureClient.cs
@@ -17,6 +17,8 @@ using Microsoft.Rest.Azure;
 using Microsoft.Azure.Quantum.Client.Models;
 using Microsoft.Azure.Quantum.Storage;
 using Microsoft.Azure.Quantum;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Quantum.IQSharp.AzureClient
 {
@@ -24,12 +26,21 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
     public class AzureClient : IAzureClient
     {
         private string ConnectionString { get; set; } = string.Empty;
-        private string ActiveTargetName { get; set; } = string.Empty;
+        private AzureExecutionTarget? ActiveTarget { get; set; }
         private AuthenticationResult? AuthenticationResult { get; set; }
         private IQuantumClient? QuantumClient { get; set; }
-        private IPage<ProviderStatus>? ProviderStatusList { get; set; }
         private Azure.Quantum.IWorkspace? ActiveWorkspace { get; set; }
         private string MostRecentJobId { get; set; } = string.Empty;
+        private IPage<ProviderStatus>? AvailableProviders { get; set; }
+        private IEnumerable<TargetStatus>? AvailableTargets { get => AvailableProviders?.SelectMany(provider => provider.Targets); }
+        private IEnumerable<TargetStatus>? ValidExecutionTargets { get => AvailableTargets?.Where(target => AzureExecutionTarget.IsValid(target.Id)); }
+        private string ValidExecutionTargetsDisplayText
+        {
+            get => ValidExecutionTargets == null
+                ? "(no execution targets available)"
+                : string.Join(", ", ValidExecutionTargets.Select(target => target.Id));
+        }
+
 
         /// <inheritdoc/>
         public async Task<ExecutionResult> ConnectAsync(
@@ -112,7 +123,7 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
 
             try
             {
-                ProviderStatusList = await QuantumClient.Providers.GetStatusAsync();
+                AvailableProviders = await QuantumClient.Providers.GetStatusAsync();
             }
             catch (Exception e)
             {
@@ -122,22 +133,22 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
 
             channel.Stdout($"Connected to Azure Quantum workspace {QuantumClient.WorkspaceName}.");
 
-            // TODO: Add encoder for IPage<ProviderStatus> rather than calling ToJupyterTable() here directly.
-            return ProviderStatusList.ToJupyterTable().ToExecutionResult();
+            // TODO: Add encoder for IEnumerable<TargetStatus> rather than calling ToJupyterTable() here directly.
+            return ValidExecutionTargets.ToJupyterTable().ToExecutionResult();
         }
 
         /// <inheritdoc/>
         public async Task<ExecutionResult> GetConnectionStatusAsync(IChannel channel)
         {
-            if (QuantumClient == null || ProviderStatusList == null)
+            if (QuantumClient == null || AvailableProviders == null)
             {
                 return AzureClientError.NotConnected.ToExecutionResult();
             }
 
             channel.Stdout($"Connected to Azure Quantum workspace {QuantumClient.WorkspaceName}.");
 
-            // TODO: Add encoder for IPage<ProviderStatus> rather than calling ToJupyterTable() here directly.
-            return ProviderStatusList.ToJupyterTable().ToExecutionResult();
+            // TODO: Add encoder for IEnumerable<TargetStatus> rather than calling ToJupyterTable() here directly.
+            return ValidExecutionTargets.ToJupyterTable().ToExecutionResult();
         }
 
         private async Task<ExecutionResult> SubmitOrExecuteJobAsync(
@@ -152,7 +163,7 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
                 return AzureClientError.NotConnected.ToExecutionResult();
             }
 
-            if (ActiveTargetName == null)
+            if (ActiveTarget == null)
             {
                 channel.Stderr("Please call %azure.target before submitting a job.");
                 return AzureClientError.NoTarget.ToExecutionResult();
@@ -165,11 +176,12 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
                 return AzureClientError.NoOperationName.ToExecutionResult();
             }
 
-            var machine = Azure.Quantum.QuantumMachineFactory.CreateMachine(ActiveWorkspace, ActiveTargetName, ConnectionString);
+            var machine = Azure.Quantum.QuantumMachineFactory.CreateMachine(ActiveWorkspace, ActiveTarget.TargetName, ConnectionString);
             if (machine == null)
             {
-                channel.Stderr($"Could not find an execution target for target {ActiveTargetName}.");
-                return AzureClientError.NoTarget.ToExecutionResult();
+                // We should never get here, since ActiveTarget should have already been validated at the time it was set.
+                channel.Stderr($"Unexpected error while preparing job for execution on target {ActiveTarget.TargetName}.");
+                return AzureClientError.InvalidTarget.ToExecutionResult();
             }
 
             var operationInfo = operationResolver.Resolve(operationName);
@@ -178,15 +190,22 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
 
             if (execute)
             {
+                channel.Stdout($"Executing {operationName} on target {ActiveTarget.TargetName}...");
                 var output = await machine.ExecuteAsync(entryPointInfo, entryPointInput);
                 MostRecentJobId = output.Job.Id;
-                // TODO: Add encoder for IQuantumMachineOutput rather than returning the Histogram directly
+
+                // TODO: Add encoder to visualize IEnumerable<KeyValuePair<string, double>>
                 return output.Histogram.ToExecutionResult();
             }
             else
             {
+                channel.Stdout($"Submitting {operationName} to target {ActiveTarget.TargetName}...");
                 var job = await machine.SubmitAsync(entryPointInfo, entryPointInput);
                 MostRecentJobId = job.Id;
+                channel.Stdout("Job submission successful.");
+                channel.Stdout($"To check the status, run:\n    %azure.status {MostRecentJobId}");
+                channel.Stdout($"To see the results, run:\n    %azure.output {MostRecentJobId}");
+
                 // TODO: Add encoder for IQuantumMachineJob rather than calling ToJupyterTable() here.
                 return job.ToJupyterTable().ToExecutionResult();
             }
@@ -210,19 +229,57 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
         public async Task<ExecutionResult> GetActiveTargetAsync(
             IChannel channel)
         {
-            // TODO: This should also print the list of available targets to the IChannel.
-            return ActiveTargetName.ToExecutionResult();
+            if (AvailableProviders == null)
+            {
+                channel.Stderr("Please call %azure.connect before getting the execution target.");
+                return AzureClientError.NotConnected.ToExecutionResult();
+            }
+
+            if (ActiveTarget == null)
+            {
+                channel.Stderr("No execution target has been specified. To specify one, run:\n%azure.target <target name>");
+                channel.Stdout($"Available execution targets: {ValidExecutionTargetsDisplayText}");
+                return AzureClientError.NoTarget.ToExecutionResult();
+            }
+
+            channel.Stdout($"Current execution target: {ActiveTarget.TargetName}");
+            channel.Stdout($"Available execution targets: {ValidExecutionTargetsDisplayText}");
+            return ActiveTarget.TargetName.ToExecutionResult();
         }
 
         /// <inheritdoc/>
         public async Task<ExecutionResult> SetActiveTargetAsync(
             IChannel channel,
+            IReferences references,
             string targetName)
         {
-            // TODO: Validate that this target name is valid in the workspace.
-            // TODO: Load the associated provider package.
-            ActiveTargetName = targetName;
-            return $"Active target is now {ActiveTargetName}".ToExecutionResult();
+            if (AvailableProviders == null)
+            {
+                channel.Stderr("Please call %azure.connect before setting an execution target.");
+                return AzureClientError.NotConnected.ToExecutionResult();
+            }
+
+            // Validate that this target name is valid in the workspace.
+            if (!AvailableTargets.Any(target => targetName == target.Id))
+            {
+                channel.Stderr($"Target name {targetName} is not available in the current Azure Quantum workspace.");
+                channel.Stdout($"Available execution targets: {ValidExecutionTargetsDisplayText}");
+                return AzureClientError.InvalidTarget.ToExecutionResult();
+            }
+
+            // Validate that we know which package to load for this target name.
+            if (!ValidExecutionTargets.Any(target => targetName == target.Id))
+            {
+                channel.Stderr($"Target name {targetName} does not support executing Q# jobs.");
+                channel.Stdout($"Available execution targets: {ValidExecutionTargetsDisplayText}");
+                return AzureClientError.InvalidTarget.ToExecutionResult();
+            }
+
+            // Set the active target and load the package.
+            ActiveTarget = new AzureExecutionTarget(targetName);
+            await references.AddPackage(ActiveTarget.PackageName);
+
+            return $"Active target is now {ActiveTarget.TargetName}".ToExecutionResult();
         }
 
         /// <inheritdoc/>
@@ -262,13 +319,18 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
             }
 
             var stream = new MemoryStream();
-            var protocol = await new JobStorageHelper(ConnectionString).DownloadJobOutputAsync(jobId, stream);
+            await new JobStorageHelper(ConnectionString).DownloadJobOutputAsync(jobId, stream);
             stream.Seek(0, SeekOrigin.Begin);
-            var outputJson = new StreamReader(stream).ReadToEnd();
+            var output = new StreamReader(stream).ReadToEnd();
+            var deserializedOutput = JsonConvert.DeserializeObject<Dictionary<string, JToken>>(output);
+            var histogram = new Dictionary<string, double>();
+            foreach (var entry in deserializedOutput["histogram"] as JObject)
+            {
+                histogram[entry.Key] = entry.Value.ToObject<double>();
+            }
 
-            // TODO: Deserialize this once we have a way of getting the output type
-            // TODO: Add encoder for job output
-            return outputJson.ToExecutionResult();
+            // TODO: Add encoder to visualize IEnumerable<KeyValuePair<string, double>>
+            return histogram.ToExecutionResult();
         }
 
         /// <inheritdoc/>

--- a/src/AzureClient/AzureClient.cs
+++ b/src/AzureClient/AzureClient.cs
@@ -268,7 +268,8 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
             }
 
             // Validate that we know which package to load for this target name.
-            if (!ValidExecutionTargets.Any(target => targetName == target.Id))
+            var executionTarget = AzureExecutionTarget.Create(targetName);
+            if (executionTarget == null)
             {
                 channel.Stderr($"Target name {targetName} does not support executing Q# jobs.");
                 channel.Stdout($"Available execution targets: {ValidExecutionTargetsDisplayText}");
@@ -276,7 +277,7 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
             }
 
             // Set the active target and load the package.
-            ActiveTarget = new AzureExecutionTarget(targetName);
+            ActiveTarget = executionTarget;
             await references.AddPackage(ActiveTarget.PackageName);
 
             return $"Active target is now {ActiveTarget.TargetName}".ToExecutionResult();

--- a/src/AzureClient/AzureEnvironment.cs
+++ b/src/AzureClient/AzureEnvironment.cs
@@ -3,7 +3,6 @@
 
 #nullable enable
 
-using Microsoft.Quantum.Simulation.Common;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/AzureClient/AzureExecutionTarget.cs
+++ b/src/AzureClient/AzureExecutionTarget.cs
@@ -4,8 +4,6 @@
 #nullable enable
 
 using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace Microsoft.Quantum.IQSharp.AzureClient
 {
@@ -14,20 +12,14 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
     internal class AzureExecutionTarget
     {
         public string TargetName { get; private set; }
-        public AzureProvider? Provider { get => GetProvider(TargetName); }
-        public string PackageName { get => $"Microsoft.Quantum.Providers.{Provider}"; }
+        public string PackageName { get => $"Microsoft.Quantum.Providers.{GetProvider(TargetName)}"; }
 
         public static bool IsValid(string targetName) => GetProvider(targetName) != null;
 
-        public AzureExecutionTarget(string targetName)
-        {
-            if (!IsValid(targetName))
-            {
-                throw new InvalidOperationException($"{targetName} is not a valid target name.");
-            }
-
-            TargetName = targetName;
-        }
+        public static AzureExecutionTarget? Create(string targetName) =>
+            IsValid(targetName)
+            ? new AzureExecutionTarget() { TargetName = targetName }
+            : null;
 
         private static AzureProvider? GetProvider(string targetName)
         {

--- a/src/AzureClient/AzureExecutionTarget.cs
+++ b/src/AzureClient/AzureExecutionTarget.cs
@@ -21,6 +21,15 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
             ? new AzureExecutionTarget() { TargetName = targetName }
             : null;
 
+        /// <summary>
+        ///     Gets the Azure Quantum provider corresponding to the given execution target.
+        /// </summary>
+        /// <param name="targetName">The Azure Quantum execution target name.</param>
+        /// <returns>The <see cref="AzureProvider"/> enum value representing the provider.</returns>
+        /// <remarks>
+        ///     Valid target names are structured as "provider.target".
+        ///     For example, "ionq.simulator" or "honeywell.qpu".
+        /// </remarks>
         private static AzureProvider? GetProvider(string targetName)
         {
             var parts = targetName.Split('.', 2);

--- a/src/AzureClient/AzureExecutionTarget.cs
+++ b/src/AzureClient/AzureExecutionTarget.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
     internal class AzureExecutionTarget
     {
         public string TargetName { get; private set; }
-        public string PackageName { get => $"Microsoft.Quantum.Providers.{GetProvider(TargetName)}"; }
+        public string PackageName => $"Microsoft.Quantum.Providers.{GetProvider(TargetName)}";
 
         public static bool IsValid(string targetName) => GetProvider(targetName) != null;
 

--- a/src/AzureClient/AzureExecutionTarget.cs
+++ b/src/AzureClient/AzureExecutionTarget.cs
@@ -1,0 +1,43 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.Quantum.IQSharp.AzureClient
+{
+    internal enum AzureProvider { IonQ, Honeywell, QCI }
+
+    internal class AzureExecutionTarget
+    {
+        public string TargetName { get; private set; }
+        public AzureProvider? Provider { get => GetProvider(TargetName); }
+        public string PackageName { get => $"Microsoft.Quantum.Providers.{Provider}"; }
+
+        public static bool IsValid(string targetName) => GetProvider(targetName) != null;
+
+        public AzureExecutionTarget(string targetName)
+        {
+            if (!IsValid(targetName))
+            {
+                throw new InvalidOperationException($"{targetName} is not a valid target name.");
+            }
+
+            TargetName = targetName;
+        }
+
+        private static AzureProvider? GetProvider(string targetName)
+        {
+            var parts = targetName.Split('.', 2);
+            if (Enum.TryParse(parts[0], true, out AzureProvider provider))
+            {
+                return provider;
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/AzureClient/Extensions.cs
+++ b/src/AzureClient/Extensions.cs
@@ -90,7 +90,6 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
                     {
                         ("JobId", job => job.Id),
                         ("JobStatus", job => job.Status),
-                        ("JobUri", job => job.Uri.ToString()),
                     },
                 Rows = new List<IQuantumMachineJob>() { job }
             };
@@ -107,7 +106,7 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
                 Rows = new List<IQuantumClient>() { quantumClient }
             };
 
-        internal static Table<TargetStatus> ToJupyterTable(this IEnumerable<ProviderStatus> providerStatusList) =>
+        internal static Table<TargetStatus> ToJupyterTable(this IEnumerable<TargetStatus> targets) =>
             new Table<TargetStatus>
             {
                 Columns = new List<(string, Func<TargetStatus, string>)>
@@ -117,7 +116,7 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
                         ("AverageQueueTime", target => target.AverageQueueTime.ToString()),
                         ("StatusPage", target => target.StatusPage),
                     },
-                Rows = providerStatusList.SelectMany(provider => provider.Targets).ToList()
+                Rows = targets.ToList()
             };
     }
 }

--- a/src/AzureClient/IAzureClient.cs
+++ b/src/AzureClient/IAzureClient.cs
@@ -18,43 +18,49 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
         /// Method completed with an unknown error.
         /// </summary>
         [Description(Resources.AzureClientErrorUnknownError)]
-        UnknownError = 0,
+        UnknownError,
 
         /// <summary>
         /// No connection has been made to any Azure Quantum workspace.
         /// </summary>
         [Description(Resources.AzureClientErrorNotConnected)]
-        NotConnected = 1,
+        NotConnected,
 
         /// <summary>
         /// A target has not yet been configured for job submission.
         /// </summary>
         [Description(Resources.AzureClientErrorNoTarget)]
-        NoTarget = 2,
+        NoTarget,
+
+        /// <summary>
+        /// The specified target is not valid for job submission.
+        /// </summary>
+        [Description(Resources.AzureClientErrorInvalidTarget)]
+        InvalidTarget,
 
         /// <summary>
         /// A job meeting the specified criteria was not found.
         /// </summary>
         [Description(Resources.AzureClientErrorJobNotFound)]
-        JobNotFound = 3,
+        JobNotFound,
 
         /// <summary>
         /// No Q# operation name was provided where one was required.
         /// </summary>
         [Description(Resources.AzureClientErrorNoOperationName)]
-        NoOperationName = 4,
+        NoOperationName,
 
         /// <summary>
         /// Authentication with the Azure service failed.
         /// </summary>
         [Description(Resources.AzureClientErrorAuthenticationFailed)]
-        AuthenticationFailed = 5,
+        AuthenticationFailed,
 
         /// <summary>
         /// A workspace meeting the specified criteria was not found.
         /// </summary>
         [Description(Resources.AzureClientErrorWorkspaceNotFound)]
-        WorkspaceNotFound = 6,
+        WorkspaceNotFound,
     }
 
     /// <summary>
@@ -118,6 +124,7 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
         /// </returns>
         public Task<ExecutionResult> SetActiveTargetAsync(
             IChannel channel,
+            IReferences references,
             string targetName);
 
         /// <summary>

--- a/src/AzureClient/IAzureClient.cs
+++ b/src/AzureClient/IAzureClient.cs
@@ -45,6 +45,12 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
         JobNotFound,
 
         /// <summary>
+        /// The result of a job was requested, but the job has not yet completed.
+        /// </summary>
+        [Description(Resources.AzureClientErrorJobNotCompleted)]
+        JobNotCompleted,
+
+        /// <summary>
         /// No Q# operation name was provided where one was required.
         /// </summary>
         [Description(Resources.AzureClientErrorNoOperationName)]

--- a/src/AzureClient/Magic/TargetMagic.cs
+++ b/src/AzureClient/Magic/TargetMagic.cs
@@ -19,13 +19,18 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
     {
         private const string ParameterNameTargetName = "name";
 
+        private IReferences? References { get; set; }
+
         /// <summary>
         /// Initializes a new instance of the <see cref="TargetMagic"/> class.
         /// </summary>
         /// <param name="azureClient">
         /// The <see cref="IAzureClient"/> object to use for Azure functionality.
         /// </param>
-        public TargetMagic(IAzureClient azureClient)
+        /// <param name="references">
+        /// The <see cref="IReferences"/> object to use for loading target-specific packages.
+        /// </param>
+        public TargetMagic(IAzureClient azureClient, IReferences references)
             : base(
                 azureClient,
                 "azure.target",
@@ -57,9 +62,8 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
                             ```
                         ".Dedent(),
                     },
-                })
-        {
-        }
+                }) =>
+            References = references;
 
         /// <summary>
         ///     Sets or views the target for job submission to the current Azure Quantum workspace.
@@ -70,7 +74,7 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
             if (inputParameters.ContainsKey(ParameterNameTargetName))
             {
                 string targetName = inputParameters.DecodeParameter<string>(ParameterNameTargetName);
-                return await AzureClient.SetActiveTargetAsync(channel, targetName);
+                return await AzureClient.SetActiveTargetAsync(channel, References, targetName);
             }
 
             return await AzureClient.GetActiveTargetAsync(channel);

--- a/src/AzureClient/Properties/AssemblyInfo.cs
+++ b/src/AzureClient/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Tests.IQsharp" + SigningConstants.PUBLIC_KEY)]

--- a/src/AzureClient/Resources.cs
+++ b/src/AzureClient/Resources.cs
@@ -16,6 +16,9 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
         public const string AzureClientErrorNoTarget =
             "No execution target has been configured for Azure Quantum job submission.";
 
+        public const string AzureClientErrorInvalidTarget =
+            "The specified execution target is not valid for Q# job submission in the current Azure Quantum workspace.";
+
         public const string AzureClientErrorJobNotFound =
             "No job with the given ID was found in the current Azure Quantum workspace.";
 

--- a/src/AzureClient/Resources.cs
+++ b/src/AzureClient/Resources.cs
@@ -22,6 +22,9 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
         public const string AzureClientErrorJobNotFound =
             "No job with the given ID was found in the current Azure Quantum workspace.";
 
+        public const string AzureClientErrorJobNotCompleted =
+            "The specified Azure Quantum job has not yet completed.";
+
         public const string AzureClientErrorNoOperationName =
             "No Q# operation name was specified for Azure Quantum job submission.";
 

--- a/src/Kernel/client/kernel.ts
+++ b/src/Kernel/client/kernel.ts
@@ -11,54 +11,106 @@ import { Telemetry, ClientInfo } from "./telemetry.js";
 
 function defineQSharpMode() {
     console.log("Loading IQ# kernel-specific extension...");
+
+    let rules = [
+        {
+            token: "comment",
+            regex: /(\/\/).*/,
+            beginWord: false,
+        },
+        {
+            token: "string",
+            regex: String.raw`^\"(?:[^\"\\]|\\[\s\S])*(?:\"|$)`,
+            beginWord: false,
+        },
+        {
+            token: "keyword",
+            regex: String.raw`(namespace|open|as|operation|function|body|adjoint|newtype|controlled)\b`,
+            beginWord: true,
+        },
+        {
+            token: "keyword",
+            regex: String.raw`(if|elif|else|repeat|until|fixup|for|in|return|fail|within|apply)\b`,
+            beginWord: true,
+        },
+        {
+            token: "keyword",
+            regex: String.raw`(Adjoint|Controlled|Adj|Ctl|is|self|auto|distribute|invert|intrinsic)\b`,
+            beginWord: true,
+        },
+        {
+            token: "keyword",
+            regex: String.raw`(let|set|w\/|new|not|and|or|using|borrowing|newtype|mutable)\b`,
+            beginWord: true,
+        },
+        {
+            token: "meta",
+            regex: String.raw`(Int|BigInt|Double|Bool|Qubit|Pauli|Result|Range|String|Unit)\b`,
+            beginWord: true,
+        },
+        {
+            token: "atom",
+            regex: String.raw`(true|false|Pauli(I|X|Y|Z)|One|Zero)\b`,
+            beginWord: true,
+        },
+        {
+            token: "builtin",
+            regex: String.raw`(X|Y|Z|H|HY|S|T|SWAP|CNOT|CCNOT|MultiX|R|RFrac|Rx|Ry|Rz|R1|R1Frac|Exp|ExpFrac|Measure|M|MultiM)\b`,
+            beginWord: true,
+        },
+        {
+            token: "builtin",
+            regex: String.raw`(Message|Length|Assert|AssertProb|AssertEqual)\b`,
+            beginWord: true,
+        },
+        {
+            // built-in magic commands
+            token: "builtin",
+            regex: String.raw`(%(config|estimate|lsmagic|package|performance|simulate|toffoli|version|who|workspace))\b`,
+            beginWord: true,
+        },
+        {
+            // Azure magic commands
+            token: "builtin",
+            regex: String.raw`(%azure\.(connect|execute|jobs|output|status|submit|target))\b`,
+            beginWord: true,
+        },
+        {
+            // chemistry magic commands
+            token: "builtin",
+            regex: String.raw`(%chemistry\.(broombridge|encode|fh\.add_terms|fh\.load|inputstate\.load))\b`,
+            beginWord: true,
+        },
+        {
+            // katas magic commands
+            token: "builtin",
+            regex: String.raw`(%(?:check_kata|kata))\b`,
+            beginWord: true,
+        },
+    ];
+
+    let simpleRules = []
+    for (let rule of rules) {
+        simpleRules.push({
+            "token": rule.token,
+            "regex": new RegExp(rule.regex, "g"),
+            "sol": rule.beginWord
+        });
+        if (rule.beginWord) {
+            // Need an additional rule due to the fact that CodeMirror simple mode doesn't work with ^ token
+            simpleRules.push({
+                "token": rule.token,
+                "regex": new RegExp(String.raw`\W` + rule.regex, "g"),
+                "sol": false
+            });
+        }
+    }
+
     // NB: The TypeScript definitions for CodeMirror don't currently understand
     //     the simple mode plugin.
     let codeMirror: any = window.CodeMirror;
     codeMirror.defineSimpleMode('qsharp', {
-        start: [
-            {
-                token: "comment",
-                // include % to support kata special commands
-                regex: /(\/\/|%kata|%version|%simulate|%package|%workspace|%check_kata).*/
-            },
-            {
-                token: "string",
-                regex: /^\"(?:[^\"\\]|\\[\s\S])*(?:\"|$)/
-            },
-            {
-                // a group of keywords that can typically occur in the beginning of the line but not in the end of a phrase
-                token: "keyword",
-                regex: /(^|\W)(?:namespace|open|as|operation|function|body|adjoint|newtype|controlled)\b/
-            },
-            {
-                token: "keyword",
-                regex: /\W(?:if|elif|else|repeat|until|fixup|for|in|return|fail|within|apply)\b/
-            },
-            {
-                token: "keyword",
-                regex: /\W(?:Adjoint|Controlled|Adj|Ctl|is|self|auto|distribute|invert|intrinsic)\b/
-            },
-            {
-                token: "keyword",
-                regex: /\W(?:let|set|w\/|new|not|and|or|using|borrowing|newtype|mutable)\b/
-            },
-            {
-                token: "meta",
-                regex: /[^\w(\s]*(?:Int|BigInt|Double|Bool|Qubit|Pauli|Result|Range|String|Unit)\b/
-            },
-            {
-                token: "atom",
-                regex: /\W(?:true|false|Pauli(I|X|Y|Z)|One|Zero)\b/
-            },
-            {
-                token: "builtin",
-                regex: /(\\n|\W)(?:X|Y|Z|H|HY|S|T|SWAP|CNOT|CCNOT|MultiX|R|RFrac|Rx|Ry|Rz|R1|R1Frac|Exp|ExpFrac|Measure|M|MultiM)\b/
-            },
-            {
-                token: "builtin",
-                regex: /(\\n|\W)(?:Message|Length|Assert|AssertProb|AssertEqual)\b/
-            }
-        ]
+        start: simpleRules
     });
     codeMirror.defineMIME("text/x-qsharp", "qsharp");
 }

--- a/src/Python/qsharp/azure.py
+++ b/src/Python/qsharp/azure.py
@@ -29,19 +29,31 @@ __all__ = [
     'connect',
     'target',
     'submit',
-    'status'
+    'execute',
+    'status',
+    'output',
+    'jobs'
 ]
 
 ## FUNCTIONS ##
 
 def connect(**params) -> Any:
-    return qsharp.client._execute_magic(f"connect", raise_on_stderr=False, **params)
+    return qsharp.client._execute_magic(f"azure.connect", raise_on_stderr=False, **params)
 
 def target(name : str = '', **params) -> Any:
-    return qsharp.client._execute_magic(f"target {name}", raise_on_stderr=False, **params)
+    return qsharp.client._execute_magic(f"azure.target {name}", raise_on_stderr=False, **params)
 
 def submit(op, **params) -> Any:
-    return qsharp.client._execute_callable_magic("submit", op, raise_on_stderr=False, **params)
+    return qsharp.client._execute_callable_magic("azure.submit", op, raise_on_stderr=False, **params)
+
+def execute(op, **params) -> Any:
+    return qsharp.client._execute_callable_magic("azure.execute", op, raise_on_stderr=False, **params)
 
 def status(jobId : str = '', **params) -> Any:
-    return qsharp.client._execute_magic(f"status {jobId}", raise_on_stderr=False, **params)
+    return qsharp.client._execute_magic(f"azure.status {jobId}", raise_on_stderr=False, **params)
+
+def output(jobId : str = '', **params) -> Any:
+    return qsharp.client._execute_magic(f"azure.output {jobId}", raise_on_stderr=False, **params)
+
+def jobs(**params) -> Any:
+    return qsharp.client._execute_magic(f"azure.jobs", raise_on_stderr=False, **params)

--- a/src/Tests/AzureClientMagicTests.cs
+++ b/src/Tests/AzureClientMagicTests.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 using Microsoft.Jupyter.Core;
 using Microsoft.Quantum.IQSharp;
 using Microsoft.Quantum.IQSharp.AzureClient;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Tests.IQSharp
 {
@@ -140,15 +141,19 @@ namespace Tests.IQSharp
         [TestMethod]
         public void TestTargetMagic()
         {
+            var workspace = "Workspace";
+            var services = Startup.CreateServiceProvider(workspace);
+            var references = services.GetService<IReferences>();
+
             // single argument - should set active target
             var azureClient = new MockAzureClient();
-            var targetMagic = new TargetMagic(azureClient);
+            var targetMagic = new TargetMagic(azureClient, references);
             targetMagic.Test(targetName);
             Assert.AreEqual(azureClient.LastAction, AzureClientAction.SetActiveTarget);
 
             // no arguments - should print active target
             azureClient = new MockAzureClient();
-            targetMagic = new TargetMagic(azureClient);
+            targetMagic = new TargetMagic(azureClient, references);
             targetMagic.Test(string.Empty);
             Assert.AreEqual(azureClient.LastAction, AzureClientAction.GetActiveTarget);
         }
@@ -177,7 +182,7 @@ namespace Tests.IQSharp
         internal List<string> SubmittedJobs = new List<string>();
         internal List<string> ExecutedJobs = new List<string>();
 
-        public async Task<ExecutionResult> SetActiveTargetAsync(IChannel channel, string targetName)
+        public async Task<ExecutionResult> SetActiveTargetAsync(IChannel channel, IReferences references, string targetName)
         {
             LastAction = AzureClientAction.SetActiveTarget;
             ActiveTargetName = targetName;

--- a/src/Tests/AzureClientTests.cs
+++ b/src/Tests/AzureClientTests.cs
@@ -46,5 +46,31 @@ namespace Tests.IQSharp
             result = azureClient.GetActiveTargetAsync(new MockChannel()).GetAwaiter().GetResult();
             Assert.IsTrue(result.Status == ExecuteStatus.Error);
         }
+
+        [TestMethod]
+        public void TestAzureExecutionTarget()
+        {
+            var targetName = "invalidname";
+            var executionTarget = AzureExecutionTarget.Create(targetName);
+            Assert.IsNull(executionTarget);
+
+            targetName = "ionq.targetname";
+            executionTarget = AzureExecutionTarget.Create(targetName);
+            Assert.IsNotNull(executionTarget);
+            Assert.AreEqual(executionTarget.TargetName, targetName);
+            Assert.AreEqual(executionTarget.PackageName, "Microsoft.Quantum.Providers.IonQ");
+
+            targetName = "HonEYWEll.targetname";
+            executionTarget = AzureExecutionTarget.Create(targetName);
+            Assert.IsNotNull(executionTarget);
+            Assert.AreEqual(executionTarget.TargetName, targetName);
+            Assert.AreEqual(executionTarget.PackageName, "Microsoft.Quantum.Providers.Honeywell");
+
+            targetName = "qci.target.name.qpu";
+            executionTarget = AzureExecutionTarget.Create(targetName);
+            Assert.IsNotNull(executionTarget);
+            Assert.AreEqual(executionTarget.TargetName, targetName);
+            Assert.AreEqual(executionTarget.PackageName, "Microsoft.Quantum.Providers.QCI");
+        }
     }
 }

--- a/src/Tool/appsettings.json
+++ b/src/Tool/appsettings.json
@@ -18,6 +18,10 @@
     "Microsoft.Quantum.Chemistry.Jupyter::0.11.2005.1924-beta",
     "Microsoft.Quantum.Numerics::0.11.2005.1924-beta",
 
-    "Microsoft.Quantum.Research::0.11.2005.1924-beta"
+    "Microsoft.Quantum.Research::0.11.2005.1924-beta",
+
+    "Microsoft.Quantum.Providers.IonQ::0.11.2005.1924-beta",
+    "Microsoft.Quantum.Providers.Honeywell::0.11.2005.1924-beta",
+    "Microsoft.Quantum.Providers.QCI::0.11.2005.1924-beta",
   ]
 }


### PR DESCRIPTION
This PR enables Azure Quantum job execution by validating and loading the required provider packages in response to an `%azure.target` call.

It also includes a few other minor improvements:
- Add basic deserialization of output histogram to display job results.
- Update Python interface to match new magic command names.
- Add syntax highlighting for %azure.* magic commands.
- Add some `channel.Stdout` calls to print helpful information during magic command execution. 