### PR TITLE
Implied resourceId parameter for %azure.connect

### DIFF
--- a/src/AzureClient/Magic/ConnectMagic.cs
+++ b/src/AzureClient/Magic/ConnectMagic.cs
@@ -52,7 +52,8 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
                         The Azure Quantum workspace can be identified by resource ID:
 
                         - `{ParameterNameResourceId}=<string>`: The resource ID of the Azure Quantum workspace.
-                        This can be obtained from the workspace page in the Azure portal.
+                        This can be obtained from the workspace page in the Azure portal. The `{ParameterNameResourceId}=` prefix
+                        is optional for this parameter, as long as the resource ID is valid.
 
                         Alternatively, it can be identified by subscription ID, resource group name, and workspace name:
                         
@@ -77,7 +78,7 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
                         $@"
                             Connect to an Azure Quantum workspace using its resource ID:
                             ```
-                            In []: %azure.connect {ParameterNameResourceId}=""/subscriptions/.../Microsoft.Quantum/Workspaces/WORKSPACE_NAME""
+                            In []: %azure.connect ""/subscriptions/.../Microsoft.Quantum/Workspaces/WORKSPACE_NAME""
                             Out[]: Connected to Azure Quantum workspace WORKSPACE_NAME.
                                     <list of Q# execution targets available in the Azure Quantum workspace>
                             ```
