### PR TITLE
Improved documentation for IQ# magic commands

### DIFF
--- a/src/AzureClient/Magic/AzureClientMagicBase.cs
+++ b/src/AzureClient/Magic/AzureClientMagicBase.cs
@@ -11,6 +11,12 @@ using Microsoft.Quantum.IQSharp.Jupyter;
 
 namespace Microsoft.Quantum.IQSharp.AzureClient
 {
+    internal static class AzureClientMagicExtensions
+    {
+        public static string ToMarkdown(this AzureClientError error) =>
+            $"`{error.ToString()}`: {error.ToDescription()}";
+    }
+
     /// <summary>
     ///     Base class used for Azure Client magic commands.
     /// </summary>

--- a/src/AzureClient/Magic/ConnectMagic.cs
+++ b/src/AzureClient/Magic/ConnectMagic.cs
@@ -50,10 +50,12 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
                         #### Required parameters
 
                         The Azure Quantum workspace can be identified by resource ID:
+
                         - `{ParameterNameResourceId}=<string>`: The resource ID of the Azure Quantum workspace.
                         This can be obtained from the workspace page in the Azure portal.
 
                         Alternatively, it can be identified by subscription ID, resource group name, and workspace name:
+                        
                         - `{ParameterNameSubscriptionId}=<string>`: The Azure subscription ID for the Azure Quantum workspace.
                         - `{ParameterNameResourceGroupName}=<string>`: The Azure resource group name for the Azure Quantum workspace.
                         - `{ParameterNameWorkspaceName}=<string>`: The name of the Azure Quantum workspace.

--- a/src/AzureClient/Magic/ConnectMagic.cs
+++ b/src/AzureClient/Magic/ConnectMagic.cs
@@ -39,73 +39,91 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
                 new Documentation
                 {
                     Summary = "Connects to an Azure Quantum workspace or displays current connection status.",
-                    Description = @"
-                            This magic command allows for connecting to an Azure Quantum workspace
-                            as specified by the resource ID of the workspace or by a combination of
-                            subscription ID, resource group name, and workspace name.
+                    Description = $@"
+                        This magic command allows for connecting to an Azure Quantum workspace
+                        as specified by the resource ID of the workspace or by a combination of
+                        subscription ID, resource group name, and workspace name.
 
-                            If the connection is successful, a list of the available Q# execution targets
-                            in the Azure Quantum workspace will be displayed.
-                        ".Dedent(),
+                        If the connection is successful, a list of the available Q# execution targets
+                        in the Azure Quantum workspace will be displayed.
+
+                        #### Required parameters
+
+                        The Azure Quantum workspace can be identified by resource ID:
+                        - `{ParameterNameResourceId}=<string>`: The resource ID of the Azure Quantum workspace.
+                        This can be obtained from the workspace page in the Azure portal.
+
+                        Alternatively, it can be identified by subscription ID, resource group name, and workspace name:
+                        - `{ParameterNameSubscriptionId}=<string>`: The Azure subscription ID for the Azure Quantum workspace.
+                        - `{ParameterNameResourceGroupName}=<string>`: The Azure resource group name for the Azure Quantum workspace.
+                        - `{ParameterNameWorkspaceName}=<string>`: The name of the Azure Quantum workspace.
+                        
+                        #### Optional parameters
+
+                        - `{ParameterNameRefresh}`: Bypasses any saved or cached credentials when connecting to Azure.
+                        - `{ParameterNameStorageAccountConnectionString}=<string>`: The connection string to the Azure storage
+                        account. Required if the specified Azure Quantum workspace was not linked to a storage
+                        account at workspace creation time.
+                        
+                        #### Possible errors
+
+                        - {AzureClientError.WorkspaceNotFound.ToMarkdown()}
+                        - {AzureClientError.AuthenticationFailed.ToMarkdown()}
+                    ".Dedent(),
                     Examples = new[]
-                        {
-                            $@"
-                                Connect to an Azure Quantum workspace using its resource ID:
-                                ```
-                                In []: %azure.connect {ParameterNameResourceId}=""/subscriptions/f846b2bd-d0e2-4a1d-8141-4c6944a9d387/resourceGroups/RESOURCE_GROUP_NAME/providers/Microsoft.Quantum/Workspaces/WORKSPACE_NAME""
-                                Out[]: Connected to Azure Quantum workspace WORKSPACE_NAME.
-                                       <list of Q# execution targets available in the Azure Quantum workspace>
-                                ```
-                            ".Dedent(),
+                    {
+                        $@"
+                            Connect to an Azure Quantum workspace using its resource ID:
+                            ```
+                            In []: %azure.connect {ParameterNameResourceId}=""/subscriptions/.../Microsoft.Quantum/Workspaces/WORKSPACE_NAME""
+                            Out[]: Connected to Azure Quantum workspace WORKSPACE_NAME.
+                                    <list of Q# execution targets available in the Azure Quantum workspace>
+                            ```
+                        ".Dedent(),
 
-                            $@"
-                                Connect to an Azure Quantum workspace using its resource ID and a storage account connection string,
-                                which is required for workspaces that do not have a linked storage account:
-                                ```
-                                In []: %azure.connect {ParameterNameResourceId}=""/subscriptions/f846b2bd-d0e2-4a1d-8141-4c6944a9d387/resourceGroups/RESOURCE_GROUP_NAME/providers/Microsoft.Quantum/Workspaces/WORKSPACE_NAME""
-                                                      {ParameterNameStorageAccountConnectionString}=""STORAGE_ACCOUNT_CONNECTION_STRING""
-                                Out[]: Connected to Azure Quantum workspace WORKSPACE_NAME.
-                                       <list of Q# execution targets available in the Azure Quantum workspace>
-                                ```
-                            ".Dedent(),
+                        $@"
+                            Connect to an Azure Quantum workspace using its resource ID and a storage account connection string:
+                            ```
+                            In []: %azure.connect {ParameterNameResourceId}=""/subscriptions/.../Microsoft.Quantum/Workspaces/WORKSPACE_NAME""
+                                                    {ParameterNameStorageAccountConnectionString}=""STORAGE_ACCOUNT_CONNECTION_STRING""
+                            Out[]: Connected to Azure Quantum workspace WORKSPACE_NAME.
+                                    <list of Q# execution targets available in the Azure Quantum workspace>
+                            ```
+                        ".Dedent(),
 
-                            $@"
-                                Connect to an Azure Quantum workspace using individual parameters:
-                                ```
-                                In []: %azure.connect {ParameterNameSubscriptionId}=""SUBSCRIPTION_ID""
-                                                      {ParameterNameResourceGroupName}=""RESOURCE_GROUP_NAME""
-                                                      {ParameterNameWorkspaceName}=""WORKSPACE_NAME""
-                                                      {ParameterNameStorageAccountConnectionString}=""STORAGE_ACCOUNT_CONNECTION_STRING""
-                                Out[]: Connected to Azure Quantum workspace WORKSPACE_NAME.
-                                       <list of Q# execution targets available in the Azure Quantum workspace>
-                                ```
-                                The `{ParameterNameStorageAccountConnectionString}` parameter is necessary only if the
-                                specified Azure Quantum workspace was not linked to a storage account at creation time.
-                            ".Dedent(),
+                        $@"
+                            Connect to an Azure Quantum workspace using individual subscription ID, resource group name, and workspace name parameters:
+                            ```
+                            In []: %azure.connect {ParameterNameSubscriptionId}=""SUBSCRIPTION_ID""
+                                                    {ParameterNameResourceGroupName}=""RESOURCE_GROUP_NAME""
+                                                    {ParameterNameWorkspaceName}=""WORKSPACE_NAME""
+                                                    {ParameterNameStorageAccountConnectionString}=""STORAGE_ACCOUNT_CONNECTION_STRING""
+                            Out[]: Connected to Azure Quantum workspace WORKSPACE_NAME.
+                                    <list of Q# execution targets available in the Azure Quantum workspace>
+                            ```
+                        ".Dedent(),
 
-                            $@"
-                                Connect to an Azure Quantum workspace and force a credential prompt using
-                                the `{ParameterNameRefresh}` option:
-                                ```
-                                In []: %azure.connect {ParameterNameRefresh} {ParameterNameResourceId}=""/subscriptions/f846b2bd-d0e2-4a1d-8141-4c6944a9d387/resourceGroups/RESOURCE_GROUP_NAME/providers/Microsoft.Quantum/Workspaces/WORKSPACE_NAME""
-                                Out[]: To sign in, use a web browser to open the page https://microsoft.com/devicelogin
-                                        and enter the code [login code] to authenticate.
-                                       Connected to Azure Quantum workspace WORKSPACE_NAME.
-                                       <list of Q# execution targets available in the Azure Quantum workspace>
-                                ```
-                                The `{ParameterNameRefresh}` option bypasses any saved or cached
-                                credentials when connecting to Azure.
-                            ".Dedent(),
+                        $@"
+                            Connect to an Azure Quantum workspace and force a credential prompt using
+                            the `{ParameterNameRefresh}` option:
+                            ```
+                            In []: %azure.connect {ParameterNameRefresh} {ParameterNameResourceId}=""/subscriptions/.../Microsoft.Quantum/Workspaces/WORKSPACE_NAME""
+                            Out[]: To sign in, use a web browser to open the page https://microsoft.com/devicelogin
+                                    and enter the code [login code] to authenticate.
+                                    Connected to Azure Quantum workspace WORKSPACE_NAME.
+                                    <list of Q# execution targets available in the Azure Quantum workspace>
+                            ```
+                        ".Dedent(),
 
-                            @"
-                                Print information about the current connection:
-                                ```
-                                In []: %azure.connect
-                                Out[]: Connected to Azure Quantum workspace WORKSPACE_NAME.
-                                       <list of Q# execution targets available in the Azure Quantum workspace>
-                                ```
-                            ".Dedent(),
-                        },
+                        @"
+                            Print information about the currently-connected Azure Quantum workspace:
+                            ```
+                            In []: %azure.connect
+                            Out[]: Connected to Azure Quantum workspace WORKSPACE_NAME.
+                                    <list of Q# execution targets available in the Azure Quantum workspace>
+                            ```
+                        ".Dedent(),
+                    },
                 }) {}
 
         /// <summary>

