### PR TITLE
Register handler for OnDisplayableDiagnostic.

### DIFF
--- a/src/Jupyter/Extensions.cs
+++ b/src/Jupyter/Extensions.cs
@@ -97,6 +97,7 @@ namespace Microsoft.Quantum.IQSharp.Jupyter
             // Next, we attach the display channel's standard output handling
             // to the log event.
             simulator.OnLog += channel.Stdout;
+            simulator.OnDisplayableDiagnostic += channel.Display;
 
             // Next, we register the generic version of the DumpMachine callable
             // as an ICallable with the simulator. Below, we'll provide our


### PR DESCRIPTION
This PR adds a listener to the new `SimulatorBase.OnDisplayableDiagnostic` event when calling `WithJupyterDisplay`, allowing IQ# to collect diagnostic events from simulators and pass them along to display encoders.