### PR TITLE
Update Microsoft.Jupyter.Core version

### DIFF
--- a/images/iqsharp-base/Dockerfile
+++ b/images/iqsharp-base/Dockerfile
@@ -109,7 +109,7 @@ ENV PATH=$PATH:${HOME}/dotnet:${HOME}/.dotnet/tools \
 # Install IQ# and the project templates, using the NuGet packages from the
 # build context.
 ARG IQSHARP_VERSION
-RUN dotnet new -i "Microsoft.Quantum.ProjectTemplates::0.12.20062518-beta" && \
+RUN dotnet new -i "Microsoft.Quantum.ProjectTemplates::0.12.20062906-beta" && \
     dotnet tool install \
            --global \
            Microsoft.Quantum.IQSharp \

--- a/src/AzureClient/AzureClient.csproj
+++ b/src/AzureClient/AzureClient.csproj
@@ -13,7 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Quantum.Client" Version="0.12.20062518-beta" />
+    <PackageReference Include="Microsoft.Azure.Quantum.Client" Version="0.12.20063023-beta" />
     <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.21" />
     <PackageReference Include="Microsoft.Rest.ClientRuntime.Azure" Version="3.3.19" />
     <PackageReference Include="System.Reactive" Version="4.3.2" />

--- a/src/Core/Core.csproj
+++ b/src/Core/Core.csproj
@@ -34,9 +34,9 @@
     <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="3.0.0" />
-    <PackageReference Include="Microsoft.Quantum.Compiler" Version="0.12.20062518-beta" />
-    <PackageReference Include="Microsoft.Quantum.CsharpGeneration" Version="0.12.20062518-beta" />
-    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.12.20062518-beta" />
+    <PackageReference Include="Microsoft.Quantum.Compiler" Version="0.12.20063023-beta" />
+    <PackageReference Include="Microsoft.Quantum.CsharpGeneration" Version="0.12.20063023-beta" />
+    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.12.20063023-beta" />
     <PackageReference Include="NuGet.Resolver" Version="5.1.0" />
     <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
   </ItemGroup>

--- a/src/Jupyter/Jupyter.csproj
+++ b/src/Jupyter/Jupyter.csproj
@@ -35,7 +35,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Jupyter.Core" Version="1.4.76835" />
+    <PackageReference Include="Microsoft.Jupyter.Core" Version="1.4.80531" />
     <PackageReference Include="System.Reactive" Version="4.3.2" />
   </ItemGroup>
 

--- a/src/Tool/appsettings.json
+++ b/src/Tool/appsettings.json
@@ -6,25 +6,25 @@
     },
     "AllowedHosts": "*",
   "DefaultPackageVersions": [
-    "Microsoft.Quantum.Compiler::0.12.20062518-beta",
+    "Microsoft.Quantum.Compiler::0.12.20062906-beta",
 
-    "Microsoft.Quantum.CsharpGeneration::0.12.20062518-beta",
-    "Microsoft.Quantum.Development.Kit::0.12.20062518-beta",
-    "Microsoft.Quantum.Simulators::0.12.20062518-beta",
-    "Microsoft.Quantum.Xunit::0.12.20062518-beta",
+    "Microsoft.Quantum.CsharpGeneration::0.12.20062906-beta",
+    "Microsoft.Quantum.Development.Kit::0.12.20062906-beta",
+    "Microsoft.Quantum.Simulators::0.12.20062906-beta",
+    "Microsoft.Quantum.Xunit::0.12.20062906-beta",
 
-    "Microsoft.Quantum.Standard::0.12.20062518-beta",
-    "Microsoft.Quantum.Chemistry::0.12.20062518-beta",
-    "Microsoft.Quantum.Chemistry.Jupyter::0.12.20062518-beta",
-    "Microsoft.Quantum.MachineLearning::0.12.20062518-beta",
-    "Microsoft.Quantum.Numerics::0.12.20062518-beta",
+    "Microsoft.Quantum.Standard::0.12.20062906-beta",
+    "Microsoft.Quantum.Chemistry::0.12.20062906-beta",
+    "Microsoft.Quantum.Chemistry.Jupyter::0.12.20062906-beta",
+    "Microsoft.Quantum.MachineLearning::0.12.20062906-beta",
+    "Microsoft.Quantum.Numerics::0.12.20062906-beta",
 
-    "Microsoft.Quantum.Katas::0.12.20062518-beta",
+    "Microsoft.Quantum.Katas::0.12.20062906-beta",
 
-    "Microsoft.Quantum.Research::0.12.20062518-beta",
+    "Microsoft.Quantum.Research::0.12.20062906-beta",
 
-    "Microsoft.Quantum.Providers.IonQ::0.12.20062518-beta",
-    "Microsoft.Quantum.Providers.Honeywell::0.12.20062518-beta",
-    "Microsoft.Quantum.Providers.QCI::0.12.20062518-beta"
+    "Microsoft.Quantum.Providers.IonQ::0.12.20062906-beta",
+    "Microsoft.Quantum.Providers.Honeywell::0.12.20062906-beta",
+    "Microsoft.Quantum.Providers.QCI::0.12.20062906-beta"
   ]
 }


### PR DESCRIPTION
Updates the referenced `Microsoft.Jupyter.Core` version to ensure that the downstream `Markdig.Signed` package reference is the same as that in `Microsoft.Quantum.Compiler` package.