--- a/src/AzureClient/Magic/ExecuteMagic.cs
+++ b/src/AzureClient/Magic/ExecuteMagic.cs
@@ -36,8 +36,9 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
                         The command waits a specified amount of time for the job to complete before returning.
 
                         The Azure Quantum workspace must have been previously initialized
-                        using the `%azure.connect` magic command, and an execution target for the job
-                        must have been specified using the `%azure.target` magic command.
+                        using the [`%azure.connect` magic command](https://docs.microsoft.com/qsharp/api/iqsharp-magic/azure.connect),
+                        and an execution target for the job must have been specified using the
+                        [`%azure.target` magic command](https://docs.microsoft.com/qsharp/api/iqsharp-magic/azure.target).
 
                         #### Required parameters
 

--- a/src/AzureClient/Magic/ExecuteMagic.cs
+++ b/src/AzureClient/Magic/ExecuteMagic.cs
@@ -30,22 +30,78 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
                 new Documentation
                 {
                     Summary = "Executes a job in an Azure Quantum workspace.",
-                    Description = @"
-                        This magic command allows for executing a job in an Azure Quantum workspace
-                        corresponding to the Q# operation provided as an argument, and it waits
-                        for the job to complete before returning.
+                    Description = $@"
+                        This magic command allows for executing a Q# operation or function
+                        on the specified target in the current Azure Quantum workspace.
+                        The command waits a specified amount of time for the job to complete before returning.
 
-                        The Azure Quantum workspace must previously have been initialized
-                        using the %azure.connect magic command.
+                        The Azure Quantum workspace must have been previously initialized
+                        using the `%azure.connect` magic command, and an execution target for the job
+                        must have been specified using the `%azure.target` magic command.
+
+                        #### Required parameters
+
+                        - Q# operation or function name. This must be the first parameter, and must be a valid Q# operation
+                        or function name that has been defined either in the notebook or in a Q# file in the same folder.
+                        - Arguments for the Q# operation or function must also be specified as `key=value` pairs.
+                        
+                        #### Optional parameters
+
+                        - `{AzureSubmissionContext.ParameterNameJobName}=<string>`: Friendly name to identify this job. If not specified,
+                        the Q# operation or function name will be used as the job name.
+                        - `{AzureSubmissionContext.ParameterNameShots}=<integer>` (default=500): Number of times to repeat execution of the
+                        specified Q# operation or function.
+                        - `{AzureSubmissionContext.ParameterNameTimeout}=<integer>` (default=30): Time to wait (in seconds) for job completion
+                        before the magic command returns.
+                        - `{AzureSubmissionContext.ParameterNamePollingInterval}=<integer>` (default=5): Interval (in seconds) to poll for
+                        job status while waiting for job execution to complete.
+                        
+                        #### Possible errors
+
+                        - {AzureClientError.NotConnected.ToMarkdown()}
+                        - {AzureClientError.NoTarget.ToMarkdown()}
+                        - {AzureClientError.NoOperationName.ToMarkdown()}
+                        - {AzureClientError.InvalidTarget.ToMarkdown()}
+                        - {AzureClientError.UnrecognizedOperationName.ToMarkdown()}
+                        - {AzureClientError.InvalidEntryPoint.ToMarkdown()}
+                        - {AzureClientError.JobSubmissionFailed.ToMarkdown()}
+                        - {AzureClientError.JobNotCompleted.ToMarkdown()}
+                        - {AzureClientError.JobOutputDownloadFailed.ToMarkdown()}
                     ".Dedent(),
                     Examples = new[]
                     {
                         @"
-                            Execute an operation in the current Azure Quantum workspace:
+                            Execute a Q# operation defined as `operation MyOperation(a : Int, b : Int) : Result`
+                            on the active target in the current Azure Quantum workspace:
                             ```
-                            In []: %azure.execute OPERATION_NAME
-                            Out[]: Executing job on target TARGET_NAME...
-                                   <job results displayed here after execution completes>
+                            In []: %azure.execute MyOperation a=5 b=10
+                            Out[]: Submitting MyOperation to target provider.qpu...
+                                   Job successfully submitted for 500 shots.
+                                      Job name: MyOperation
+                                      Job ID: <Azure Quantum job ID>
+                                   Waiting up to 30 seconds for Azure Quantum job to complete...
+                                   [1:23:45 PM] Current job status: Waiting
+                                   [1:23:50 PM] Current job status: Executing
+                                   [1:23:55 PM] Current job status: Succeeded
+                                   <detailed results of completed job>
+                            ```
+                        ".Dedent(),
+                        @"
+                            Execute a Q# operation defined as `operation MyOperation(a : Int, b : Int) : Result`
+                            on the active target in the current Azure Quantum workspace,
+                            specifying a custom job name, number of shots, timeout, and polling interval:
+                            ```
+                            In []: %azure.submit MyOperation a=5 b=10 jobName=""My job"" shots=100 timeout=60 poll=10
+                            Out[]: Submitting MyOperation to target provider.qpu...
+                                   Job successfully submitted for 100 shots.
+                                      Job name: My job
+                                      Job ID: <Azure Quantum job ID>
+                                   Waiting up to 60 seconds for Azure Quantum job to complete...
+                                   [1:23:45 PM] Current job status: Waiting
+                                   [1:23:55 PM] Current job status: Waiting
+                                   [1:24:05 PM] Current job status: Executing
+                                   [1:24:15 PM] Current job status: Succeeded
+                                   <detailed results of completed job>
                             ```
                         ".Dedent(),
                     },

--- a/src/AzureClient/Magic/JobsMagic.cs
+++ b/src/AzureClient/Magic/JobsMagic.cs
@@ -33,29 +33,39 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
                 new Documentation
                 {
                     Summary = "Displays a list of jobs in the current Azure Quantum workspace.",
-                    Description = @"
+                    Description = $@"
                         This magic command allows for displaying the list of jobs in the current 
                         Azure Quantum workspace, optionally filtering the list to jobs which
                         have an ID, name, or target containing the provided filter parameter.
 
-                        The Azure Quantum workspace must previously have been initialized
-                        using the %azure.connect magic command.
+                        The Azure Quantum workspace must have been previously initialized
+                        using the `%azure.connect` magic command.
+                        
+                        #### Optional parameters
+
+                        - A string to filter the list of jobs. Jobs which have an ID, name, or target
+                        containing the provided filter parameter will be displayed. If not specified,
+                        all recent jobs are displayed.
+                        
+                        #### Possible errors
+
+                        - {AzureClientError.NotConnected.ToMarkdown()}
                     ".Dedent(),
                     Examples = new[]
                     {
                         @"
-                            Print the list of jobs:
+                            Get the list of jobs:
                             ```
                             In []: %azure.jobs
-                            Out[]: <list of jobs in the workspace>
+                            Out[]: <detailed status of all recent jobs in the workspace>
                             ```
                         ".Dedent(),
 
                         @"
-                            Print the list of jobs whose ID, name, or target contains ""MyJob"":
+                            Get the list of jobs whose ID, name, or target contains ""My job"":
                             ```
-                            In []: %azure.jobs ""MyJob""
-                            Out[]: <list of matching jobs>
+                            In []: %azure.jobs ""My job""
+                            Out[]: <detailed status of matching jobs in the workspace>
                             ```
                         ".Dedent(),
                     },

--- a/src/AzureClient/Magic/JobsMagic.cs
+++ b/src/AzureClient/Magic/JobsMagic.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
                         have an ID, name, or target containing the provided filter parameter.
 
                         The Azure Quantum workspace must have been previously initialized
-                        using the `%azure.connect` magic command.
+                        using the [`%azure.connect` magic command](https://docs.microsoft.com/qsharp/api/iqsharp-magic/azure.connect).
                         
                         #### Optional parameters
 

--- a/src/AzureClient/Magic/OutputMagic.cs
+++ b/src/AzureClient/Magic/OutputMagic.cs
@@ -32,34 +32,43 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
                 "azure.output",
                 new Documentation
                 {
-                    Summary = "Displays results for jobs in the current Azure Quantum workspace.",
-                    Description = @"
-                        This magic command allows for displaying results of jobs in the current 
-                        Azure Quantum workspace. If a valid job ID is provided as an argument, and the
-                        job has completed, the output of that job will be displayed. If no job ID is
-                        provided, the job ID from the most recent call to `%azure.submit` or
-                        `%azure.execute` will be used.
-                        
-                        If the job has not yet completed, an error message will be displayed.
+                    Summary = "Displays results for a job in the current Azure Quantum workspace.",
+                    Description = $@"
+                        This magic command allows for displaying results for a job in the current 
+                        Azure Quantum workspace.
+                        The job execution must already be completed in order to display
+                        results.
 
-                        The Azure Quantum workspace must previously have been initialized
-                        using the %azure.connect magic command.
+                        The Azure Quantum workspace must have been previously initialized
+                        using the `%azure.connect` magic command.
+                        
+                        #### Optional parameters
+
+                        - The job ID for which to display results. If not specified, the job ID from
+                        the most recent call to `%azure.submit` or `%azure.execute` will be used.
+                        
+                        #### Possible errors
+
+                        - {AzureClientError.NotConnected.ToMarkdown()}
+                        - {AzureClientError.JobNotFound.ToMarkdown()}
+                        - {AzureClientError.JobNotCompleted.ToMarkdown()}
+                        - {AzureClientError.JobOutputDownloadFailed.ToMarkdown()}
                     ".Dedent(),
                     Examples = new[]
                     {
                         @"
-                            Print results of a specific job:
+                            Get results of a specific job:
                             ```
                             In []: %azure.output JOB_ID
-                            Out[]: <job results of specified job>
+                            Out[]: <detailed results of specified job>
                             ```
                         ".Dedent(),
 
                         @"
-                            Print results of the most recently-submitted job:
+                            Get results of the most recently submitted job:
                             ```
                             In []: %azure.output
-                            Out[]: <job results of most recently-submitted job>
+                            Out[]: <detailed results of most recently submitted job>
                             ```
                         ".Dedent(),
                     },

--- a/src/AzureClient/Magic/OutputMagic.cs
+++ b/src/AzureClient/Magic/OutputMagic.cs
@@ -40,12 +40,13 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
                         results.
 
                         The Azure Quantum workspace must have been previously initialized
-                        using the `%azure.connect` magic command.
+                        using the [`%azure.connect` magic command](https://docs.microsoft.com/qsharp/api/iqsharp-magic/azure.connect).
                         
                         #### Optional parameters
 
                         - The job ID for which to display results. If not specified, the job ID from
-                        the most recent call to `%azure.submit` or `%azure.execute` will be used.
+                        the most recent call to [`%azure.submit`](https://docs.microsoft.com/qsharp/api/iqsharp-magic/azure.submit)
+                        or [`%azure.execute`](https://docs.microsoft.com/qsharp/api/iqsharp-magic/azure.execute) will be used.
                         
                         #### Possible errors
 

--- a/src/AzureClient/Magic/StatusMagic.cs
+++ b/src/AzureClient/Magic/StatusMagic.cs
@@ -38,12 +38,13 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
                         Azure Quantum workspace.
 
                         The Azure Quantum workspace must have been previously initialized
-                        using the `%azure.connect` magic command.
+                        using the [`%azure.connect` magic command](https://docs.microsoft.com/qsharp/api/iqsharp-magic/azure.connect).
                         
                         #### Optional parameters
 
                         - The job ID for which to display status. If not specified, the job ID from
-                        the most recent call to `%azure.submit` or `%azure.execute` will be used.
+                        the most recent call to [`%azure.submit`](https://docs.microsoft.com/qsharp/api/iqsharp-magic/azure.submit)
+                        or [`%azure.execute`](https://docs.microsoft.com/qsharp/api/iqsharp-magic/azure.execute) will be used.
                         
                         #### Possible errors
 

--- a/src/AzureClient/Magic/StatusMagic.cs
+++ b/src/AzureClient/Magic/StatusMagic.cs
@@ -32,32 +32,39 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
                 "azure.status",
                 new Documentation
                 {
-                    Summary = "Displays status for jobs in the current Azure Quantum workspace.",
-                    Description = @"
-                        This magic command allows for displaying status of jobs in the current 
-                        Azure Quantum workspace. If a valid job ID is provided as an argument, the
-                        detailed status of that job will be displayed. If no job ID is
-                        provided, the job ID from the most recent call to `%azure.submit` or
-                        `%azure.execute` will be used.
+                    Summary = "Displays status for a job in the current Azure Quantum workspace.",
+                    Description = $@"
+                        This magic command allows for displaying status for a job in the current 
+                        Azure Quantum workspace.
 
-                        The Azure Quantum workspace must previously have been initialized
-                        using the %azure.connect magic command.
+                        The Azure Quantum workspace must have been previously initialized
+                        using the `%azure.connect` magic command.
+                        
+                        #### Optional parameters
+
+                        - The job ID for which to display status. If not specified, the job ID from
+                        the most recent call to `%azure.submit` or `%azure.execute` will be used.
+                        
+                        #### Possible errors
+
+                        - {AzureClientError.NotConnected.ToMarkdown()}
+                        - {AzureClientError.JobNotFound.ToMarkdown()}
                     ".Dedent(),
                     Examples = new[]
                     {
                         @"
-                            Print status of a specific job:
+                            Get the status of a specific job:
                             ```
                             In []: %azure.status JOB_ID
-                            Out[]: <job status of specified job>
+                            Out[]: <detailed status of specified job>
                             ```
                         ".Dedent(),
 
                         @"
-                            Print status of the most recently-submitted job:
+                            Get the status of the most recently submitted job:
                             ```
                             In []: %azure.status
-                            Out[]: <job status of most recently-submitted job>
+                            Out[]: <detailed status of most recently submitted job>
                             ```
                         ".Dedent(),
                     },

--- a/src/AzureClient/Magic/SubmitMagic.cs
+++ b/src/AzureClient/Magic/SubmitMagic.cs
@@ -35,8 +35,9 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
                         The command returns immediately after the job is submitted.
 
                         The Azure Quantum workspace must have been previously initialized
-                        using the `%azure.connect` magic command, and an execution target for the job
-                        must have been specified using the `%azure.target` magic command.
+                        using the [`%azure.connect` magic command](https://docs.microsoft.com/qsharp/api/iqsharp-magic/azure.connect),
+                        and an execution target for the job must have been specified using the
+                        [`%azure.target` magic command](https://docs.microsoft.com/qsharp/api/iqsharp-magic/azure.target).
 
                         #### Required parameters
 

--- a/src/AzureClient/Magic/SubmitMagic.cs
+++ b/src/AzureClient/Magic/SubmitMagic.cs
@@ -29,20 +29,63 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
                 new Documentation
                 {
                     Summary = "Submits a job to an Azure Quantum workspace.",
-                    Description = @"
-                        This magic command allows for submitting a job to an Azure Quantum workspace
-                        corresponding to the Q# operation provided as an argument.
+                    Description = $@"
+                        This magic command allows for submitting a Q# operation or function
+                        for execution on the specified target in the current Azure Quantum workspace.
+                        The command returns immediately after the job is submitted.
 
-                        The Azure Quantum workspace must previously have been initialized
-                        using the %azure.connect magic command.
+                        The Azure Quantum workspace must have been previously initialized
+                        using the `%azure.connect` magic command, and an execution target for the job
+                        must have been specified using the `%azure.target` magic command.
+
+                        #### Required parameters
+
+                        - Q# operation or function name. This must be the first parameter, and must be a valid Q# operation
+                        or function name that has been defined either in the notebook or in a Q# file in the same folder.
+                        - Arguments for the Q# operation or function must also be specified as `key=value` pairs.
+
+                        #### Optional parameters
+
+                        - `{AzureSubmissionContext.ParameterNameJobName}=<string>`: Friendly name to identify this job. If not specified,
+                        the Q# operation or function name will be used as the job name.
+                        - `{AzureSubmissionContext.ParameterNameShots}=<integer>` (default=500): Number of times to repeat execution of the
+                        specified Q# operation or function.
+                        
+                        #### Possible errors
+
+                        - {AzureClientError.NotConnected.ToMarkdown()}
+                        - {AzureClientError.NoTarget.ToMarkdown()}
+                        - {AzureClientError.NoOperationName.ToMarkdown()}
+                        - {AzureClientError.InvalidTarget.ToMarkdown()}
+                        - {AzureClientError.UnrecognizedOperationName.ToMarkdown()}
+                        - {AzureClientError.InvalidEntryPoint.ToMarkdown()}
+                        - {AzureClientError.JobSubmissionFailed.ToMarkdown()}
                     ".Dedent(),
                     Examples = new[]
                     {
                         @"
-                            Submit an operation as a new job to the current Azure Quantum workspace:
+                            Submit a Q# operation defined as `operation MyOperation(a : Int, b : Int) : Result`
+                            for execution on the active target in the current Azure Quantum workspace:
                             ```
-                            In []: %azure.submit OPERATION_NAME
-                            Out[]: Submitted job JOB_ID
+                            In []: %azure.submit MyOperation a=5 b=10
+                            Out[]: Submitting MyOperation to target provider.qpu...
+                                   Job successfully submitted for 500 shots.
+                                      Job name: MyOperation
+                                      Job ID: <Azure Quantum job ID>
+                                   <detailed properties of submitted job>
+                            ```
+                        ".Dedent(),
+                        @"
+                            Submit a Q# operation defined as `operation MyOperation(a : Int, b : Int) : Result`
+                            for execution on the active target in the current Azure Quantum workspace,
+                            specifying a custom job name, number of shots, timeout, and polling interval:
+                            ```
+                            In []: %azure.submit MyOperation a=5 b=10 jobName=""My job"" shots=100
+                            Out[]: Submitting MyOperation to target provider.qpu...
+                                   Job successfully submitted for 100 shots.
+                                      Job name: My job
+                                      Job ID: <Azure Quantum job ID>
+                                   <detailed properties of submitted job>
                             ```
                         ".Dedent(),
                     },

--- a/src/AzureClient/Magic/TargetMagic.cs
+++ b/src/AzureClient/Magic/TargetMagic.cs
@@ -32,29 +32,44 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
                 "azure.target",
                 new Documentation
                 {
-                    Summary = "Views or sets the target for job submission to an Azure Quantum workspace.",
-                    Description = @"
-                        This magic command allows for specifying a target for job submission
-                        to an Azure Quantum workspace, or viewing the list of all available targets.
+                    Summary = "Sets or displays the active execution target for Q# job submission in an Azure Quantum workspace.",
+                    Description = $@"
+                        This magic command allows for specifying or displaying the execution target for Q# job submission
+                        in an Azure Quantum workspace.
 
-                        The Azure Quantum workspace must previously have been initialized
-                        using the %azure.connect magic command, and the specified target must be
-                        available in the workspace.   
+                        The Azure Quantum workspace must have been previously initialized
+                        using the `%azure.connect` magic command. The specified execution target must be
+                        available in the workspace and support execution of Q# programs.
+
+                        #### Optional parameters
+
+                        - The target ID to set as the active execution target for Q# job submission. If not specified,
+                        the currently active execution target is displayed.
+
+                        #### Possible errors
+
+                        - {AzureClientError.NotConnected.ToMarkdown()}
+                        - {AzureClientError.InvalidTarget.ToMarkdown()}
+                        - {AzureClientError.NoTarget.ToMarkdown()}
                     ".Dedent(),
                     Examples = new[]
                     {
                         @"
-                            Set the current target for job submission:
+                            Set the current target for Q# job submission to `provider.qpu`:
                             ```
-                            In []: %azure.target TARGET_ID
-                            Out[]: Active target is now TARGET_ID
+                            In []: %azure.target provider.qpu
+                            Out[]: Loading package Microsoft.Quantum.Providers.Provider and dependencies...
+                                   Active target is now provider.qpu
+                                   <detailed properties of active execution target>
                             ```
                         ".Dedent(),
                         @"
-                            View the current target and all available targets in the current Azure Quantum workspace:
+                            Display the current target and all available targets in the current Azure Quantum workspace:
                             ```
                             In []: %azure.target
-                            Out[]: <current target and list of available targets>
+                            Out[]: Current execution target: provider.qpu
+                                   Available execution targets: provider.qpu, provider.simulator
+                                   <detailed properties of active execution target>
                             ```
                         ".Dedent(),
                     },

--- a/src/AzureClient/Magic/TargetMagic.cs
+++ b/src/AzureClient/Magic/TargetMagic.cs
@@ -38,8 +38,8 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
                         in an Azure Quantum workspace.
 
                         The Azure Quantum workspace must have been previously initialized
-                        using the `%azure.connect` magic command. The specified execution target must be
-                        available in the workspace and support execution of Q# programs.
+                        using the [`%azure.connect` magic command](https://docs.microsoft.com/qsharp/api/iqsharp-magic/azure.connect)
+                        magic command. The specified execution target must be available in the workspace and support execution of Q# programs.
 
                         #### Optional parameters
 

--- a/src/Jupyter/Visualization/StateDisplayEncoders.cs
+++ b/src/Jupyter/Visualization/StateDisplayEncoders.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Quantum.IQSharp.Jupyter
         ///     Display phase information as an arrow (<c>↑</c>) rotated by an angle
         ///     dependent on the phase as well as display phase information in number
         ///     format.
-        ArrowsAndNumber
+        ArrowAndNumber
     }
 
     /// <summary>
@@ -255,7 +255,7 @@ namespace Microsoft.Quantum.IQSharp.Jupyter
                                  ↑
                                 </td>
                             "),
-                            PhaseDisplayStyle.ArrowsAndNumber => FormattableString.Invariant($@"
+                            PhaseDisplayStyle.ArrowAndNumber => FormattableString.Invariant($@"
                                 <td>
                                  <div style=""{StyleForAngle(amplitude.Phase)}""> ↑ </div> <div style=""{StyleForNumber()}"">{amplitude.Phase}</div>
                                 </td>

--- a/src/Kernel/Magic/ConfigMagic.cs
+++ b/src/Kernel/Magic/ConfigMagic.cs
@@ -25,7 +25,8 @@ namespace Microsoft.Quantum.IQSharp.Kernel
         /// </summary>
         public ConfigMagic(IConfigurationSource configurationSource) : base(
             "config",
-            new Documentation {
+            new Documentation
+            {
                 Summary = "Allows setting or querying configuration options.",
                 Description = @"
                     This magic command allows for setting or querying
@@ -36,14 +37,14 @@ namespace Microsoft.Quantum.IQSharp.Kernel
 
                     #### Configuration settings
 
-                    ##### `dump.basisStateLabelingConvention`
+                    **`dump.basisStateLabelingConvention`**
 
                     **Value:** `""LittleEndian""` (default), `""BigEndian""`, or `""Bitstring""`
 
                     The convention to be used when labeling computational
-                    basis states in output from methods such as `DumpMachine()` or `DumpRegister()`.
+                    basis states in output from callables such as `DumpMachine` or `DumpRegister`.
 
-                    ##### `dump.truncateSmallAmplitudes`
+                    **`dump.truncateSmallAmplitudes`**
 
                     **Value:** `true` or `false` (default)
 
@@ -51,7 +52,7 @@ namespace Microsoft.Quantum.IQSharp.Kernel
                     (i.e., squared amplitudes) are smaller than a particular threshold, as determined by
                     the `dump.truncationThreshold` setting.
 
-                    ##### `dump.truncationThreshold`
+                    **`dump.truncationThreshold`**
 
                     **Value:** floating point number such as `0.001` or `1E-8` (default `1E-10`)
 
@@ -59,12 +60,12 @@ namespace Microsoft.Quantum.IQSharp.Kernel
                     threshold for measurement probabilities (i.e., squared amplitudes) below which to hide the display
                     of basis states of a state vector.
 
-                    ##### `dump.phaseDisplayStyle`
+                    **`dump.phaseDisplayStyle`**
 
                     **Value:** `""ArrowOnly""` (default), `""NumberOnly""`, `""ArrowAndNumber""`, or `""None""`
 
-                    Configures the phase visualization style in output from methods such as
-                    `DumpMachine()` or `DumpRegister()`. Supports displaying phase as arrows, numbers (in radians), both, or neither.
+                    Configures the phase visualization style in output from callables such as
+                    `DumpMachine` or `DumpRegister`. Supports displaying phase as arrows, numbers (in radians), both, or neither.
                 ".Dedent(),
                 Examples = new []
                 {

--- a/src/Kernel/Magic/ConfigMagic.cs
+++ b/src/Kernel/Magic/ConfigMagic.cs
@@ -30,9 +30,41 @@ namespace Microsoft.Quantum.IQSharp.Kernel
                 Description = @"
                     This magic command allows for setting or querying
                     configuration options used to control the behavior of the
-                    IQ# kernel (e.g.: state visualization options), and to
-                    save those options to a JSON file in the current working
-                    directory.
+                    IQ# kernel (such as state visualization options). It also
+                    allows for saving those options to a JSON file in the current
+                    working directory (using the `--save` option).
+
+                    #### Configuration settings
+
+                    ##### `dump.basisStateLabelingConvention`
+
+                    **Value:** `""LittleEndian""` (default), `""BigEndian""`, or `""Bitstring""`
+
+                    The convention to be used when labeling computational
+                    basis states in output from methods such as `DumpMachine()` or `DumpRegister()`.
+
+                    ##### `dump.truncateSmallAmplitudes`
+
+                    **Value:** `true` or `false` (default)
+
+                    Hides basis states of a state vector whose measurement probabilities
+                    (i.e., squared amplitudes) are smaller than a particular threshold, as determined by
+                    the `dump.truncationThreshold` setting.
+
+                    ##### `dump.truncationThreshold`
+
+                    **Value:** floating point number such as `0.001` or `1E-8` (default `1E-10`)
+
+                    If `dump.truncateSmallAmplitudes` is set to `true`, determines the
+                    threshold for measurement probabilities (i.e., squared amplitudes) below which to hide the display
+                    of basis states of a state vector.
+
+                    ##### `dump.phaseDisplayStyle`
+
+                    **Value:** `""ArrowOnly""` (default), `""NumberOnly""`, `""ArrowAndNumber""`, or `""None""`
+
+                    Configures the phase visualization style in output from methods such as
+                    `DumpMachine()` or `DumpRegister()`. Supports displaying phase as arrows, numbers (in radians), both, or neither.
                 ".Dedent(),
                 Examples = new []
                 {
@@ -51,7 +83,7 @@ namespace Microsoft.Quantum.IQSharp.Kernel
                         Configure the `DumpMachine` and `DumpRegister` callables
                         to use big-endian convention:
                         ```
-                        In []: %config dump.basisStateLabelingConvention = ""BigEndian""
+                        In []: %config dump.basisStateLabelingConvention=""BigEndian""
                         Out[]: ""BigEndian""
                         ```
                     ".Dedent(),
@@ -109,7 +141,7 @@ namespace Microsoft.Quantum.IQSharp.Kernel
                 var parts = input.Split("=", 2);
                 if (parts.Length != 2)
                 {
-                    return "Expected config option in the form key = value."
+                    return "Expected config option in the form key=value."
                            .ToExecutionResult(ExecuteStatus.Error);
                 }
                 var key = parts[0].Trim();

--- a/src/Kernel/Magic/EstimateMagic.cs
+++ b/src/Kernel/Magic/EstimateMagic.cs
@@ -34,8 +34,8 @@ namespace Microsoft.Quantum.IQSharp.Kernel
                     The ResourcesEstimator estimates statistics about how many resources the given
                     operation needs for execution. The resources it calculates include:
                     - Counts for each primitive operation
-                    - Depth (maximum number of qubits allocated at any given point)
-                    - Width (total number of gates used for the computation)
+                    - Depth (lower bound for the T-gate depth of the quantum circuit)
+                    - Width (lower bound for the maximum number of qubits used for the computation)
 
                     #### Required parameters
 

--- a/src/Kernel/Magic/EstimateMagic.cs
+++ b/src/Kernel/Magic/EstimateMagic.cs
@@ -28,9 +28,40 @@ namespace Microsoft.Quantum.IQSharp.Kernel
         /// </summary>
         public EstimateMagic(ISymbolResolver resolver) : base(
             "estimate",
-            new Documentation
-            {
-                Summary = "Runs a given function or operation on the ResourcesEstimator target machine."
+            new Documentation {
+                Summary = "Runs a given function or operation on the ResourcesEstimator target machine.",
+                Description = @"
+                    The ResourcesEstimator estimates statistics about how many resources the given
+                    operation needs for execution. The resources it calculates include:
+                    - Counts for each primitive operation
+                    - Depth (maximum number of qubits allocated at any given point)
+                    - Width (total number of gates used for the computation)
+
+                    #### Required parameters
+
+                    - Q# operation or function name. This must be the first parameter, and must be a valid Q# operation
+                    or function name that has been defined either in the notebook or in a Q# file in the same folder.
+                    - Arguments for the Q# operation or function must also be specified as `key=value` pairs.
+                ".Dedent(),
+                Examples = new []
+                {
+                    @"
+                        Estimate resources for a Q# operation defined as `operation MyOperation(a : Int, b : Int) : Result`:
+                        ```
+                        In []: %estimate MyOperation a=5 b=10
+                        Out[]: Metric           Sum     
+                               ---------------- ----
+                               CNOT             0
+                               QubitClifford    4
+                               R                0
+                               Measure          8
+                               T                0
+                               Depth            0
+                               Width            4
+                               BorrowedWidth    0
+                        ```
+                    ".Dedent(),
+                }
             })
         {
             this.SymbolResolver = resolver;

--- a/src/Kernel/Magic/EstimateMagic.cs
+++ b/src/Kernel/Magic/EstimateMagic.cs
@@ -39,6 +39,8 @@ namespace Microsoft.Quantum.IQSharp.Kernel
                     - Depth (lower bound for the T-gate depth of the quantum circuit)
                     - Width (lower bound for the maximum number of qubits used for the computation)
 
+                    See the [ResourcesEstimator user guide](https://docs.microsoft.com/quantum/user-guide/machines/resources-estimator) to learn more.
+
                     #### Required parameters
 
                     - Q# operation or function name. This must be the first parameter, and must be a valid Q# operation
@@ -47,6 +49,22 @@ namespace Microsoft.Quantum.IQSharp.Kernel
                 ".Dedent(),
                 Examples = new []
                 {
+                    @"
+                        Estimate resources for a Q# operation defined as `operation MyOperation() : Result`:
+                        ```
+                        In []: %estimate MyOperation
+                        Out[]: Metric           Sum     
+                               ---------------- ----
+                               CNOT             0
+                               QubitClifford    4
+                               R                0
+                               Measure          8
+                               T                0
+                               Depth            0
+                               Width            4
+                               BorrowedWidth    0
+                        ```
+                    ".Dedent(),
                     @"
                         Estimate resources for a Q# operation defined as `operation MyOperation(a : Int, b : Int) : Result`:
                         ```

--- a/src/Kernel/Magic/EstimateMagic.cs
+++ b/src/Kernel/Magic/EstimateMagic.cs
@@ -28,11 +28,13 @@ namespace Microsoft.Quantum.IQSharp.Kernel
         /// </summary>
         public EstimateMagic(ISymbolResolver resolver) : base(
             "estimate",
-            new Documentation {
+            new Documentation
+            {
                 Summary = "Runs a given function or operation on the ResourcesEstimator target machine.",
                 Description = @"
                     The ResourcesEstimator estimates statistics about how many resources the given
                     operation needs for execution. The resources it calculates include:
+
                     - Counts for each primitive operation
                     - Depth (lower bound for the T-gate depth of the quantum circuit)
                     - Width (lower bound for the maximum number of qubits used for the computation)

--- a/src/Kernel/Magic/LsMagicMagic.cs
+++ b/src/Kernel/Magic/LsMagicMagic.cs
@@ -33,7 +33,8 @@ namespace Microsoft.Quantum.IQSharp.Kernel
         /// </summary>
         public LsMagicMagic(IMagicSymbolResolver resolver, IExecutionEngine engine) : base(
             "lsmagic",
-            new Documentation {
+            new Documentation
+            {
                 Summary = "Returns a list of all currently available magic commands.",
                 Description = @"
                     This magic command lists all of the magic commands available in the IQ# kernel,

--- a/src/Kernel/Magic/LsMagicMagic.cs
+++ b/src/Kernel/Magic/LsMagicMagic.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Quantum.IQSharp.Kernel
                 Description = @"
                     This magic command lists all of the magic commands available in the IQ# kernel,
                     as well as those defined in any packages that have been loaded in the current
-                    session via the `%package` magic command.
+                    session via the [`%package` magic command](https://docs.microsoft.com/qsharp/api/iqsharp-magic/package).
                 ".Dedent(),
                 Examples = new []
                 {

--- a/src/Kernel/Magic/LsMagicMagic.cs
+++ b/src/Kernel/Magic/LsMagicMagic.cs
@@ -33,9 +33,23 @@ namespace Microsoft.Quantum.IQSharp.Kernel
         /// </summary>
         public LsMagicMagic(IMagicSymbolResolver resolver, IExecutionEngine engine) : base(
             "lsmagic",
-            new Documentation
-            {
-                Summary = "Returns a list of all currently available magic commands."
+            new Documentation {
+                Summary = "Returns a list of all currently available magic commands.",
+                Description = @"
+                    This magic command lists all of the magic commands available in the IQ# kernel,
+                    as well as those defined in any packages that have been loaded in the current
+                    session via the `%package` magic command.
+                ".Dedent(),
+                Examples = new []
+                {
+                    @"
+                        Display the list of available magic commands:
+                        ```
+                        In []: %lsmagic
+                        Out[]: <detailed list of all available magic commands>
+                        ```
+                    ".Dedent(),
+                }
             })
         {
             this.resolver = resolver;

--- a/src/Kernel/Magic/PackageMagic.cs
+++ b/src/Kernel/Magic/PackageMagic.cs
@@ -26,7 +26,48 @@ namespace Microsoft.Quantum.IQSharp.Kernel
         public PackageMagic(IReferences references) : base(
             "package",
             new Documentation {
-                Summary = "Provides the ability to load a Nuget package. The package must be available on the list of nuget sources, typically this includes nuget.org"
+                Summary = "Provides the ability to load a NuGet package.",
+                Description = @"
+                    This magic command allows for loading a NuGet package into the current IQ# kernel process.
+                    The package must be available on the system's list of NuGet sources, which typically includes nuget.org.
+                    Functionality such as magic commands and result encoders defined in the loaded package will
+                    automatically become available for use in the current session.
+
+                    The package can be specified by name only, or by name and version (using `name::version` syntax).
+
+                    If no version is specified:
+                    - For packages that are part of the Microsoft Quantum Development Kit, IQ# will attempt to
+                    obtain the version of the package that matches the current IQ# version.
+                    - For other packages, IQ# will attempt to obtain the most recent version of the package.
+                ".Dedent(),
+                Examples = new []
+                {
+                    @"
+                        Load the `Microsoft.Quantum.MachineLearning` package into the current IQ# session:
+                        ```
+                        In []: %package Microsoft.Quantum.MachineLearning
+                        Out[]: Adding package Microsoft.Quantum.MachineLearning: done!
+                               <list of all loaded packages and versions>
+                        ```
+                    ".Dedent(),
+                    
+                    @"
+                        Load a specific version of the `Microsoft.Quantum.Katas` package into the current IQ# session:
+                        ```
+                        In []: %package Microsoft.Quantum.Katas::0.11.2006.403
+                        Out[]: Adding package Microsoft.Quantum.Katas::0.11.2006.403: done!
+                               <list of all loaded packages and versions>
+                        ```
+                    ".Dedent(),
+                    
+                    @"
+                        View the list of all packages that have been loaded into the current IQ# session:
+                        ```
+                        In []: %package
+                        Out[]: <list of all loaded packages and versions>
+                        ```
+                    ".Dedent(),
+                }
             })
         {
             this.References = references;

--- a/src/Kernel/Magic/PackageMagic.cs
+++ b/src/Kernel/Magic/PackageMagic.cs
@@ -36,6 +36,7 @@ namespace Microsoft.Quantum.IQSharp.Kernel
                     The package can be specified by name only, or by name and version (using `name::version` syntax).
 
                     If no version is specified:
+
                     - For packages that are part of the Microsoft Quantum Development Kit, IQ# will attempt to
                     obtain the version of the package that matches the current IQ# version.
                     - For other packages, IQ# will attempt to obtain the most recent version of the package.

--- a/src/Kernel/Magic/PackageMagic.cs
+++ b/src/Kernel/Magic/PackageMagic.cs
@@ -25,13 +25,15 @@ namespace Microsoft.Quantum.IQSharp.Kernel
         /// </summary>
         public PackageMagic(IReferences references) : base(
             "package",
-            new Documentation {
+            new Documentation
+            {
                 Summary = "Provides the ability to load a NuGet package.",
                 Description = @"
                     This magic command allows for loading a NuGet package into the current IQ# kernel process.
                     The package must be available on the system's list of NuGet sources, which typically includes nuget.org.
-                    Functionality such as magic commands and result encoders defined in the loaded package will
-                    automatically become available for use in the current session.
+                    Q# operations, functions, and user-defined types defined in the loaded package,
+                    along with functionality such as magic commands and result encoders,
+                    will automatically become available for use in the current session.
 
                     The package can be specified by name only, or by name and version (using `name::version` syntax).
 

--- a/src/Kernel/Magic/PerformanceMagic.cs
+++ b/src/Kernel/Magic/PerformanceMagic.cs
@@ -30,6 +30,7 @@ namespace Microsoft.Quantum.IQSharp.Kernel
                 Summary = "Reports current performance metrics for this kernel.",
                 Description = @"
                     Reports various performance metrics for the current IQ# kernel process, including:
+
                     - Managed RAM usage
                     - Total RAM usage
                     - Virtual memory size

--- a/src/Kernel/Magic/PerformanceMagic.cs
+++ b/src/Kernel/Magic/PerformanceMagic.cs
@@ -27,7 +27,31 @@ namespace Microsoft.Quantum.IQSharp.Kernel
         public PerformanceMagic() : base(
             "performance",
             new Documentation {
-                Summary = "Reports current performance metrics for this kernel."
+                Summary = "Reports current performance metrics for this kernel.",
+                Description = @"
+                    Reports various performance metrics for the current IQ# kernel process, including:
+                    - Managed RAM usage
+                    - Total RAM usage
+                    - Virtual memory size
+                    - User time
+                    - Total time
+                ".Dedent(),
+                Examples = new []
+                {
+                    @"
+                        Display performance metrics for the current IQ# kernel process:
+                        ```
+                        In []: %performance
+                        Out[]: Metric                        Value
+                               ----------------------------  -------------
+                               Managed RAM usage (bytes)     4.985 MiB
+                               Total RAM usage (bytes)       54.543 MiB
+                               Virtual memory size (bytes)   2.005 TiB
+                               User time                     00:00:01.109
+                               Total time                    00:00:01.437
+                        ```
+                    ".Dedent(),
+                }
             })
         {
         }

--- a/src/Kernel/Magic/Simulate.cs
+++ b/src/Kernel/Magic/Simulate.cs
@@ -27,12 +27,15 @@ namespace Microsoft.Quantum.IQSharp.Kernel
         /// </summary>
         public SimulateMagic(ISymbolResolver resolver, IConfigurationSource configurationSource) : base(
             "simulate",
-            new Documentation {
+            new Documentation
+            {
                 Summary = "Runs a given function or operation on the QuantumSimulator target machine.",
                 Description = @"
                     This magic command allows executing a given function or operation on the QuantumSimulator, 
                     which performs a full-state simulation of the given function or operation
                     and prints the resulting return value.
+
+                    See the [QuantumSimulator user guide](https://docs.microsoft.com/quantum/user-guide/machines/full-state-simulator) to learn more.
 
                     #### Required parameters
 
@@ -42,6 +45,13 @@ namespace Microsoft.Quantum.IQSharp.Kernel
                 ".Dedent(),
                 Examples = new []
                 {
+                    @"
+                        Simulate a Q# operation defined as `operation MyOperation() : Result`:
+                        ```
+                        In []: %simulate MyOperation
+                        Out[]: <return value of the operation>
+                        ```
+                    ".Dedent(),
                     @"
                         Simulate a Q# operation defined as `operation MyOperation(a : Int, b : Int) : Result`:
                         ```

--- a/src/Kernel/Magic/Simulate.cs
+++ b/src/Kernel/Magic/Simulate.cs
@@ -28,7 +28,28 @@ namespace Microsoft.Quantum.IQSharp.Kernel
         public SimulateMagic(ISymbolResolver resolver, IConfigurationSource configurationSource) : base(
             "simulate",
             new Documentation {
-                Summary = "Runs a given function or operation on the QuantumSimulator target machine"
+                Summary = "Runs a given function or operation on the QuantumSimulator target machine.",
+                Description = @"
+                    This magic command allows executing a given function or operation on the QuantumSimulator, 
+                    which performs a full-state simulation of the given function or operation
+                    and prints the resulting return value.
+
+                    #### Required parameters
+
+                    - Q# operation or function name. This must be the first parameter, and must be a valid Q# operation
+                    or function name that has been defined either in the notebook or in a Q# file in the same folder.
+                    - Arguments for the Q# operation or function must also be specified as `key=value` pairs.
+                ".Dedent(),
+                Examples = new []
+                {
+                    @"
+                        Simulate a Q# operation defined as `operation MyOperation(a : Int, b : Int) : Result`:
+                        ```
+                        In []: %simulate MyOperation a=5 b=10
+                        Out[]: <return value of the operation>
+                        ```
+                    ".Dedent(),
+                }
             })
         {
             this.SymbolResolver = resolver;

--- a/src/Kernel/Magic/ToffoliMagic.cs
+++ b/src/Kernel/Magic/ToffoliMagic.cs
@@ -23,12 +23,15 @@ namespace Microsoft.Quantum.IQSharp.Kernel
         /// </summary>
         public ToffoliMagic(ISymbolResolver resolver) : base(
             "toffoli",
-            new Documentation {
+            new Documentation
+            {
                 Summary = "Runs a given function or operation on the ToffoliSimulator target machine.",
                 Description = @"
                     This magic command allows executing a given function or operation on the ToffoliSimulator, 
                     which performs a simulation of the given function or operation in which the state is always
                     a simple product state in the computational basis, and prints the resulting return value.
+
+                    See the [ToffoliSimulator user guide](https://docs.microsoft.com/quantum/user-guide/machines/toffoli-simulator) to learn more.
 
                     #### Required parameters
 
@@ -38,6 +41,14 @@ namespace Microsoft.Quantum.IQSharp.Kernel
                 ".Dedent(),
                 Examples = new []
                 {
+                    @"
+                        Use the ToffoliSimulator to simulate a Q# operation
+                        defined as `operation MyOperation() : Result`:
+                        ```
+                        In []: %toffoli MyOperation
+                        Out[]: <return value of the operation>
+                        ```
+                    ".Dedent(),
                     @"
                         Use the ToffoliSimulator to simulate a Q# operation
                         defined as `operation MyOperation(a : Int, b : Int) : Result`:

--- a/src/Kernel/Magic/ToffoliMagic.cs
+++ b/src/Kernel/Magic/ToffoliMagic.cs
@@ -24,7 +24,29 @@ namespace Microsoft.Quantum.IQSharp.Kernel
         public ToffoliMagic(ISymbolResolver resolver) : base(
             "toffoli",
             new Documentation {
-                Summary = "Runs a given function or operation on the ToffoliSimulator simulator target machine"
+                Summary = "Runs a given function or operation on the ToffoliSimulator target machine.",
+                Description = @"
+                    This magic command allows executing a given function or operation on the ToffoliSimulator, 
+                    which performs a simulation of the given function or operation in which the state is always
+                    a simple product state in the computational basis, and prints the resulting return value.
+
+                    #### Required parameters
+
+                    - Q# operation or function name. This must be the first parameter, and must be a valid Q# operation
+                    or function name that has been defined either in the notebook or in a Q# file in the same folder.
+                    - Arguments for the Q# operation or function must also be specified as `key=value` pairs.
+                ".Dedent(),
+                Examples = new []
+                {
+                    @"
+                        Use the ToffoliSimulator to simulate a Q# operation
+                        defined as `operation MyOperation(a : Int, b : Int) : Result`:
+                        ```
+                        In []: %toffoli MyOperation a=5 b=10
+                        Out[]: <return value of the operation>
+                        ```
+                    ".Dedent(),
+                }
             })
         {
             this.SymbolResolver = resolver;

--- a/src/Kernel/Magic/WhoMagic.cs
+++ b/src/Kernel/Magic/WhoMagic.cs
@@ -23,7 +23,26 @@ namespace Microsoft.Quantum.IQSharp.Kernel
             "who",
             new Documentation
             {
-                Summary = "Provides actions related to the current workspace."
+                Summary = "Lists the Q# operations available in the current session.",
+                Description = @"
+                    This magic command returns a list of Q# operations and functions that are available
+                    in the current IQ# session for use with magic commands such as `%simulate`
+                    and `%estimate`.
+
+                    The list will include Q# operations and functions which have been defined interactively
+                    within cells in the current notebook (after the cells have been executed),
+                    as well as any Q# operations and functions defined within .qs files in the current folder.
+                ".Dedent(),
+                Examples = new []
+                {
+                    @"
+                        Display the list of Q# operations and functions available in the current session:
+                        ```
+                        In []: %who
+                        Out[]: <list of Q# operation and function names>
+                        ```
+                    ".Dedent(),
+                }
             })
         {
             this.Snippets = snippets;

--- a/src/Kernel/Magic/WorkspaceMagic.cs
+++ b/src/Kernel/Magic/WorkspaceMagic.cs
@@ -23,7 +23,40 @@ namespace Microsoft.Quantum.IQSharp.Kernel
         public WorkspaceMagic(IWorkspace workspace) : base(
             "workspace", 
             new Documentation {
-                Summary = "Returns a list of all operations and functions defined in the current session, either interactively or loaded from the current workspace."
+                Summary = "Provides actions related to the current workspace.",
+                Description = @"
+                    This magic command allows for displaying and reloading the Q# operations and functions
+                    defined within .qs files in the current folder.
+
+                    If no parameters are provided, the command displays a list of Q# operations or functions
+                    within .qs files in the current folder which are available
+                    in the current IQ# session for use with magic commands such as `%simulate`
+                    and `%estimate`.
+
+                    The command will also output any errors encountered while compiling the .qs files
+                    in the current folder.
+                    
+                    #### Optional parameters
+
+                    - `reload`: Causes the IQ# kernel to recompile all .qs files in the current folder.
+                ".Dedent(),
+                Examples = new []
+                {
+                    @"
+                        Display the list of Q# operations and functions available in the current folder:
+                        ```
+                        In []: %workspace
+                        Out[]: <list of Q# operation and function names>
+                        ```
+                    ".Dedent(),
+                    @"
+                        Recompile the .qs files in the current folder:
+                        ```
+                        In []: %workspace reload
+                        Out[]: <list of Q# operation and function names>
+                        ```
+                    ".Dedent(),
+                }
             })
         {
             this.Workspace = workspace;

--- a/src/Kernel/Magic/WorkspaceMagic.cs
+++ b/src/Kernel/Magic/WorkspaceMagic.cs
@@ -22,7 +22,8 @@ namespace Microsoft.Quantum.IQSharp.Kernel
         /// </summary>
         public WorkspaceMagic(IWorkspace workspace) : base(
             "workspace", 
-            new Documentation {
+            new Documentation
+            {
                 Summary = "Provides actions related to the current workspace.",
                 Description = @"
                     This magic command allows for displaying and reloading the Q# operations and functions

--- a/src/Python/qsharp/azure.py
+++ b/src/Python/qsharp/azure.py
@@ -101,36 +101,64 @@ class AzureError(Exception):
 ## FUNCTIONS ##
 
 def connect(**params) -> List[AzureTarget]:
+    """
+    Connects to an Azure Quantum workspace or displays current connection status.
+    See https://docs.microsoft.com/qsharp/api/iqsharp-magic/azure.connect for more details.
+    """
     result = qsharp.client._execute_magic(f"azure.connect", raise_on_stderr=False, **params)
     if "error_code" in result: raise AzureError(result)
     return [AzureTarget(target) for target in result]
 
 def target(name : str = '', **params) -> AzureTarget:
+    """
+    Sets or displays the active execution target for Q# job submission in an Azure Quantum workspace.
+    See https://docs.microsoft.com/qsharp/api/iqsharp-magic/azure.target for more details.
+    """
     result = qsharp.client._execute_magic(f"azure.target {name}", raise_on_stderr=False, **params)
     if "error_code" in result: raise AzureError(result)
     return AzureTarget(result)
 
-def submit(op, **params) -> AzureJob:
+def submit(op : qsharp.QSharpCallable, **params) -> AzureJob:
+    """
+    Submits a job to an Azure Quantum workspace.
+    See https://docs.microsoft.com/qsharp/api/iqsharp-magic/azure.submit for more details.
+    """
     result = qsharp.client._execute_callable_magic("azure.submit", op, raise_on_stderr=False, **params)
     if "error_code" in result: raise AzureError(result)
     return AzureJob(result)
 
-def execute(op, **params) -> Dict:
+def execute(op : qsharp.QSharpCallable, **params) -> Dict:
+    """
+    Executes a job in an Azure Quantum workspace.
+    See https://docs.microsoft.com/qsharp/api/iqsharp-magic/azure.execute for more details.
+    """
     result = qsharp.client._execute_callable_magic("azure.execute", op, raise_on_stderr=False, **params)
     if "error_code" in result: raise AzureError(result)
     return result
 
 def status(jobId : str = '', **params) -> AzureJob:
+    """
+    Displays status for a job in the current Azure Quantum workspace.
+    See https://docs.microsoft.com/qsharp/api/iqsharp-magic/azure.status for more details.
+    """
     result = qsharp.client._execute_magic(f"azure.status {jobId}", raise_on_stderr=False, **params)
     if "error_code" in result: raise AzureError(result)
     return AzureJob(result)
 
 def output(jobId : str = '', **params) -> Dict:
+    """
+    Displays results for a job in the current Azure Quantum workspace.
+    See https://docs.microsoft.com/qsharp/api/iqsharp-magic/azure.output for more details.
+    """
     result = qsharp.client._execute_magic(f"azure.output {jobId}", raise_on_stderr=False, **params)
     if "error_code" in result: raise AzureError(result)
     return result
 
 def jobs(filter : str = '', **params) -> List[AzureJob]:
+    """
+    Displays a list of jobs in the current Azure Quantum workspace.
+    See https://docs.microsoft.com/qsharp/api/iqsharp-magic/azure.jobs for more details.
+    """
     result = qsharp.client._execute_magic(f"azure.jobs \"{filter}\"", raise_on_stderr=False, **params)
     if "error_code" in result: raise AzureError(result)
     return [AzureJob(job) for job in result]


### PR DESCRIPTION
This PR adds more detailed information to the `Documentation` property of each of the IQ# magic commands, including magic commands in the `Kernel` project and in the `AzureClient` project.

This includes documentation for `%config` parameters, which helps to address #126.

An illustration of what the documentation looks like within Jupyter Notebook:

![image](https://user-images.githubusercontent.com/3620100/85635191-22ff5400-b632-11ea-941e-ef3c36a0f9c2.png)
