### PR TITLE
Can display phase as number, arrow, or both in dumpMachine

### DIFF
--- a/src/Jupyter/ConfigurationSource.cs
+++ b/src/Jupyter/ConfigurationSource.cs
@@ -62,6 +62,11 @@ namespace Microsoft.Quantum.IQSharp.Jupyter
         public double TruncationThreshold =>
             GetOptionOrDefault("dump.truncationThreshold", 1e-10);
 
+        /// <summary>
+        ///     Allows for options to view phase as arrows, or in radians
+        ///     or both in arrow format and radians. This also allows the
+        ///     option to show None. 
+        /// </summary>
         public PhaseDisplayStyle PhaseDisplayStyle =>
             GetOptionOrDefault("dump.phaseDisplayStyle", PhaseDisplayStyle.ArrowOnly);
     }

--- a/src/Jupyter/ConfigurationSource.cs
+++ b/src/Jupyter/ConfigurationSource.cs
@@ -61,6 +61,9 @@ namespace Microsoft.Quantum.IQSharp.Jupyter
         /// </summary>
         public double TruncationThreshold =>
             GetOptionOrDefault("dump.truncationThreshold", 1e-10);
+
+        public PhaseDisplayStyle PhaseDisplayStyle =>
+            GetOptionOrDefault("dump.phaseDisplayStyle", PhaseDisplayStyle.ArrowOnly);
     }
 
     /// <summary>

--- a/src/Jupyter/Visualization/StateDisplayEncoders.cs
+++ b/src/Jupyter/Visualization/StateDisplayEncoders.cs
@@ -227,11 +227,11 @@ namespace Microsoft.Quantum.IQSharp.Jupyter
                         var (amplitude, basisLabel) = item;
                         var displayPhaseAsArrows = ConfigurationSource.PhaseDisplayStyle;
 
