### PR TITLE
Add default version for Microsoft.Quantum.MachineLearning package

### DIFF
--- a/src/Core/Core.csproj
+++ b/src/Core/Core.csproj
@@ -34,9 +34,9 @@
     <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Quantum.Compiler" Version="0.11.2006.207" />
-    <PackageReference Include="Microsoft.Quantum.CsharpGeneration" Version="0.11.2006.207" />
-    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.11.2006.207" />
+    <PackageReference Include="Microsoft.Quantum.Compiler" Version="0.11.2006.403" />
+    <PackageReference Include="Microsoft.Quantum.CsharpGeneration" Version="0.11.2006.403" />
+    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.11.2006.403" />
     <PackageReference Include="NuGet.Resolver" Version="5.1.0" />
     <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
   </ItemGroup>

--- a/src/Tool/appsettings.json
+++ b/src/Tool/appsettings.json
@@ -6,20 +6,21 @@
     },
     "AllowedHosts": "*",
   "DefaultPackageVersions": [
-    "Microsoft.Quantum.Compiler::0.11.2006.207",
+    "Microsoft.Quantum.Compiler::0.11.2006.403",
 
-    "Microsoft.Quantum.CsharpGeneration::0.11.2006.207",
-    "Microsoft.Quantum.Development.Kit::0.11.2006.207",
-    "Microsoft.Quantum.Simulators::0.11.2006.207",
-    "Microsoft.Quantum.Xunit::0.11.2006.207",
+    "Microsoft.Quantum.CsharpGeneration::0.11.2006.403",
+    "Microsoft.Quantum.Development.Kit::0.11.2006.403",
+    "Microsoft.Quantum.Simulators::0.11.2006.403",
+    "Microsoft.Quantum.Xunit::0.11.2006.403",
 
-    "Microsoft.Quantum.Standard::0.11.2006.207",
-    "Microsoft.Quantum.Chemistry::0.11.2006.207",
-    "Microsoft.Quantum.Chemistry.Jupyter::0.11.2006.207",
-    "Microsoft.Quantum.Numerics::0.11.2006.207",
+    "Microsoft.Quantum.Standard::0.11.2006.403",
+    "Microsoft.Quantum.Chemistry::0.11.2006.403",
+    "Microsoft.Quantum.Chemistry.Jupyter::0.11.2006.403",
+    "Microsoft.Quantum.MachineLearning::0.11.2006.403",
+    "Microsoft.Quantum.Numerics::0.11.2006.403",
 
-    "Microsoft.Quantum.Katas::0.11.2006.207",
+    "Microsoft.Quantum.Katas::0.11.2006.403",
 
-    "Microsoft.Quantum.Research::0.11.2006.207"
+    "Microsoft.Quantum.Research::0.11.2006.403"
   ]
 }


### PR DESCRIPTION
This PR adds a default version for the Microsoft.Quantum.MachineLearning package so that notebooks and Python scripts don't have to explicitly specify a version.

Also updates the QDK version to the latest release.