### PR TITLE
Add source distribution to qsharp PyPI package

### DIFF
--- a/build/pack.ps1
+++ b/build/pack.ps1
@@ -32,7 +32,7 @@ function Pack-Wheel() {
     $result = 0
 
     Push-Location (Join-Path $PSScriptRoot $Path)
-        python setup.py bdist_wheel sdist
+        python setup.py bdist_wheel sdist --formats=gztar,zip
 
         if  ($LastExitCode -ne 0) {
             Write-Host "##vso[task.logissue type=error;]Failed to build $Path."
@@ -40,6 +40,7 @@ function Pack-Wheel() {
         } else {
             Copy-Item "dist/*.whl" $Env:PYTHON_OUTDIR
             Copy-Item "dist/*.tar.gz" $Env:PYTHON_OUTDIR
+            Copy-Item "dist/*.zip" $Env:PYTHON_OUTDIR
         }
     Pop-Location
 

--- a/build/pack.ps1
+++ b/build/pack.ps1
@@ -32,7 +32,7 @@ function Pack-Wheel() {
     $result = 0
 
     Push-Location (Join-Path $PSScriptRoot $Path)
-        python setup.py bdist_wheel sdist --formats=gztar,zip
+        python setup.py bdist_wheel sdist --formats=gztar
 
         if  ($LastExitCode -ne 0) {
             Write-Host "##vso[task.logissue type=error;]Failed to build $Path."
@@ -40,7 +40,6 @@ function Pack-Wheel() {
         } else {
             Copy-Item "dist/*.whl" $Env:PYTHON_OUTDIR
             Copy-Item "dist/*.tar.gz" $Env:PYTHON_OUTDIR
-            Copy-Item "dist/*.zip" $Env:PYTHON_OUTDIR
         }
     Pop-Location
 

--- a/build/pack.ps1
+++ b/build/pack.ps1
@@ -32,13 +32,14 @@ function Pack-Wheel() {
     $result = 0
 
     Push-Location (Join-Path $PSScriptRoot $Path)
-        python setup.py bdist_wheel
+        python setup.py bdist_wheel sdist
 
         if  ($LastExitCode -ne 0) {
             Write-Host "##vso[task.logissue type=error;]Failed to build $Path."
             $script:all_ok = $False
         } else {
             Copy-Item "dist/*.whl" $Env:PYTHON_OUTDIR
+            Copy-Item "dist/*.tar.gz" $Env:PYTHON_OUTDIR
         }
     Pop-Location
 

--- a/src/Python/setup.py
+++ b/src/Python/setup.py
@@ -49,6 +49,7 @@ setuptools.setup(
     name="qsharp",
     version=version,
     author="Microsoft",
+    author_email="opencode@microsoft.com",
     description="Python client for Q#, a domain-specific quantum programming language",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/src/Python/setup.py
+++ b/src/Python/setup.py
@@ -49,7 +49,7 @@ setuptools.setup(
     name="qsharp",
     version=version,
     author="Microsoft",
-    author_email="opencode@microsoft.com",
+    author_email="que-contacts@microsoft.com",
     description="Python client for Q#, a domain-specific quantum programming language",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
The `qsharp` PyPI package currently does not include a source distribution. This PR simply adds `sdist --formats=gztar` arguments to the `setuptools` script, which creates a source distribution that gets uploaded along with the wheel.

Adding a source distribution also required me to add a contact email address. I'm using `que-contacts@microsoft.com`, which appears to be the contact email address used for our NuGet packages.

I verified that an end-to-end build succeeds with these changes and that the PyPI publish step succeeds.

Resolves #30.