@@ -109,7 +110,7 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
                             Connect to an Azure Quantum workspace and force a credential prompt using
                             the `{ParameterNameRefresh}` option:
                             ```
-                            In []: %azure.connect {ParameterNameRefresh} {ParameterNameResourceId}=""/subscriptions/.../Microsoft.Quantum/Workspaces/WORKSPACE_NAME""
+                            In []: %azure.connect {ParameterNameRefresh} ""/subscriptions/.../Microsoft.Quantum/Workspaces/WORKSPACE_NAME""
                             Out[]: To sign in, use a web browser to open the page https://microsoft.com/devicelogin
                                     and enter the code [login code] to authenticate.
                                     Connected to Azure Quantum workspace WORKSPACE_NAME.

--- a/src/AzureClient/Magic/ConnectMagic.cs
+++ b/src/AzureClient/Magic/ConnectMagic.cs
@@ -147,9 +147,15 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
 
             // A valid resource ID looks like:
             // /subscriptions/f846b2bd-d0e2-4a1d-8141-4c6944a9d387/resourceGroups/RESOURCE_GROUP_NAME/providers/Microsoft.Quantum/Workspaces/WORKSPACE_NAME
-            var match = Regex.Match(resourceId,
+            var resourceIdRegex = new Regex(
                 @"^/subscriptions/([a-fA-F0-9-]*)/resourceGroups/([^\s/]*)/providers/Microsoft\.Quantum/Workspaces/([^\s/]*)$",
                 RegexOptions.IgnoreCase);
+            if (string.IsNullOrEmpty(resourceId))
+            {
+                resourceId = inputParameters.Keys.FirstOrDefault(key => resourceIdRegex.IsMatch(key)) ?? string.Empty;
+            }
+
+            var match = resourceIdRegex.Match(resourceId);
             if (match.Success)
             {
                 // match.Groups will be a GroupCollection containing four Group objects:

--- a/src/AzureClient/Magic/ConnectMagic.cs
+++ b/src/AzureClient/Magic/ConnectMagic.cs
@@ -25,6 +25,12 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
         private const string ParameterNameResourceGroupName = "resourceGroup";
         private const string ParameterNameWorkspaceName = "workspace";
         private const string ParameterNameResourceId = "resourceId";
+        
+        // A valid resource ID looks like:
+        // /subscriptions/f846b2bd-d0e2-4a1d-8141-4c6944a9d387/resourceGroups/RESOURCE_GROUP_NAME/providers/Microsoft.Quantum/Workspaces/WORKSPACE_NAME
+        private readonly static Regex ResourceIdRegex = new Regex(
+            @"^/subscriptions/([a-fA-F0-9-]*)/resourceGroups/([^\s/]*)/providers/Microsoft\.Quantum/Workspaces/([^\s/]*)$",
+            RegexOptions.IgnoreCase);
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ConnectMagic"/> class.
@@ -146,17 +152,12 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
             var resourceGroupName = string.Empty;
             var workspaceName = string.Empty;
 
-            // A valid resource ID looks like:
-            // /subscriptions/f846b2bd-d0e2-4a1d-8141-4c6944a9d387/resourceGroups/RESOURCE_GROUP_NAME/providers/Microsoft.Quantum/Workspaces/WORKSPACE_NAME
-            var resourceIdRegex = new Regex(
-                @"^/subscriptions/([a-fA-F0-9-]*)/resourceGroups/([^\s/]*)/providers/Microsoft\.Quantum/Workspaces/([^\s/]*)$",
-                RegexOptions.IgnoreCase);
             if (string.IsNullOrEmpty(resourceId))
             {
-                resourceId = inputParameters.Keys.FirstOrDefault(key => resourceIdRegex.IsMatch(key)) ?? string.Empty;
+                resourceId = inputParameters.Keys.FirstOrDefault(key => ResourceIdRegex.IsMatch(key)) ?? string.Empty;
             }
 
-            var match = resourceIdRegex.Match(resourceId);
+            var match = ResourceIdRegex.Match(resourceId);
             if (match.Success)
             {
                 // match.Groups will be a GroupCollection containing four Group objects:

--- a/src/Tests/AzureClientMagicTests.cs
+++ b/src/Tests/AzureClientMagicTests.cs
@@ -58,8 +58,17 @@ namespace Tests.IQSharp
             Assert.AreEqual(workspaceName, azureClient.WorkspaceName);
             Assert.AreEqual(string.Empty, azureClient.ConnectionString);
 
-            // valid input with implied resource ID key
+            // valid input with implied resource ID key, without surrounding quotes
             connectMagic.Test($"/subscriptions/{subscriptionId}/RESOurceGroups/{resourceGroupName}/providers/Microsoft.Quantum/Workspaces/{workspaceName}");
+            Assert.AreEqual(AzureClientAction.Connect, azureClient.LastAction);
+            Assert.IsFalse(azureClient.RefreshCredentials);
+            Assert.AreEqual(subscriptionId, azureClient.SubscriptionId);
+            Assert.AreEqual(resourceGroupName, azureClient.ResourceGroupName);
+            Assert.AreEqual(workspaceName, azureClient.WorkspaceName);
+            Assert.AreEqual(string.Empty, azureClient.ConnectionString);
+
+            // valid input with implied resource ID key, with surrounding quotes
+            connectMagic.Test($"\"/subscriptions/{subscriptionId}/RESOurceGroups/{resourceGroupName}/providers/Microsoft.Quantum/Workspaces/{workspaceName}\"");
             Assert.AreEqual(AzureClientAction.Connect, azureClient.LastAction);
             Assert.IsFalse(azureClient.RefreshCredentials);
             Assert.AreEqual(subscriptionId, azureClient.SubscriptionId);

--- a/src/Tests/AzureClientMagicTests.cs
+++ b/src/Tests/AzureClientMagicTests.cs
@@ -58,6 +58,15 @@ namespace Tests.IQSharp
             Assert.AreEqual(workspaceName, azureClient.WorkspaceName);
             Assert.AreEqual(string.Empty, azureClient.ConnectionString);
 
+            // valid input with implied resource ID key
+            connectMagic.Test($"/subscriptions/{subscriptionId}/RESOurceGroups/{resourceGroupName}/providers/Microsoft.Quantum/Workspaces/{workspaceName}");
+            Assert.AreEqual(AzureClientAction.Connect, azureClient.LastAction);
+            Assert.IsFalse(azureClient.RefreshCredentials);
+            Assert.AreEqual(subscriptionId, azureClient.SubscriptionId);
+            Assert.AreEqual(resourceGroupName, azureClient.ResourceGroupName);
+            Assert.AreEqual(workspaceName, azureClient.WorkspaceName);
+            Assert.AreEqual(string.Empty, azureClient.ConnectionString);
+
             // valid input with resource ID and storage account connection string
             connectMagic.Test(
                 @$"resourceId=/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Quantum/Workspaces/{workspaceName}
@@ -102,6 +111,14 @@ namespace Tests.IQSharp
                    workspace={workspaceName}
                    storage={storageAccountConnectionString}");
             Assert.IsTrue(azureClient.RefreshCredentials);
+
+            // forced login with implied resource ID before, after, and missing
+            connectMagic.Test($"refresh /subscriptions/{subscriptionId}/RESOurceGroups/{resourceGroupName}/providers/Microsoft.Quantum/Workspaces/{workspaceName}");
+            Assert.IsTrue(azureClient.RefreshCredentials);
+            connectMagic.Test($"/subscriptions/{subscriptionId}/RESOurceGroups/{resourceGroupName}/providers/Microsoft.Quantum/Workspaces/{workspaceName} refresh");
+            Assert.IsTrue(azureClient.RefreshCredentials);
+            connectMagic.Test($"/subscriptions/{subscriptionId}/RESOurceGroups/{resourceGroupName}/providers/Microsoft.Quantum/Workspaces/{workspaceName}");
+            Assert.IsFalse(azureClient.RefreshCredentials);
         }
 
         [TestMethod]


### PR DESCRIPTION
This PR allows `%azure.connect` to recognize a `resourceId` parameter without requiring the key name `resourceId` to be explicitly specified.

For example, a command like this:
```
%azure.connect resourceId=/subscriptions/.../Microsoft.Quantum/Workspaces/WORKSPACE_NAME
```
can now be expressed as just:
```
%azure.connect /subscriptions/.../Microsoft.Quantum/Workspaces/WORKSPACE_NAME
```