### PR TITLE
Remove logger call during shutdown that can fail in pytest

### DIFF
--- a/build/test.ps1
+++ b/build/test.ps1
@@ -41,7 +41,7 @@ function Test-Python {
     Write-Host "##[info]Testing Python inside $testFolder"    
     Push-Location (Join-Path $PSScriptRoot $testFolder)
         python --version
-        pytest --log-level=DEBUG
+        pytest -v
     Pop-Location
 
     if ($LastExitCode -ne 0) {

--- a/src/Python/qsharp/clients/iqsharp.py
+++ b/src/Python/qsharp/clients/iqsharp.py
@@ -77,7 +77,8 @@ class IQSharpClient(object):
         atexit.register(self.stop)
 
     def stop(self):
-        logger.info("Stopping IQ# kernel...")
+        # Don't use logger here. If we're running inside pytest, the handle to the
+        # log output file may have already been closed.
         try:
             self.kernel_manager.shutdown_kernel()
         except:


### PR DESCRIPTION
The call to `logger.info()` inside `IQSharpClient.stop()` could fail in pytest if the log file was closed too early. Looks likely related to this issue: https://github.com/pytest-dev/pytest/issues/5502.

We can easily work around this by just removing the problematic call.