### PR TITLE
Adding MSAL token cache parameters for Mac and Linux

### DIFF
--- a/images/iqsharp-base/Dockerfile
+++ b/images/iqsharp-base/Dockerfile
@@ -109,7 +109,7 @@ ENV PATH=$PATH:${HOME}/dotnet:${HOME}/.dotnet/tools \
 # Install IQ# and the project templates, using the NuGet packages from the
 # build context.
 ARG IQSHARP_VERSION
-RUN dotnet new -i "Microsoft.Quantum.ProjectTemplates::0.11.2006.2203-beta" && \
+RUN dotnet new -i "Microsoft.Quantum.ProjectTemplates::0.12.20062518-beta" && \
     dotnet tool install \
            --global \
            Microsoft.Quantum.IQSharp \

--- a/src/AzureClient/AzureClient.csproj
+++ b/src/AzureClient/AzureClient.csproj
@@ -13,7 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Quantum.Client" Version="0.11.2006.1615-beta" />
+    <PackageReference Include="Microsoft.Azure.Quantum.Client" Version="0.12.20062518-beta" />
     <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.21" />
     <PackageReference Include="Microsoft.Rest.ClientRuntime.Azure" Version="3.3.19" />
     <PackageReference Include="System.Reactive" Version="4.3.2" />

--- a/src/AzureClient/AzureEnvironment.cs
+++ b/src/AzureClient/AzureEnvironment.cs
@@ -75,7 +75,17 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
 
             // Register the token cache for serialization
             var cacheFileName = "iqsharp.bin";
-            var storageCreationProperties = new StorageCreationPropertiesBuilder(cacheFileName, cacheDirectory, ClientId).Build();
+            var storageCreationProperties = new StorageCreationPropertiesBuilder(cacheFileName, cacheDirectory, ClientId)
+                .WithMacKeyChain(
+                    serviceName: "Microsoft.Quantum.IQSharp",
+                    accountName: "MSALCache")
+                .WithLinuxKeyring(
+                    schemaName: "com.microsoft.quantum.iqsharp",
+                    collection: "default",
+                    secretLabel: "Credentials used by Microsoft IQ# kernel",
+                    attribute1: new KeyValuePair<string, string>("Version", typeof(AzureClient).Assembly.GetName().Version.ToString()),
+                    attribute2: new KeyValuePair<string, string>("ProductGroup", "QDK"))
+                .Build();
             var cacheHelper = await MsalCacheHelper.CreateAsync(storageCreationProperties);
             var msalApp = PublicClientApplicationBuilder.Create(ClientId).WithAuthority(Authority).Build();
             cacheHelper.RegisterCache(msalApp.UserTokenCache);

--- a/src/Core/Core.csproj
+++ b/src/Core/Core.csproj
@@ -34,9 +34,9 @@
     <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="3.0.0" />
-    <PackageReference Include="Microsoft.Quantum.Compiler" Version="0.11.2006.2203-beta" />
-    <PackageReference Include="Microsoft.Quantum.CsharpGeneration" Version="0.11.2006.2203-beta" />
-    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.11.2006.2203-beta" />
+    <PackageReference Include="Microsoft.Quantum.Compiler" Version="0.12.20062518-beta" />
+    <PackageReference Include="Microsoft.Quantum.CsharpGeneration" Version="0.12.20062518-beta" />
+    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.12.20062518-beta" />
     <PackageReference Include="NuGet.Resolver" Version="5.1.0" />
     <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
   </ItemGroup>

--- a/src/Tool/appsettings.json
+++ b/src/Tool/appsettings.json
@@ -6,25 +6,25 @@
     },
     "AllowedHosts": "*",
   "DefaultPackageVersions": [
-    "Microsoft.Quantum.Compiler::0.11.2006.2203-beta",
+    "Microsoft.Quantum.Compiler::0.12.20062518-beta",
 
-    "Microsoft.Quantum.CsharpGeneration::0.11.2006.2203-beta",
-    "Microsoft.Quantum.Development.Kit::0.11.2006.2203-beta",
-    "Microsoft.Quantum.Simulators::0.11.2006.2203-beta",
-    "Microsoft.Quantum.Xunit::0.11.2006.2203-beta",
+    "Microsoft.Quantum.CsharpGeneration::0.12.20062518-beta",
+    "Microsoft.Quantum.Development.Kit::0.12.20062518-beta",
+    "Microsoft.Quantum.Simulators::0.12.20062518-beta",
+    "Microsoft.Quantum.Xunit::0.12.20062518-beta",
 
-    "Microsoft.Quantum.Standard::0.11.2006.2203-beta",
-    "Microsoft.Quantum.Chemistry::0.11.2006.2203-beta",
-    "Microsoft.Quantum.Chemistry.Jupyter::0.11.2006.2203-beta",
-    "Microsoft.Quantum.MachineLearning::0.11.2006.2203-beta",
-    "Microsoft.Quantum.Numerics::0.11.2006.2203-beta",
+    "Microsoft.Quantum.Standard::0.12.20062518-beta",
+    "Microsoft.Quantum.Chemistry::0.12.20062518-beta",
+    "Microsoft.Quantum.Chemistry.Jupyter::0.12.20062518-beta",
+    "Microsoft.Quantum.MachineLearning::0.12.20062518-beta",
+    "Microsoft.Quantum.Numerics::0.12.20062518-beta",
 
-    "Microsoft.Quantum.Katas::0.11.2006.2203-beta",
+    "Microsoft.Quantum.Katas::0.12.20062518-beta",
 
-    "Microsoft.Quantum.Research::0.11.2006.2203-beta",
+    "Microsoft.Quantum.Research::0.12.20062518-beta",
 
-    "Microsoft.Quantum.Providers.IonQ::0.11.2006.2203-beta",
-    "Microsoft.Quantum.Providers.Honeywell::0.11.2006.2203-beta",
-    "Microsoft.Quantum.Providers.QCI::0.11.2006.2203-beta"
+    "Microsoft.Quantum.Providers.IonQ::0.12.20062518-beta",
+    "Microsoft.Quantum.Providers.Honeywell::0.12.20062518-beta",
+    "Microsoft.Quantum.Providers.QCI::0.12.20062518-beta"
   ]
 }


### PR DESCRIPTION
The `%azure.connect` command currently works only on Windows because the usage of `StorageCreationPropertiesBuilder` is incomplete. See #184 for details.

Manual verification and Azure Quantum job submission performed:
- [x] on Windows
- [x] on Mac OS X (used 10.15.5)
- [x] on Linux

Fixes #184.