### PR TITLE
Return snippet operations in order of definition

### DIFF
--- a/src/Kernel/IQSharpEngine.cs
+++ b/src/Kernel/IQSharpEngine.cs
@@ -104,7 +104,6 @@ namespace Microsoft.Quantum.IQSharp.Kernel
                     code.Elements?
                         .Where(e => e.IsQsCallable)
                         .Select(e => e.ToFullName().WithoutNamespace(IQSharp.Snippets.SNIPPETS_NAMESPACE))
-                        .OrderBy(o => o)
                         .ToArray();
 
                 return opsNames.ToExecutionResult();

--- a/src/Python/qsharp/tests/test_iqsharp.py
+++ b/src/Python/qsharp/tests/test_iqsharp.py
@@ -60,7 +60,8 @@ def test_simple_compile():
 
 def test_multi_compile():
     """
-    Verifies that compile works
+    Verifies that compile works and that operations
+    are returned in the correct order
     """
     ops = qsharp.compile( """
     operation HelloQ() : Result
@@ -75,8 +76,8 @@ def test_multi_compile():
         return HelloQ();
     }
 """)
-    assert "Hello2" == ops[0]._name
-    assert "HelloQ" == ops[1]._name
+    assert "HelloQ" == ops[0]._name
+    assert "Hello2" == ops[1]._name
 
     r = ops[1].simulate()
     assert r == qsharp.Result.One

--- a/src/Tests/SNIPPETS.cs
+++ b/src/Tests/SNIPPETS.cs
@@ -80,7 +80,9 @@ namespace Tests.IQSharp
         public static string Op6b_Op6a =
 @"
     /// # Summary
-    ///     This to show that the order of snippet operations is preserved:
+    ///     This to show that the order of snippet operations returned
+    ///     from compilation is the same as the order in which they
+    ///     are defined in the code:
     operation Op6b() : Unit
     {
         HelloQ();
@@ -88,7 +90,7 @@ namespace Tests.IQSharp
 
     operation Op6a() : Unit
     {
-        Op6b();
+        HelloQ();
     }
 ";
 

--- a/src/Tests/SNIPPETS.cs
+++ b/src/Tests/SNIPPETS.cs
@@ -77,6 +77,21 @@ namespace Tests.IQSharp
     }
 ";
 
+        public static string Op6b_Op6a =
+@"
+    /// # Summary
+    ///     This to show that the order of snippet operations is preserved:
+    operation Op6b() : Unit
+    {
+        HelloQ();
+    }
+
+    operation Op6a() : Unit
+    {
+        Op6b();
+    }
+";
+
         public static string DependsOnWorkspace =
 @"
     /// # Summary

--- a/src/Tests/SnippetsControllerTests.cs
+++ b/src/Tests/SnippetsControllerTests.cs
@@ -35,7 +35,7 @@ namespace Tests.IQSharp
             Console.WriteLine(JsonConvert.SerializeObject(response));
             Assert.AreEqual(Status.Success, response.Status);
             Assert.AreEqual(0, response.Messages.Length);
-            foreach (var op in ops.OrderBy(o => o).Zip(response.Result.OrderBy(o => o), (expected, actual) => new { expected, actual })) { Assert.AreEqual(op.expected, op.actual); }
+            foreach (var op in ops.Zip(response.Result, (expected, actual) => new { expected, actual })) { Assert.AreEqual(op.expected, op.actual); }
 
             return response.Result;
         }
@@ -152,6 +152,9 @@ namespace Tests.IQSharp
             // Compile snippet with entry point attributes and multiple operations:
             await AssertCompile(controller, SNIPPETS.Op3_Op4_Op5_EntryPoints, "Op3", "Op4", "Op5");
 
+            // Compile snippet with operations out of alphabetical order to ensure order is preserved:
+            await AssertCompile(controller, SNIPPETS.Op6b_Op6a, "Op6b", "Op6a");
+
             // running Op2:
             await AssertSimulate(controller, "Op2", "Hello from quantum world!");
         }
@@ -175,7 +178,7 @@ namespace Tests.IQSharp
         {
             var compiler = new CompilerService();
 
-            var elements = compiler.IdentifyElements(SNIPPETS.Op1_Op2).Select(Extensions.ToFullName).OrderBy(o => o).ToArray();
+            var elements = compiler.IdentifyElements(SNIPPETS.Op1_Op2).Select(Extensions.ToFullName).ToArray();
 
             Assert.AreEqual(2, elements.Length);
             Assert.AreEqual("SNIPPET.Op2", elements[1]);

--- a/src/Web/SnippetsController.cs
+++ b/src/Web/SnippetsController.cs
@@ -72,7 +72,6 @@ namespace Microsoft.Quantum.IQSharp
                     result.Elements?
                         .Where(e => e.IsQsCallable)
                         .Select(e => e.ToFullName().WithoutNamespace(IQSharp.Snippets.SNIPPETS_NAMESPACE))
-                        .OrderBy(o => o)
                         .ToArray();
 
                 return opsNames;


### PR DESCRIPTION
Resolves #148 by always returning snippet operations in the order of definition within the snippet.

Note that magic commands `%who` and `%workspace` are unaffected by this and will continue to return operations in alphabetical order.