+                        //different options for displaying phase style
                         var phaseCell = ConfigurationSource.PhaseDisplayStyle switch
                         {
                             PhaseDisplayStyle.None => FormattableString.Invariant($@"
                                 <td> 
-                                
                                 </td>
                             "),
                             PhaseDisplayStyle.ArrowOnly => FormattableString.Invariant($@"
@@ -251,18 +251,6 @@ namespace Microsoft.Quantum.IQSharp.Jupyter
                             "),
                             _ => throw new ArgumentException($"Unsupported style {ConfigurationSource.PhaseDisplayStyle}")
                         };
-
-                        // displayPhaseAsArrows
-                        //     ? FormattableString.Invariant($@"
-                        //         <td style=""{StyleForAngle(amplitude.Phase)}"">
-                        //             ↑
-                        //         </td>
-                        //     ")
-                        //     : FormattableString.Invariant($@"
-                        //         <td> 
-                                    
-                        //         </td>
-                        //     ");
 
                         return FormattableString.Invariant($@"
                             <tr>

--- a/src/Jupyter/Visualization/StateDisplayEncoders.cs
+++ b/src/Jupyter/Visualization/StateDisplayEncoders.cs
@@ -15,6 +15,15 @@ using Newtonsoft.Json.Converters;
 
 namespace Microsoft.Quantum.IQSharp.Jupyter
 {
+    [JsonConverter(typeof(StringEnumConverter))]
+    public enum PhaseDisplayStyle
+    {
+        None,
+        ArrowOnly,
+        NumberOnly,
+        ArrowsAndNumber
+    }
+
     /// <summary>
     ///     The convention to be used in labeling computational basis states
     ///     given their representations as strings of classical bits.
@@ -216,6 +225,44 @@ namespace Microsoft.Quantum.IQSharp.Jupyter
                     vector.SignificantAmplitudes(ConfigurationSource).Select(item =>
                     {
                         var (amplitude, basisLabel) = item;
+                        var displayPhaseAsArrows = ConfigurationSource.PhaseDisplayStyle;
+
+                        var phaseCell = ConfigurationSource.PhaseDisplayStyle switch
+                        {
+                            PhaseDisplayStyle.None => FormattableString.Invariant($@"
+                                <td> 
+                                
+                                </td>
+                            "),
+                            PhaseDisplayStyle.ArrowOnly => FormattableString.Invariant($@"
+                                <td style=""{StyleForAngle(amplitude.Phase)}"">
+                                 ↑
+                                </td>
+                            "),
+                            PhaseDisplayStyle.ArrowsAndNumber => FormattableString.Invariant($@"
+                                <td>
+                                 <div style=""{StyleForAngle(amplitude.Phase)}""> ↑ </div> <div>{amplitude.Phase}</div>
+                                </td>
+                            "),
+                            PhaseDisplayStyle.NumberOnly => FormattableString.Invariant($@"
+                                <td> 
+                                    {amplitude.Phase}
+                                </td>
+                            "),
+                            _ => throw new ArgumentException($"Unsupported style {ConfigurationSource.PhaseDisplayStyle}")
+                        };
+
+                        // displayPhaseAsArrows
+                        //     ? FormattableString.Invariant($@"
+                        //         <td style=""{StyleForAngle(amplitude.Phase)}"">
+                        //             ↑
+                        //         </td>
+                        //     ")
+                        //     : FormattableString.Invariant($@"
+                        //         <td> 
+                                    
+                        //         </td>
+                        //     ");
 
                         return FormattableString.Invariant($@"
                             <tr>
@@ -228,9 +275,7 @@ namespace Microsoft.Quantum.IQSharp.Jupyter
                                         style=""width: 100%;""
                                     >
                                 </td>
-                                <td style=""{StyleForAngle(amplitude.Phase)}"">
-                                    ↑
-                                </td>
+                                {phaseCell}
                             </tr>
                         ");
                     })
@@ -316,4 +361,4 @@ namespace Microsoft.Quantum.IQSharp.Jupyter
             else return null;
         }
     }
-}
+} 

--- a/src/Jupyter/Visualization/StateDisplayEncoders.cs
+++ b/src/Jupyter/Visualization/StateDisplayEncoders.cs
@@ -31,7 +31,14 @@ namespace Microsoft.Quantum.IQSharp.Jupyter
         ///     dependent on the phase.
         /// </summary>
         ArrowOnly,
+        /// <summary> 
+        ///     Display phase information in number format.
+        /// </summary>
         NumberOnly,
+        /// <summary>
+        ///     Display phase information as an arrow (<c>↑</c>) rotated by an angle
+        ///     dependent on the phase as well as display phase information in number
+        ///     format.
         ArrowsAndNumber
     }
 

--- a/src/Jupyter/Visualization/StateDisplayEncoders.cs
+++ b/src/Jupyter/Visualization/StateDisplayEncoders.cs
@@ -208,6 +208,8 @@ namespace Microsoft.Quantum.IQSharp.Jupyter
             string StyleForAngle(double angle) =>
                 $@"transform: rotate({angle * 360.0 / TWO_PI}deg);
                    text-align: center;";
+            string StyleForNumber() =>
+                $@"text-align: center;";
 
             if (displayable is DisplayableState vector)
             {
@@ -225,7 +227,6 @@ namespace Microsoft.Quantum.IQSharp.Jupyter
                     vector.SignificantAmplitudes(ConfigurationSource).Select(item =>
                     {
                         var (amplitude, basisLabel) = item;
-                        var displayPhaseAsArrows = ConfigurationSource.PhaseDisplayStyle;
 
                         //different options for displaying phase style
                         var phaseCell = ConfigurationSource.PhaseDisplayStyle switch
@@ -241,7 +242,7 @@ namespace Microsoft.Quantum.IQSharp.Jupyter
                             "),
                             PhaseDisplayStyle.ArrowsAndNumber => FormattableString.Invariant($@"
                                 <td>
-                                 <div style=""{StyleForAngle(amplitude.Phase)}""> ↑ </div> <div>{amplitude.Phase}</div>
+                                 <div style=""{StyleForAngle(amplitude.Phase)}""> ↑ </div> <div style=""{StyleForNumber()}"">{amplitude.Phase}</div>
                                 </td>
                             "),
                             PhaseDisplayStyle.NumberOnly => FormattableString.Invariant($@"


### PR DESCRIPTION
%config now has an option to change the display of Phase in dumpMachine as either
1-Arrow
2-Number
3-Arrow and Number
or None, in this case no phase representation is shown when dumpMachine is printed to console.

