### PR TITLE
Automatically retrieve embedded resources defined in Kernel.csproj

### DIFF
--- a/src/Kernel/Kernel.csproj
+++ b/src/Kernel/Kernel.csproj
@@ -28,7 +28,7 @@
   <!-- TypeScript compilation -->
   <ItemGroup>
     <EmbeddedResource Include="res\kernel.js" />
-    <EmbeddedResource Include="res\telemetry.js" />
+    <EmbeddedResource Include="res\compiled.js" />
     <Content Include="tsconfig.json">
       <CopyToOutputDirectory>Never</CopyToOutputDirectory>
     </Content>

--- a/src/Kernel/Kernel.csproj
+++ b/src/Kernel/Kernel.csproj
@@ -28,7 +28,7 @@
   <!-- TypeScript compilation -->
   <ItemGroup>
     <EmbeddedResource Include="res\kernel.js" />
-    <EmbeddedResource Include="res\compiled.js" />
+    <EmbeddedResource Include="res\bundle.js" />
     <Content Include="tsconfig.json">
       <CopyToOutputDirectory>Never</CopyToOutputDirectory>
     </Content>

--- a/src/Kernel/res/.gitignore
+++ b/src/Kernel/res/.gitignore
@@ -1,2 +1,2 @@
 # Ignore generated files.
-compiled.js
+bundle.js

--- a/src/Kernel/res/.gitignore
+++ b/src/Kernel/res/.gitignore
@@ -1,3 +1,2 @@
 # Ignore generated files.
-kernel.js
-telemetry.js
+compiled.js

--- a/src/Kernel/res/kernel.js
+++ b/src/Kernel/res/kernel.js
@@ -1,0 +1,9 @@
+requirejs.config({
+    bundles: {
+        '../kernelspecs/iqsharp/compiled.js': ['kernel'],
+    }
+});
+
+define(["exports", "kernel"], function (exports, kernel) {
+    Object.defineProperty(exports, "onload", { enumerable: true, get: function () { return kernel.onload; } });
+});

--- a/src/Kernel/res/kernel.js
+++ b/src/Kernel/res/kernel.js
@@ -1,6 +1,6 @@
 requirejs.config({
     bundles: {
-        '../kernelspecs/iqsharp/compiled.js': ['kernel'],
+        '../kernelspecs/iqsharp/bundle.js': ['kernel'],
     }
 });
 

--- a/src/Kernel/tsconfig.json
+++ b/src/Kernel/tsconfig.json
@@ -2,11 +2,12 @@
   "compilerOptions": {
     "noImplicitAny": false,
     "noEmitOnError": true,
-    "removeComments": false,
+    "removeComments": true,
     "sourceMap": false,
     "target": "ES5",
     "baseUrl": ".",
     "outDir": "res",
+    "outFile": "res/compiled.js",
     "lib": [ "DOM", "ES2015" ],
     "module": "AMD"
   },

--- a/src/Kernel/tsconfig.json
+++ b/src/Kernel/tsconfig.json
@@ -7,7 +7,7 @@
     "target": "ES5",
     "baseUrl": ".",
     "outDir": "res",
-    "outFile": "res/compiled.js",
+    "outFile": "res/bundle.js",
     "lib": [ "DOM", "ES2015" ],
     "module": "AMD"
   },

--- a/src/Tool/Program.cs
+++ b/src/Tool/Program.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Quantum.IQSharp
 
         /// <summary>
         /// Creates dictionary of kernelspec file names to the embedded resource path
-        /// of all embedded resources found in `Kernel.csproj`.
+        /// of all embedded resources found in <c>Kernel.csproj</c>.
         /// Note: `WithKernelSpecResources` cannot handle keys that include directories
         /// so we treat all path names as period-separated file names.
         /// </summary>

--- a/src/Tool/Program.cs
+++ b/src/Tool/Program.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Quantum.IQSharp
         /// <summary>
         /// Creates dictionary of kernelspec file names to the embedded resource path
         /// of all embedded resources found in <c>Kernel.csproj</c>.
-        /// Note: `WithKernelSpecResources` cannot handle keys that include directories
+        /// Note: <c>WithKernelSpecResources</c> cannot handle keys that include directories
         /// so we treat all path names as period-separated file names.
         /// </summary>
         private static Dictionary<string, string> GetEmbeddedKernelResources() =>

--- a/src/Tool/Program.cs
+++ b/src/Tool/Program.cs
@@ -36,27 +36,18 @@ namespace Microsoft.Quantum.IQSharp
             => true;
 #endif
 
-        // Creates dictionary of kernelspec file names to the embedded resource path
-        // of all embedded resources found in `Kernel.csproj`.
-        public static Dictionary<string, string> GetEmbeddedKernelResources()
-        {
-            var res = new Dictionary<string, string>();
-            foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
-            {
-                if (String.Equals(assembly.GetName().Name, "Microsoft.Quantum.IQSharp.Kernel"))
-                {
-                    foreach (var resName in assembly.GetManifestResourceNames())
-                    {
-                        // Compute "filename.extension"
-                        // Note: WithKernelSpecResources cannot handle keys that include directories
-                        // so we only use the filename without directory path.
-                        var fileName = String.Join(".", resName.Split(".").TakeLast(2));
-                        res.Add(fileName, resName);
-                    }
-                }
-            }
-            return res;
-        }
+        /// <summary>
+        /// Creates dictionary of kernelspec file names to the embedded resource path
+        /// of all embedded resources found in `Kernel.csproj`.
+        /// Note: `WithKernelSpecResources` cannot handle keys that include directories
+        /// so we treat all path names as period-separated file names.
+        /// </summary>
+        private static Dictionary<string, string> GetEmbeddedKernelResources() =>
+            AppDomain.CurrentDomain.GetAssemblies()
+                .Single(asm => asm.GetName().Name == "Microsoft.Quantum.IQSharp.Kernel")
+                .GetManifestResourceNames()
+                // Take file name as substring after "Microsoft.Quantum.IQSharp.Kernel.res"
+                .ToDictionary(resName => string.Join(".", resName.Split(".").Skip(5)));
 
         public static int Main(string[] args)
         {


### PR DESCRIPTION
Currently, each new `EmbeddedResource` we add in `Kernel.csproj` has to be manually added in as a KV-pair in the dictionary provided to `.WithKernelSpecResources` in `Program.cs`.

This PR automates this process by finding all `EmbeddedResources` within `Kernel.csproj` and creates a dictionary of all resources.

Note: `WithKernelSpecResources` cannot handle nested directory file names (possibly because it cannot write to a non-existing directory [[link](https://github.com/microsoft/jupyter-core/blob/e144ee6bfa88b17a8be2b368626511701a56bfe6/src/KernelApplication.cs#L467)]). So, we add the embedded resource with its period-separated path (i.e. `folder/file.js` -> `folder.file.js`) as a key to the dictionary.

TypeScript files are also compiled into one out file (`res/compiled.js`) for improved browser caching and avoiding the above pitfall with nested directories.