### PR TITLE
Use SearchOption.TopDirectoryOnly for workspace cache

### DIFF
--- a/src/Core/Workspace/Workspace.cs
+++ b/src/Core/Workspace/Workspace.cs
@@ -78,6 +78,11 @@ namespace Microsoft.Quantum.IQSharp
         public string Root { get; set; }
 
         /// <summary>
+        /// Gets the source files to be built for this Workspace.
+        /// </summary>
+        public IEnumerable<string> SourceFiles => Directory.EnumerateFiles(Root, "*.qs", SearchOption.TopDirectoryOnly);
+
+        /// <summary>
         /// Information about the assembly built from this Workspace.
         /// </summary>
         public AssemblyInfo AssemblyInfo { get; set; }
@@ -200,7 +205,7 @@ namespace Microsoft.Quantum.IQSharp
             if (!File.Exists(CacheDll)) return false;
             var last = File.GetLastWriteTime(CacheDll);
 
-            foreach (var f in Directory.EnumerateFiles(Root, "*.qs", SearchOption.AllDirectories))
+            foreach (var f in SourceFiles)
             {
                 if (File.GetLastWriteTime(f) > last)
                 {
@@ -230,7 +235,7 @@ namespace Microsoft.Quantum.IQSharp
 
                 if (File.Exists(CacheDll)) { File.Delete(CacheDll); }
 
-                files = Directory.EnumerateFiles(Root, "*.qs", SearchOption.TopDirectoryOnly).ToArray();
+                files = SourceFiles.ToArray();
 
                 if (files.Length > 0)
                 {


### PR DESCRIPTION
This PR should fix #149 by ensuring that we only look in the current folder for .qs files when checking the freshness of the workspace cache.

This is related to a similar change a while ago by PR #49 to address issue #20. That change updated the behavior to only actually load .qs files from the current folder into the workspace. But because the cache-freshness check was still enumerating all subfolders, any folders with permissions issues could still cause errors during kernel initialization.

I have not yet been able to reproduce the actual bug here, despite many attempts at various permissions-related things. If anyone can find concrete repro steps, that would help with the confidence in the fix.