### PR TITLE
Add Katas default version and update hard-coded QDK versions

### DIFF
--- a/src/Core/Core.csproj
+++ b/src/Core/Core.csproj
@@ -34,9 +34,9 @@
     <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Quantum.Compiler" Version="0.11.2004.2825" />
-    <PackageReference Include="Microsoft.Quantum.CsharpGeneration" Version="0.11.2004.2825" />
-    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.11.2004.2825" />
+    <PackageReference Include="Microsoft.Quantum.Compiler" Version="0.11.2006.207" />
+    <PackageReference Include="Microsoft.Quantum.CsharpGeneration" Version="0.11.2006.207" />
+    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.11.2006.207" />
     <PackageReference Include="NuGet.Resolver" Version="5.1.0" />
     <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
   </ItemGroup>

--- a/src/Tool/appsettings.json
+++ b/src/Tool/appsettings.json
@@ -6,18 +6,20 @@
     },
     "AllowedHosts": "*",
   "DefaultPackageVersions": [
-    "Microsoft.Quantum.Compiler::0.11.2004.2825",
+    "Microsoft.Quantum.Compiler::0.11.2006.207",
 
-    "Microsoft.Quantum.CsharpGeneration::0.11.2004.2825",
-    "Microsoft.Quantum.Development.Kit::0.11.2004.2825",
-    "Microsoft.Quantum.Simulators::0.11.2004.2825",
-    "Microsoft.Quantum.Xunit::0.11.2004.2825",
+    "Microsoft.Quantum.CsharpGeneration::0.11.2006.207",
+    "Microsoft.Quantum.Development.Kit::0.11.2006.207",
+    "Microsoft.Quantum.Simulators::0.11.2006.207",
+    "Microsoft.Quantum.Xunit::0.11.2006.207",
 
-    "Microsoft.Quantum.Standard::0.11.2004.2825",
-    "Microsoft.Quantum.Chemistry::0.11.2004.2825",
-    "Microsoft.Quantum.Chemistry.Jupyter::0.11.2004.2825",
-    "Microsoft.Quantum.Numerics::0.11.2004.2825",
+    "Microsoft.Quantum.Standard::0.11.2006.207",
+    "Microsoft.Quantum.Chemistry::0.11.2006.207",
+    "Microsoft.Quantum.Chemistry.Jupyter::0.11.2006.207",
+    "Microsoft.Quantum.Numerics::0.11.2006.207",
 
-    "Microsoft.Quantum.Research::0.11.2004.2825"
+    "Microsoft.Quantum.Katas::0.11.2006.207",
+
+    "Microsoft.Quantum.Research::0.11.2006.207"
   ]
 }


### PR DESCRIPTION
Adds a default version for the Microsoft.Quantum.Katas package to appsettings.json, so that the matching version of the Katas package is automatically loaded if no version is specified.

Also updates the hard-coded version numbers to the latest QDK release, since I'm touching this anyway.