### PR TITLE
Add `ExecutionPathTracer` to repo.

### DIFF
--- a/src/Core/Core.csproj
+++ b/src/Core/Core.csproj
@@ -39,6 +39,7 @@
     <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.12.20071622-beta" />
     <PackageReference Include="NuGet.Resolver" Version="5.1.0" />
     <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
+    <PackageReference Include="System.Text.Json" Version="4.7.2" />
   </ItemGroup>
 
 </Project>

--- a/src/Core/Core.csproj
+++ b/src/Core/Core.csproj
@@ -39,7 +39,6 @@
     <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.12.20071622-beta" />
     <PackageReference Include="NuGet.Resolver" Version="5.1.0" />
     <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
-    <PackageReference Include="System.Text.Json" Version="4.7.2" />
   </ItemGroup>
 
 </Project>

--- a/src/Core/ExecutionPathTracer/ExecutionPath.cs
+++ b/src/Core/ExecutionPathTracer/ExecutionPath.cs
@@ -4,7 +4,8 @@
 #nullable enable
 
 using System.Collections.Generic;
-using System.Text.Json;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
 
 namespace Microsoft.Quantum.IQSharp.Core.ExecutionPathTracer
 {
@@ -31,11 +32,13 @@ namespace Microsoft.Quantum.IQSharp.Core.ExecutionPathTracer
         /// <summary>
         /// A list of <see cref="QubitDeclaration"/> that represents the declared qubits used in the execution path.
         /// </summary>
+        [JsonProperty("qubits")]
         public IEnumerable<QubitDeclaration> Qubits { get; private set; }
 
         /// <summary>
         /// A list of <see cref="Operation"/> that represents the operations used in the execution path.
         /// </summary>
+        [JsonProperty("operations")]
         public IEnumerable<Operation> Operations { get; private set; }
 
         /// <summary>
@@ -45,12 +48,11 @@ namespace Microsoft.Quantum.IQSharp.Core.ExecutionPathTracer
         /// Pretty prints the JSON (i.e. with white space and indents) if <c>true</c>.
         /// </param>
         public string ToJson(bool prettyPrint = false) =>
-            JsonSerializer.Serialize(this,
-                new JsonSerializerOptions
+            JsonConvert.SerializeObject(this,
+                (prettyPrint) ? Formatting.Indented : Formatting.None,
+                new JsonSerializerSettings
                 {
-                    PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-                    IgnoreNullValues = true,
-                    WriteIndented = prettyPrint,
+                    NullValueHandling = NullValueHandling.Ignore,
                 }
             );
     }
@@ -69,7 +71,7 @@ namespace Microsoft.Quantum.IQSharp.Core.ExecutionPathTracer
         /// <param name="numChildren">
         /// Number of associated classical registers.
         /// </param>
-        public QubitDeclaration(int id, int? numChildren = null)
+        public QubitDeclaration(int id, int numChildren = 0)
         {
             this.Id = id;
             this.NumChildren = numChildren;
@@ -78,12 +80,20 @@ namespace Microsoft.Quantum.IQSharp.Core.ExecutionPathTracer
         /// <summary>
         /// Id of qubit.
         /// </summary>
+        [JsonProperty("id")]
         public int Id { get; private set; }
 
         /// <summary>
         /// Number of associated classical registers.
         /// </summary>
-        public int? NumChildren { get; private set; }
+        [JsonProperty("numChildren")]
+        public int NumChildren { get; private set; }
+
+        /// <summary>
+        /// Used by <see cref="Newtonsoft" /> to determine if <see cref="NumChildren" />
+        /// should be included in the JSON serialization.
+        /// </summary>
+        public bool ShouldSerializeNumChildren() => NumChildren > 0;
     }
 
     /// <summary>
@@ -94,6 +104,7 @@ namespace Microsoft.Quantum.IQSharp.Core.ExecutionPathTracer
         /// <summary>
         /// Label of gate.
         /// </summary>
+        [JsonProperty("gate")]
         public string Gate { get; set; } = "";
 
         /// <summary>
@@ -107,26 +118,31 @@ namespace Microsoft.Quantum.IQSharp.Core.ExecutionPathTracer
         /// <remarks>
         /// Currently not used as this is intended for classically-controlled operations.
         /// </remarks>
+        [JsonProperty("children")]
         public IEnumerable<IEnumerable<Operation>>? Children { get; set; }
 
         /// <summary>
         /// True if operation is a controlled operations.
         /// </summary>
+        [JsonProperty("controlled")]
         public bool Controlled { get; set; }
 
         /// <summary>
         /// True if operation is an adjoint operations.
         /// </summary>
+        [JsonProperty("adjoint")]
         public bool Adjoint { get; set; }
 
         /// <summary>
         /// List of control registers.
         /// </summary>
+        [JsonProperty("controls")]
         public IEnumerable<Register> Controls { get; set; } = new List<Register>();
 
         /// <summary>
         /// List of target registers.
         /// </summary>
+        [JsonProperty("targets")]
         public IEnumerable<Register> Targets { get; set; } = new List<Register>();
     }
 }

--- a/src/Core/ExecutionPathTracer/ExecutionPath.cs
+++ b/src/Core/ExecutionPathTracer/ExecutionPath.cs
@@ -1,10 +1,12 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+
+#nullable enable
 
 using System.Collections.Generic;
 using System.Text.Json;
 
-namespace Microsoft.Quantum.IQSharp
+namespace Microsoft.Quantum.IQSharp.Core.ExecutionPathTracer
 {
     /// <summary>
     /// Represents the qubit resources and operations traced out in an execution path of a Q# operation.
@@ -15,43 +17,42 @@ namespace Microsoft.Quantum.IQSharp
         /// Initializes a new instance of the <see cref="ExecutionPathTracer"/> class.
         /// </summary>
         /// <param name="qubits">
-        /// An array of <c>QubitDeclaration</c>s that represents the declared qubits used in the execution path.
+        /// A list of <see cref="QubitDeclaration"/> that represents the declared qubits used in the execution path.
         /// </param>
         /// <param name="operations">
-        /// An array of <c>Operation</c>s that represents the operations used in the execution path.
+        /// A list of <see cref="Operation"/> that represents the operations used in the execution path.
         /// </param>
-        public ExecutionPath(QubitDeclaration[] qubits, Operation[] operations)
+        public ExecutionPath(IEnumerable<QubitDeclaration> qubits, IEnumerable<Operation> operations)
         {
             this.Qubits = qubits;
             this.Operations = operations;
         }
 
         /// <summary>
-        /// An array of <c>QubitDeclaration</c>s that represents the declared qubits used in the execution path.
+        /// A list of <see cref="QubitDeclaration"/> that represents the declared qubits used in the execution path.
         /// </summary>
-        public QubitDeclaration[] Qubits { get; set; }
+        public IEnumerable<QubitDeclaration> Qubits { get; private set; }
 
         /// <summary>
-        /// An array of <c>Operation</c>s that represents the operations used in the execution path.
+        /// A list of <see cref="Operation"/> that represents the operations used in the execution path.
         /// </summary>
-        public Operation[] Operations { get; set; }
+        public IEnumerable<Operation> Operations { get; private set; }
 
         /// <summary>
-        /// Serializes <c>ExecutionPath</c> into its JSON representation.
+        /// Serializes <see cref="ExecutionPath"/> into its JSON representation.
         /// </summary>
         /// <param name="prettyPrint">
-        /// Pretty prints the JSON (i.e. with white space and indents) if true (default = false).
+        /// Pretty prints the JSON (i.e. with white space and indents) if <c>true</c>.
         /// </param>
-        public string ToJson(bool prettyPrint = false)
-        {
-            var options = new JsonSerializerOptions
-            {
-                PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-                IgnoreNullValues = true,
-                WriteIndented = prettyPrint,
-            };
-            return JsonSerializer.Serialize(this, options);
-        }
+        public string ToJson(bool prettyPrint = false) =>
+            JsonSerializer.Serialize(this,
+                new JsonSerializerOptions
+                {
+                    PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+                    IgnoreNullValues = true,
+                    WriteIndented = prettyPrint,
+                }
+            );
     }
 
     /// <summary>
@@ -77,12 +78,12 @@ namespace Microsoft.Quantum.IQSharp
         /// <summary>
         /// Id of qubit.
         /// </summary>
-        public int Id { get; set; }
+        public int Id { get; private set; }
 
         /// <summary>
         /// Number of associated classical registers.
         /// </summary>
-        public int? NumChildren { get; set; }
+        public int? NumChildren { get; private set; }
     }
 
     /// <summary>
@@ -93,12 +94,12 @@ namespace Microsoft.Quantum.IQSharp
         /// <summary>
         /// Label of gate.
         /// </summary>
-        public string Gate { get; set; }
+        public string Gate { get; set; } = "";
 
         /// <summary>
         /// Non-qubit arguments provided to gate.
         /// </summary>
-        public string ArgStr { get; set; }
+        public string? ArgStr { get; set; }
 
         /// <summary>
         /// Group of operations for each classical branch.
@@ -106,7 +107,7 @@ namespace Microsoft.Quantum.IQSharp
         /// <remarks>
         /// Currently not used as this is intended for classically-controlled operations.
         /// </remarks>
-        public List<List<Operation>> Children { get; set; }
+        public IEnumerable<IEnumerable<Operation>> Children { get; set; } = new List<List<Operation>>();
 
         /// <summary>
         /// True if operation is a controlled operations.
@@ -121,11 +122,11 @@ namespace Microsoft.Quantum.IQSharp
         /// <summary>
         /// List of control registers.
         /// </summary>
-        public List<Register> Controls { get; set; } = new List<Register>();
+        public IEnumerable<Register> Controls { get; set; } = new List<Register>();
 
         /// <summary>
         /// List of target registers.
         /// </summary>
-        public List<Register> Targets { get; set; } = new List<Register>();
+        public IEnumerable<Register> Targets { get; set; } = new List<Register>();
     }
 }

--- a/src/Core/ExecutionPathTracer/ExecutionPath.cs
+++ b/src/Core/ExecutionPathTracer/ExecutionPath.cs
@@ -33,13 +33,13 @@ namespace Microsoft.Quantum.IQSharp.Core.ExecutionPathTracer
         /// A list of <see cref="QubitDeclaration"/> that represents the declared qubits used in the execution path.
         /// </summary>
         [JsonProperty("qubits")]
-        public IEnumerable<QubitDeclaration> Qubits { get; private set; }
+        public IEnumerable<QubitDeclaration> Qubits { get; }
 
         /// <summary>
         /// A list of <see cref="Operation"/> that represents the operations used in the execution path.
         /// </summary>
         [JsonProperty("operations")]
-        public IEnumerable<Operation> Operations { get; private set; }
+        public IEnumerable<Operation> Operations { get; }
 
         /// <summary>
         /// Serializes <see cref="ExecutionPath"/> into its JSON representation.
@@ -81,13 +81,13 @@ namespace Microsoft.Quantum.IQSharp.Core.ExecutionPathTracer
         /// Id of qubit.
         /// </summary>
         [JsonProperty("id")]
-        public int Id { get; private set; }
+        public int Id { get; }
 
         /// <summary>
         /// Number of associated classical registers.
         /// </summary>
         [JsonProperty("numChildren")]
-        public int NumChildren { get; private set; }
+        public int NumChildren { get; }
 
         /// <summary>
         /// Used by <see cref="Newtonsoft" /> to determine if <see cref="NumChildren" />

--- a/src/Core/ExecutionPathTracer/ExecutionPath.cs
+++ b/src/Core/ExecutionPathTracer/ExecutionPath.cs
@@ -108,9 +108,11 @@ namespace Microsoft.Quantum.IQSharp.Core.ExecutionPathTracer
         public string Gate { get; set; } = "";
 
         /// <summary>
-        /// Non-qubit arguments provided to gate.
+        /// Arguments (except <see cref="Qubit" /> types) provided to gate that
+        /// will be displayed by the visualizer.
         /// </summary>
-        public string? ArgStr { get; set; }
+        [JsonProperty("displayArgs")]
+        public string? DisplayArgs { get; set; }
 
         /// <summary>
         /// Group of operations for each classical branch.

--- a/src/Core/ExecutionPathTracer/ExecutionPath.cs
+++ b/src/Core/ExecutionPathTracer/ExecutionPath.cs
@@ -107,7 +107,7 @@ namespace Microsoft.Quantum.IQSharp.Core.ExecutionPathTracer
         /// <remarks>
         /// Currently not used as this is intended for classically-controlled operations.
         /// </remarks>
-        public IEnumerable<IEnumerable<Operation>> Children { get; set; } = new List<List<Operation>>();
+        public IEnumerable<IEnumerable<Operation>>? Children { get; set; }
 
         /// <summary>
         /// True if operation is a controlled operations.

--- a/src/Core/ExecutionPathTracer/ExecutionPath.cs
+++ b/src/Core/ExecutionPathTracer/ExecutionPath.cs
@@ -1,0 +1,131 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.Text.Json;
+
+namespace Microsoft.Quantum.IQSharp
+{
+    /// <summary>
+    /// Represents the qubit resources and operations traced out in an execution path of a Q# operation.
+    /// </summary>
+    public class ExecutionPath
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ExecutionPathTracer"/> class.
+        /// </summary>
+        /// <param name="qubits">
+        /// An array of <c>QubitDeclaration</c>s that represents the declared qubits used in the execution path.
+        /// </param>
+        /// <param name="operations">
+        /// An array of <c>Operation</c>s that represents the operations used in the execution path.
+        /// </param>
+        public ExecutionPath(QubitDeclaration[] qubits, Operation[] operations)
+        {
+            this.Qubits = qubits;
+            this.Operations = operations;
+        }
+
+        /// <summary>
+        /// An array of <c>QubitDeclaration</c>s that represents the declared qubits used in the execution path.
+        /// </summary>
+        public QubitDeclaration[] Qubits { get; set; }
+
+        /// <summary>
+        /// An array of <c>Operation</c>s that represents the operations used in the execution path.
+        /// </summary>
+        public Operation[] Operations { get; set; }
+
+        /// <summary>
+        /// Serializes <c>ExecutionPath</c> into its JSON representation.
+        /// </summary>
+        /// <param name="prettyPrint">
+        /// Pretty prints the JSON (i.e. with white space and indents) if true (default = false).
+        /// </param>
+        public string ToJson(bool prettyPrint = false)
+        {
+            var options = new JsonSerializerOptions
+            {
+                PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+                IgnoreNullValues = true,
+                WriteIndented = prettyPrint,
+            };
+            return JsonSerializer.Serialize(this, options);
+        }
+    }
+
+    /// <summary>
+    /// Represents a qubit resource used in an execution path.
+    /// </summary>
+    public class QubitDeclaration
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="QubitDeclaration"/> class.
+        /// </summary>
+        /// <param name="id">
+        /// Id of qubit.
+        /// </param>
+        /// <param name="numChildren">
+        /// Number of associated classical registers.
+        /// </param>
+        public QubitDeclaration(int id, int? numChildren = null)
+        {
+            this.Id = id;
+            this.NumChildren = numChildren;
+        }
+
+        /// <summary>
+        /// Id of qubit.
+        /// </summary>
+        public int Id { get; set; }
+
+        /// <summary>
+        /// Number of associated classical registers.
+        /// </summary>
+        public int? NumChildren { get; set; }
+    }
+
+    /// <summary>
+    /// Represents an operation used in an execution path.
+    /// </summary>
+    public class Operation
+    {
+        /// <summary>
+        /// Label of gate.
+        /// </summary>
+        public string Gate { get; set; }
+
+        /// <summary>
+        /// Non-qubit arguments provided to gate.
+        /// </summary>
+        public string ArgStr { get; set; }
+
+        /// <summary>
+        /// Group of operations for each classical branch.
+        /// </summary>
+        /// <remarks>
+        /// Currently not used as this is intended for classically-controlled operations.
+        /// </remarks>
+        public List<List<Operation>> Children { get; set; }
+
+        /// <summary>
+        /// True if operation is a controlled operations.
+        /// </summary>
+        public bool Controlled { get; set; }
+
+        /// <summary>
+        /// True if operation is an adjoint operations.
+        /// </summary>
+        public bool Adjoint { get; set; }
+
+        /// <summary>
+        /// List of control registers.
+        /// </summary>
+        public List<Register> Controls { get; set; } = new List<Register>();
+
+        /// <summary>
+        /// List of target registers.
+        /// </summary>
+        public List<Register> Targets { get; set; } = new List<Register>();
+    }
+}

--- a/src/Core/ExecutionPathTracer/ExecutionPathTracer.cs
+++ b/src/Core/ExecutionPathTracer/ExecutionPathTracer.cs
@@ -39,11 +39,9 @@ namespace Microsoft.Quantum.IQSharp.Core.ExecutionPathTracer
             new ExecutionPath(
                 this.qubitRegisters.Keys
                     .OrderBy(k => k)
-                    .Select(k => new QubitDeclaration(k,
-                        // Get number of classical registers associated with qubit register (null if none).
-                        (this.classicalRegisters.ContainsKey(k))
-                            ? this.classicalRegisters[k].Count
-                            : null as int?
+                    .Select(k => new QubitDeclaration(k, (this.classicalRegisters.ContainsKey(k))
+                        ? this.classicalRegisters[k].Count
+                        : 0
                     )),
                 this.operations
             );

--- a/src/Core/ExecutionPathTracer/ExecutionPathTracer.cs
+++ b/src/Core/ExecutionPathTracer/ExecutionPathTracer.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.Quantum.Simulation.Core;
 
@@ -23,13 +22,6 @@ namespace Microsoft.Quantum.IQSharp.Core.ExecutionPathTracer
         private IDictionary<int, QubitRegister> qubitRegisters = new Dictionary<int, QubitRegister>();
         private IDictionary<int, List<ClassicalRegister>> classicalRegisters = new Dictionary<int, List<ClassicalRegister>>();
         private List<Operation> operations = new List<Operation>();
-        private readonly ImmutableList<Type> nestedTypes =
-            ImmutableList.Create(
-                typeof(Microsoft.Quantum.Canon.ApplyToEach<Qubit>),
-                typeof(Microsoft.Quantum.Canon.ApplyToEachC<Qubit>),
-                typeof(Microsoft.Quantum.Canon.ApplyToEachA<Qubit>),
-                typeof(Microsoft.Quantum.Canon.ApplyToEachCA<Qubit>)
-            );
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ExecutionPathTracer"/> class.
@@ -63,10 +55,6 @@ namespace Microsoft.Quantum.IQSharp.Core.ExecutionPathTracer
         /// </summary>
         public void OnOperationStartHandler(ICallable operation, IApplyData arguments)
         {
-            // If the operation type is one of the nestedTypes, go one depth deeper and parse
-            // those operations instead
-            if (this.nestedTypes.Contains(operation.GetType())) return;
-
             this.currentDepth++;
 
             // Parse operations at specified depth
@@ -85,16 +73,7 @@ namespace Microsoft.Quantum.IQSharp.Core.ExecutionPathTracer
         /// </summary>
         public void OnOperationEndHandler(ICallable operation, IApplyData result)
         {
-            if (this.nestedTypes.Contains(operation.GetType())) return;
             this.currentDepth--;
-        }
-
-        private static bool IsPartialApplication(ICallable operation)
-        {
-            var t = operation.GetType();
-            if (t == null) return false;
-
-            return t.IsGenericType && t.GetGenericTypeDefinition() == typeof(OperationPartial<,,>);
         }
 
         /// <summary>
@@ -141,7 +120,7 @@ namespace Microsoft.Quantum.IQSharp.Core.ExecutionPathTracer
             var cId = this.classicalRegisters[qId].Count - 1;
             return this.classicalRegisters[qId][cId];
         }
-        
+
         /// <summary>
         /// Parse <see cref="RuntimeMetadata"/> into its corresponding <see cref="Operation"/>.
         /// </summary>

--- a/src/Core/ExecutionPathTracer/ExecutionPathTracer.cs
+++ b/src/Core/ExecutionPathTracer/ExecutionPathTracer.cs
@@ -129,7 +129,7 @@ namespace Microsoft.Quantum.IQSharp.Core.ExecutionPathTracer
             var op = new Operation()
             {
                 Gate = metadata.Label,
-                ArgStr = metadata.Args,
+                DisplayArgs = (metadata.FormattedNonQubitArgs.Length > 0) ? metadata.FormattedNonQubitArgs : null,
                 Children = metadata.Children?.Select(child => child.Select(this.MetadataToOperation).WhereNotNull()),
                 Controlled = metadata.IsControlled,
                 Adjoint = metadata.IsAdjoint,

--- a/src/Core/ExecutionPathTracer/ExecutionPathTracer.cs
+++ b/src/Core/ExecutionPathTracer/ExecutionPathTracer.cs
@@ -1,0 +1,307 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Quantum.Simulation.Core;
+
+#nullable enable
+
+namespace Microsoft.Quantum.IQSharp
+{
+    /// <summary>
+    /// Traces through the operations in a given execution path of a Q# program by hooking on
+    /// to a simulator via the event listeners <c>OnOperationStartHandler</c> and
+    /// <c>OnOperationEndHandler</c>, and generates the corresponding <c>ExecutionPath</c>.
+    /// </summary>
+    public class ExecutionPathTracer
+    {
+        private int currDepth = 0;
+        private int renderDepth;
+        private IDictionary<int, QubitRegister> qubitRegisters = new Dictionary<int, QubitRegister>();
+        private IDictionary<int, List<ClassicalRegister>> classicalRegisters = new Dictionary<int, List<ClassicalRegister>>();
+        private List<Operation> operations = new List<Operation>();
+        private Type[] nestedTypes = new Type[]
+        {
+            typeof(Microsoft.Quantum.Canon.ApplyToEach<Qubit>),
+            typeof(Microsoft.Quantum.Canon.ApplyToEachC<Qubit>),
+            typeof(Microsoft.Quantum.Canon.ApplyToEachA<Qubit>),
+            typeof(Microsoft.Quantum.Canon.ApplyToEachCA<Qubit>),
+        };
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ExecutionPathTracer"/> class.
+        /// </summary>
+        /// <param name="depth">
+        /// The depth at which to render operations.
+        /// </param>
+        public ExecutionPathTracer(int depth = 1) => this.renderDepth = depth + 1;
+
+        /// <summary>
+        /// Returns the generated <c>ExecutionPath</c>.
+        /// </summary>
+        public ExecutionPath GetExecutionPath()
+        {
+            var qubits = this.qubitRegisters.Keys
+                .OrderBy(k => k)
+                .Select(k =>
+                {
+                    var qubitDecl = new QubitDeclaration(k);
+                    if (this.classicalRegisters.ContainsKey(k))
+                    {
+                        qubitDecl.NumChildren = this.classicalRegisters[k].Count;
+                    }
+
+                    return qubitDecl;
+                })
+                .ToArray();
+
+            return new ExecutionPath(qubits, this.operations.ToArray());
+        }
+
+        /// <summary>
+        /// Provides the event listener to listen to <c>SimulatorBase</c>'s <c>OnOperationStart</c> event.
+        /// </summary>
+        public void OnOperationStartHandler(ICallable operation, IApplyData arguments)
+        {
+            // If the operation type is one of the nestedTypes, go one depth deeper and parse
+            // those operations instead
+            if (this.nestedTypes.Contains(operation.GetType())) return;
+
+            this.currDepth++;
+
+            // Parse operations at specified depth
+            if (this.currDepth == this.renderDepth)
+            {
+                var parsedOp = this.ParseOperation(operation, arguments);
+                if (parsedOp != null)
+                {
+                    this.operations.Add(parsedOp);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Provides the event listener to listen to <c>SimulatorBase</c>'s <c>OnOperationEnd</c> event.
+        /// </summary>
+        public void OnOperationEndHandler(ICallable operation, IApplyData result)
+        {
+            if (this.nestedTypes.Contains(operation.GetType())) return;
+            this.currDepth--;
+        }
+
+        private static bool IsPartialApplication(ICallable operation)
+        {
+            var t = operation.GetType();
+            if (t == null) return false;
+
+            return t.IsGenericType && t.GetGenericTypeDefinition() == typeof(OperationPartial<,,>);
+        }
+
+        /// <summary>
+        /// Retrieves the <c>QubitRegister</c> associated with the given <c>Qubit</c> or create a new
+        /// one if it doesn't exist.
+        /// </summary>
+        private QubitRegister GetQubitRegister(Qubit qubit)
+        {
+            if (!this.qubitRegisters.ContainsKey(qubit.Id))
+            {
+                this.qubitRegisters[qubit.Id] = new QubitRegister(qubit.Id);
+            }
+
+            return this.qubitRegisters[qubit.Id];
+        }
+
+        private List<QubitRegister> GetQubitRegisters(IEnumerable<Qubit> qubits)
+        {
+            return qubits.Select(this.GetQubitRegister).ToList();
+        }
+
+        /// <summary>
+        /// Creates a new <c>ClassicalRegister</c> and associate it with the given <c>Qubit</c>.
+        /// </summary>
+        private ClassicalRegister CreateClassicalRegister(Qubit measureQubit)
+        {
+            var qId = measureQubit.Id;
+
+            if (!this.classicalRegisters.ContainsKey(qId))
+            {
+                this.classicalRegisters[qId] = new List<ClassicalRegister>();
+            }
+
+            var cId = this.classicalRegisters[qId].Count;
+            ClassicalRegister register = new ClassicalRegister(qId, cId);
+
+            // Add classical register under the given qubit id
+            this.classicalRegisters[qId].Add(register);
+
+            return register;
+        }
+
+        /// <summary>
+        /// Retrieves the most recent <c>ClassicalRegister</c> associated with the given <c>Qubit</c>.
+        /// </summary>
+        /// <remarks>
+        /// Currently not used as this is intended for classically-controlled operations.
+        /// </remarks>
+        private ClassicalRegister GetClassicalRegister(Qubit controlQubit)
+        {
+            var qId = controlQubit.Id;
+            if (!this.classicalRegisters.ContainsKey(qId) || this.classicalRegisters[qId].Count == 0)
+            {
+                throw new Exception("No classical registers found for qubit {qId}.");
+            }
+
+            // Get most recent measurement on given control qubit
+            var cId = this.classicalRegisters[qId].Count - 1;
+            return this.classicalRegisters[qId][cId];
+        }
+
+        /// <summary>
+        /// Given a <c>Type</c> and its value, extract its fields and format it as a string.
+        /// </summary>
+        private string? ExtractArgs(Type t, object value)
+        {
+            List<string?> fields = new List<string?>();
+
+            foreach (var f in t.GetFields())
+            {
+                // If field is a tuple, recursively extract its inner arguments and format as a tuple string.
+                if (f.FieldType.IsTuple())
+                {
+                    var nestedArgs = f.GetValue(value);
+                    if (nestedArgs != null)
+                    {
+                        var nestedFields = this.ExtractArgs(f.FieldType, nestedArgs);
+                        fields.Add(nestedFields);
+                    }
+                }
+                // Add field as an argument if it is not a Qubit type
+                else if (!f.FieldType.IsQubitsContainer())
+                {
+                    fields.Add(f.GetValue(value)?.ToString());
+                }
+            }
+
+            return fields.Any() ? $"({string.Join(",", fields.WhereNotNull())})" : null;
+        }
+
+        /// <summary>
+        /// Given an operation and its arguments, parse it into an <c>Operation</c> object.
+        /// </summary>
+        private Operation? ParseOperation(ICallable operation, IApplyData arguments)
+        {
+            // If operation is a partial application, perform on baseOp recursively.
+            if (IsPartialApplication(operation))
+            {
+                dynamic partialOp = operation;
+                dynamic partialOpArgs = arguments;
+
+                // Recursively get base operation operations
+                var baseOp = partialOp.BaseOp;
+                var baseArgs = baseOp.__dataIn(partialOpArgs.Value);
+                return this.ParseOperation(baseOp, baseArgs);
+            }
+
+            var controlled = operation.Variant == OperationFunctor.Controlled ||
+                             operation.Variant == OperationFunctor.ControlledAdjoint;
+            var adjoint = operation.Variant == OperationFunctor.Adjoint ||
+                          operation.Variant == OperationFunctor.ControlledAdjoint;
+
+            // If operation is controlled, perform on baseOp recursively and mark as controlled.
+            if (controlled)
+            {
+                dynamic ctrlOp = operation;
+                dynamic ctrlOpArgs = arguments;
+
+                var ctrls = ctrlOpArgs.Value.Item1;
+                var controlRegs = this.GetQubitRegisters(ctrls);
+
+                // Recursively get base operation operations
+                var baseOp = ctrlOp.BaseOp;
+                var baseArgs = baseOp.__dataIn(ctrlOpArgs.Value.Item2);
+                var parsedBaseOp = this.ParseOperation(baseOp, baseArgs);
+
+                parsedBaseOp.Controlled = true;
+                parsedBaseOp.Adjoint = adjoint;
+                parsedBaseOp.Controls.InsertRange(0, controlRegs);
+
+                return parsedBaseOp;
+            }
+
+            // Handle operation based on type
+            switch (operation)
+            {
+                // Handle CNOT operations as a Controlled X
+                case Microsoft.Quantum.Intrinsic.CNOT cnot:
+                case Microsoft.Quantum.Intrinsic.CCNOT ccnot:
+                    var ctrlRegs = new List<Register>();
+                    var targetRegs = new List<Register>();
+
+                    switch (arguments.Value)
+                    {
+                        case ValueTuple<Qubit, Qubit> cnotQs:
+                            var (ctrl, cnotTarget) = cnotQs;
+                            ctrlRegs.Add(this.GetQubitRegister(ctrl));
+                            targetRegs.Add(this.GetQubitRegister(cnotTarget));
+                            break;
+                        case ValueTuple<Qubit, Qubit, Qubit> ccnotQs:
+                            var (ctrl1, ctrl2, ccnotTarget) = ccnotQs;
+                            ctrlRegs.Add(this.GetQubitRegister(ctrl1));
+                            ctrlRegs.Add(this.GetQubitRegister(ctrl2));
+                            targetRegs.Add(this.GetQubitRegister(ccnotTarget));
+                            break;
+                    }
+
+                    return new Operation
+                    {
+                        Gate = "X",
+                        Controlled = true,
+                        Adjoint = adjoint,
+                        Controls = ctrlRegs,
+                        Targets = targetRegs,
+                    };
+
+                // Measurement operations
+                case Microsoft.Quantum.Intrinsic.M m:
+                case Microsoft.Quantum.Measurement.MResetX mx:
+                case Microsoft.Quantum.Measurement.MResetY my:
+                case Microsoft.Quantum.Measurement.MResetZ mz:
+                    var measureQubit = arguments.GetQubits().ElementAt(0);
+                    var measureReg = this.GetQubitRegister(measureQubit);
+                    var clsReg = this.CreateClassicalRegister(measureQubit);
+
+                    return new Operation
+                    {
+                        Gate = "measure",
+                        Controlled = false,
+                        Adjoint = adjoint,
+                        Controls = new List<Register>() { measureReg },
+                        Targets = new List<Register>() { clsReg },
+                    };
+
+                // Operations to ignore
+                case Microsoft.Quantum.Intrinsic.Reset reset:
+                case Microsoft.Quantum.Intrinsic.ResetAll resetAll:
+                    return null;
+
+                // General operations
+                default:
+                    Type t = arguments.Value.GetType();
+                    var argStr = this.ExtractArgs(t, arguments.Value);
+                    var qubitRegs = this.GetQubitRegisters(arguments.GetQubits());
+
+                    return new Operation
+                    {
+                        Gate = operation.Name,
+                        ArgStr = argStr,
+                        Controlled = false,
+                        Adjoint = adjoint,
+                        Controls = new List<Register>(),
+                        Targets = qubitRegs.Cast<Register>().ToList(),
+                    };
+            }
+        }
+    }
+}

--- a/src/Core/ExecutionPathTracer/ExecutionPathTracer.cs
+++ b/src/Core/ExecutionPathTracer/ExecutionPathTracer.cs
@@ -24,16 +24,15 @@ namespace Microsoft.Quantum.IQSharp.Core.ExecutionPathTracer
         private List<Operation> operations = new List<Operation>();
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="ExecutionPathTracer"/> class.
+        /// Initializes a new instance of the <see cref="ExecutionPathTracer"/> class with the depth to render operations at.
         /// </summary>
         /// <param name="depth">
         /// The depth at which to render operations.
         /// </param>
-        public ExecutionPathTracer(int depth = 1) =>
-            this.renderDepth = depth + 1;
+        public ExecutionPathTracer(int depth = 1) => this.renderDepth = depth + 1;
 
         /// <summary>
-        /// Returns the generated <c>ExecutionPath</c>.
+        /// Returns the generated <see cref="ExecutionPath"/>.
         /// </summary>
         public ExecutionPath GetExecutionPath() =>
             new ExecutionPath(
@@ -69,10 +68,7 @@ namespace Microsoft.Quantum.IQSharp.Core.ExecutionPathTracer
         /// <see cref="Microsoft.Quantum.Simulation.Common.SimulatorBase"/>'s
         /// <c>OnOperationEnd</c> event.
         /// </summary>
-        public void OnOperationEndHandler(ICallable operation, IApplyData result)
-        {
-            this.currentDepth--;
-        }
+        public void OnOperationEndHandler(ICallable operation, IApplyData result) => this.currentDepth--;
 
         /// <summary>
         /// Retrieves the <see cref="QubitRegister"/> associated with the given <see cref="Qubit"/> or create a new

--- a/src/Core/ExecutionPathTracer/Extensions.cs
+++ b/src/Core/ExecutionPathTracer/Extensions.cs
@@ -1,0 +1,88 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Quantum.Simulation.Common;
+using Microsoft.Quantum.Simulation.Core;
+
+namespace Microsoft.Quantum.IQSharp.Core.ExecutionPathTracer
+{
+    /// <summary>
+    /// Extension methods to be used with and by <see cref="ExecutionPathTracer">.
+    /// </summary>
+    public static class Extensions
+    {
+        /// <summary>
+        /// Attaches <c>ExecutionPathTracer</c> event listeners to the simulator to generate
+        /// the <c>ExecutionPath</c> of the operation performed by the simulator.
+        /// </summary>
+        public static T WithExecutionPathTracer<T>(this T sim, ExecutionPathTracer tracer)
+            where T : SimulatorBase
+        {
+            sim.OnOperationStart += tracer.OnOperationStartHandler;
+            sim.OnOperationEnd += tracer.OnOperationEndHandler;
+            return sim;
+        }
+
+        /// <summary>
+        /// Gets the value associated with the specified key and creates a new entry with the <c>defaultVal</c> if
+        /// the key doesn't exist.
+        /// </summary>
+        public static TValue GetOrCreate<TKey, TValue>(this IDictionary<TKey, TValue> dict, TKey key, TValue defaultVal)
+        {
+            TValue val;
+            if (!dict.TryGetValue(key, out val))
+            {
+                val = defaultVal;
+                dict.Add(key, val);
+            }
+            return val;
+        }
+
+        /// <summary>
+        /// Gets the value associated with the specified key and creates a new entry of the default type if
+        /// the key doesn't exist.
+        /// </summary>
+        public static TValue GetOrCreate<TKey, TValue>(this IDictionary<TKey, TValue> dict, TKey key)
+            where TValue : new()
+        {
+            return dict.GetOrCreate(key, new TValue());
+        }
+
+        /// <summary>
+        /// Given a <see cref="Type"/>, format its non-qubit arguments into a string.
+        /// Returns null if no arguments found.
+        /// </summary>
+        public static string? ArgsToString(this Type t, object args)
+        {
+            var argsStrings = t.GetFields()
+                .Select(f =>
+                {
+                    var argString = null as string;
+
+                    // If field is a tuple, recursively extract its inner arguments and format as a tuple string.
+                    if (f.FieldType.IsTuple())
+                    {
+                        var nestedArgs = f.GetValue(args);
+                        if (nestedArgs != null) argString = f.FieldType.ArgsToString(nestedArgs);
+                    }
+                    // Add field as an argument if it is not a Qubit type
+                    else if (!f.FieldType.IsQubitsContainer())
+                    {
+                        argString = f.GetValue(args)?.ToString();
+                    }
+
+                    return argString;
+                })
+                .WhereNotNull();
+
+            return argsStrings.Any()
+                ? $"({string.Join(",", argsStrings)})"
+                : null;
+        }
+    }
+}

--- a/src/Core/ExecutionPathTracer/Extensions.cs
+++ b/src/Core/ExecutionPathTracer/Extensions.cs
@@ -17,8 +17,8 @@ namespace Microsoft.Quantum.IQSharp.Core.ExecutionPathTracer
     public static class Extensions
     {
         /// <summary>
-        /// Attaches <c>ExecutionPathTracer</c> event listeners to the simulator to generate
-        /// the <c>ExecutionPath</c> of the operation performed by the simulator.
+        /// Attaches <see cref="ExecutionPathTracer"> event listeners to the simulator to generate
+        /// the <see cref="ExecutionPath"> of the operation performed by the simulator.
         /// </summary>
         public static T WithExecutionPathTracer<T>(this T sim, ExecutionPathTracer tracer)
             where T : SimulatorBase
@@ -48,41 +48,6 @@ namespace Microsoft.Quantum.IQSharp.Core.ExecutionPathTracer
         /// the key doesn't exist.
         /// </summary>
         public static TValue GetOrCreate<TKey, TValue>(this IDictionary<TKey, TValue> dict, TKey key)
-            where TValue : new()
-        {
-            return dict.GetOrCreate(key, new TValue());
-        }
-
-        /// <summary>
-        /// Given a <see cref="Type"/>, format its non-qubit arguments into a string.
-        /// Returns null if no arguments found.
-        /// </summary>
-        public static string? ArgsToString(this Type t, object args)
-        {
-            var argsStrings = t.GetFields()
-                .Select(f =>
-                {
-                    var argString = null as string;
-
-                    // If field is a tuple, recursively extract its inner arguments and format as a tuple string.
-                    if (f.FieldType.IsTuple())
-                    {
-                        var nestedArgs = f.GetValue(args);
-                        if (nestedArgs != null) argString = f.FieldType.ArgsToString(nestedArgs);
-                    }
-                    // Add field as an argument if it is not a Qubit type
-                    else if (!f.FieldType.IsQubitsContainer())
-                    {
-                        argString = f.GetValue(args)?.ToString();
-                    }
-
-                    return argString;
-                })
-                .WhereNotNull();
-
-            return argsStrings.Any()
-                ? $"({string.Join(",", argsStrings)})"
-                : null;
-        }
+            where TValue : new() => dict.GetOrCreate(key, new TValue());
     }
 }

--- a/src/Core/ExecutionPathTracer/Register.cs
+++ b/src/Core/ExecutionPathTracer/Register.cs
@@ -1,19 +1,27 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-namespace Microsoft.Quantum.IQSharp
+#nullable enable
+
+namespace Microsoft.Quantum.IQSharp.Core.ExecutionPathTracer
 {
     /// <summary>
     /// Enum for the 2 types of registers: Qubit and Classical.
     /// </summary>
     public enum RegisterType
     {
+        /// <summary>
+        /// Qubit register that holds a qubit.
+        /// </summary>
         Qubit,
+        /// <summary>
+        /// Classical register that holds a classical bit.
+        /// </summary>
         Classical,
     }
 
     /// <summary>
-    /// Represents a register used by an <c>Operation</c>.
+    /// Represents a register used by an <see cref="Operation"/>.
     /// </summary>
     public class Register
     {
@@ -34,12 +42,12 @@ namespace Microsoft.Quantum.IQSharp
     }
 
     /// <summary>
-    /// Represents a qubit register used by an <c>Operation</c>.
+    /// Represents a qubit register used by an <see cref="Operation"/>.
     /// </summary>
     public class QubitRegister : Register
     {
         /// <summary>
-        /// Creates a new <c>QubitRegister</c> with the given qubit id.
+        /// Creates a new <see cref="QubitRegister"/> with the given qubit id.
         /// </summary>
         /// <param name="qId">
         /// Id of qubit register.
@@ -53,12 +61,12 @@ namespace Microsoft.Quantum.IQSharp
     }
 
     /// <summary>
-    /// Represents a classical register used by an <c>Operation</c>.
+    /// Represents a classical register used by an <see cref="Operation"/>.
     /// </summary>
     public class ClassicalRegister : Register
     {
         /// <summary>
-        /// Creates a new <c>ClassicalRegister</c> with the given qubit id and classical bit id.
+        /// Creates a new <see cref="ClassicalRegister"/> with the given qubit id and classical bit id.
         /// </summary>
         /// <param name="qId">
         /// Id of qubit register.

--- a/src/Core/ExecutionPathTracer/Register.cs
+++ b/src/Core/ExecutionPathTracer/Register.cs
@@ -1,0 +1,77 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Microsoft.Quantum.IQSharp
+{
+    /// <summary>
+    /// Enum for the 2 types of registers: Qubit and Classical.
+    /// </summary>
+    public enum RegisterType
+    {
+        Qubit,
+        Classical,
+    }
+
+    /// <summary>
+    /// Represents a register used by an <c>Operation</c>.
+    /// </summary>
+    public class Register
+    {
+        /// <summary>
+        /// Type of register.
+        /// </summary>
+        public virtual RegisterType Type { get; set; }
+
+        /// <summary>
+        /// Qubit id of register.
+        /// </summary>
+        public virtual int QId { get; set; }
+
+        /// <summary>
+        /// Classical bit id of register.
+        /// </summary>
+        public virtual int? CId { get; set; }
+    }
+
+    /// <summary>
+    /// Represents a qubit register used by an <c>Operation</c>.
+    /// </summary>
+    public class QubitRegister : Register
+    {
+        /// <summary>
+        /// Creates a new <c>QubitRegister</c> with the given qubit id.
+        /// </summary>
+        /// <param name="qId">
+        /// Id of qubit register.
+        /// </param>
+        public QubitRegister(int qId)
+        {
+            this.QId = qId;
+        }
+
+        public override RegisterType Type => RegisterType.Qubit;
+    }
+
+    /// <summary>
+    /// Represents a classical register used by an <c>Operation</c>.
+    /// </summary>
+    public class ClassicalRegister : Register
+    {
+        /// <summary>
+        /// Creates a new <c>ClassicalRegister</c> with the given qubit id and classical bit id.
+        /// </summary>
+        /// <param name="qId">
+        /// Id of qubit register.
+        /// </param>
+        /// <param name="cId">
+        /// Id of classical register associated with the given qubit id.
+        /// </param>
+        public ClassicalRegister(int qId, int cId)
+        {
+            this.QId = qId;
+            this.CId = cId;
+        }
+
+        public override RegisterType Type => RegisterType.Classical;
+    }
+}

--- a/src/Core/ExecutionPathTracer/Register.cs
+++ b/src/Core/ExecutionPathTracer/Register.cs
@@ -3,6 +3,9 @@
 
 #nullable enable
 
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+
 namespace Microsoft.Quantum.IQSharp.Core.ExecutionPathTracer
 {
     /// <summary>
@@ -28,16 +31,19 @@ namespace Microsoft.Quantum.IQSharp.Core.ExecutionPathTracer
         /// <summary>
         /// Type of register.
         /// </summary>
+        [JsonProperty("type")]
         public virtual RegisterType Type { get; set; }
 
         /// <summary>
         /// Qubit id of register.
         /// </summary>
+        [JsonProperty("qId")]
         public virtual int QId { get; set; }
 
         /// <summary>
-        /// Classical bit id of register.
+        /// Classical bit id of register. <c>null</c> if register is a qubit register.
         /// </summary>
+        [JsonProperty("cId")]
         public virtual int? CId { get; set; }
     }
 
@@ -52,10 +58,8 @@ namespace Microsoft.Quantum.IQSharp.Core.ExecutionPathTracer
         /// <param name="qId">
         /// Id of qubit register.
         /// </param>
-        public QubitRegister(int qId)
-        {
+        public QubitRegister(int qId) =>
             this.QId = qId;
-        }
 
         public override RegisterType Type => RegisterType.Qubit;
     }

--- a/src/Core/ExecutionPathTracer/Register.cs
+++ b/src/Core/ExecutionPathTracer/Register.cs
@@ -9,7 +9,7 @@ using Newtonsoft.Json.Serialization;
 namespace Microsoft.Quantum.IQSharp.Core.ExecutionPathTracer
 {
     /// <summary>
-    /// Enum for the 2 types of registers: Qubit and Classical.
+    /// Enum for the 2 types of registers: <c>Qubit</c> and <c>Classical</c>.
     /// </summary>
     public enum RegisterType
     {
@@ -32,19 +32,19 @@ namespace Microsoft.Quantum.IQSharp.Core.ExecutionPathTracer
         /// Type of register.
         /// </summary>
         [JsonProperty("type")]
-        public virtual RegisterType Type { get; set; }
+        public virtual RegisterType Type { get; }
 
         /// <summary>
         /// Qubit id of register.
         /// </summary>
         [JsonProperty("qId")]
-        public virtual int QId { get; set; }
+        public virtual int QId { get; protected set; }
 
         /// <summary>
         /// Classical bit id of register. <c>null</c> if register is a qubit register.
         /// </summary>
         [JsonProperty("cId")]
-        public virtual int? CId { get; set; }
+        public virtual int? CId { get; protected set; }
     }
 
     /// <summary>
@@ -58,9 +58,9 @@ namespace Microsoft.Quantum.IQSharp.Core.ExecutionPathTracer
         /// <param name="qId">
         /// Id of qubit register.
         /// </param>
-        public QubitRegister(int qId) =>
-            this.QId = qId;
+        public QubitRegister(int qId) => this.QId = qId;
 
+        /// <inheritdoc/>
         public override RegisterType Type => RegisterType.Qubit;
     }
 
@@ -84,6 +84,7 @@ namespace Microsoft.Quantum.IQSharp.Core.ExecutionPathTracer
             this.CId = cId;
         }
 
+        /// <inheritdoc/>
         public override RegisterType Type => RegisterType.Classical;
     }
 }

--- a/src/Kernel/Extensions.cs
+++ b/src/Kernel/Extensions.cs
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Jupyter.Core;
 using Microsoft.Quantum.IQSharp.Jupyter;
+using Microsoft.Quantum.Simulation.Common;
 
 namespace Microsoft.Quantum.IQSharp.Kernel
 {
@@ -23,6 +23,17 @@ namespace Microsoft.Quantum.IQSharp.Kernel
             services.AddSingleton<IMagicSymbolResolver, Kernel.MagicSymbolResolver>();
             services.AddSingleton<IExecutionEngine, Kernel.IQSharpEngine>();
             services.AddSingleton<IConfigurationSource, ConfigurationSource>();
+        }
+
+        /// <summary>
+        ///     Attaches <c>ExecutionPathTracer</c> event listeners to the simulator to generate
+        ///     the <c>ExecutionPath</c> of the operation performed by the simulator.
+        /// </summary>
+        public static T WithExecutionPathTracer<T>(this T sim, ExecutionPathTracer tracer) where T : SimulatorBase
+        {
+            sim.OnOperationStart += tracer.OnOperationStartHandler;
+            sim.OnOperationEnd += tracer.OnOperationEndHandler;
+            return sim;
         }
     }
 }

--- a/src/Kernel/Extensions.cs
+++ b/src/Kernel/Extensions.cs
@@ -4,7 +4,6 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Jupyter.Core;
 using Microsoft.Quantum.IQSharp.Jupyter;
-using Microsoft.Quantum.Simulation.Common;
 
 namespace Microsoft.Quantum.IQSharp.Kernel
 {
@@ -23,17 +22,6 @@ namespace Microsoft.Quantum.IQSharp.Kernel
             services.AddSingleton<IMagicSymbolResolver, Kernel.MagicSymbolResolver>();
             services.AddSingleton<IExecutionEngine, Kernel.IQSharpEngine>();
             services.AddSingleton<IConfigurationSource, ConfigurationSource>();
-        }
-
-        /// <summary>
-        ///     Attaches <c>ExecutionPathTracer</c> event listeners to the simulator to generate
-        ///     the <c>ExecutionPath</c> of the operation performed by the simulator.
-        /// </summary>
-        public static T WithExecutionPathTracer<T>(this T sim, ExecutionPathTracer tracer) where T : SimulatorBase
-        {
-            sim.OnOperationStart += tracer.OnOperationStartHandler;
-            sim.OnOperationEnd += tracer.OnOperationEndHandler;
-            return sim;
         }
     }
 }

--- a/src/Kernel/client/ExecutionPathVisualizer/executionPath.ts
+++ b/src/Kernel/client/ExecutionPathVisualizer/executionPath.ts
@@ -25,8 +25,8 @@ export interface Qubit {
 export interface Operation {
     /** Gate label. */
     gate: string;
-    /** Gate arguments as string. */
-    argStr?: string,
+    /** Formatted gate arguments to be displayed. */
+    displayArgs?: string,
     /** Classically-controlled gates.
      *  - children[0]: gates when classical control bit is 0.
      *  - children[1]: gates when classical control bit is 1.

--- a/src/Kernel/client/ExecutionPathVisualizer/formatters/gateFormatter.ts
+++ b/src/Kernel/client/ExecutionPathVisualizer/formatters/gateFormatter.ts
@@ -42,12 +42,12 @@ const formatGates = (opsMetadata: Metadata[]): string => {
  * @returns SVG representation of gate.
  */
 const _formatGate = (metadata: Metadata): string => {
-    const { type, x, controlsY, targetsY, label, argStr, width } = metadata;
+    const { type, x, controlsY, targetsY, label, displayArgs, width } = metadata;
     switch (type) {
         case GateType.Measure:
             return _measure(x, controlsY[0], targetsY[0]);
         case GateType.Unitary:
-            return _unitary(label, x, targetsY, width, argStr);
+            return _unitary(label, x, targetsY, width, displayArgs);
         case GateType.Swap:
             if (controlsY.length > 0) return _controlledGate(metadata);
             else return _swap(x, targetsY);
@@ -89,12 +89,12 @@ const _measure = (x: number, qy: number, cy: number): string => {
  * @param x                x coord of gate.
  * @param y                Array of y coords of registers acted upon by gate.
  * @param width            Width of gate.
- * @param argStr           Arguments passed in to gate.
+ * @param displayArgs           Arguments passed in to gate.
  * @param renderDashedLine If true, draw dashed lines between non-adjacent unitaries.
  * 
  * @returns SVG representation of unitary gate.
  */
-const _unitary = (label: string, x: number, y: number[], width: number, argStr?: string, renderDashedLine: boolean = true): string => {
+const _unitary = (label: string, x: number, y: number[], width: number, displayArgs?: string, renderDashedLine: boolean = true): string => {
     if (y.length === 0) return "";
 
     // Sort y in ascending order
@@ -116,7 +116,7 @@ const _unitary = (label: string, x: number, y: number[], width: number, argStr?:
     const unitaryBoxes: string[] = regGroups.map((group: number[]) => {
         const maxY: number = group[group.length - 1], minY: number = group[0];
         const height: number = maxY - minY + gateHeight;
-        return _unitaryBox(label, x, minY, width, height, argStr);
+        return _unitaryBox(label, x, minY, width, height, displayArgs);
     });
 
     // Draw dashed line between disconnected unitaries
@@ -135,19 +135,19 @@ const _unitary = (label: string, x: number, y: number[], width: number, argStr?:
  * @param y      y coord of gate.
  * @param width  Width of gate.
  * @param height Height of gate.
- * @param argStr Arguments passed in to gate.
+ * @param displayArgs Arguments passed in to gate.
  * 
  * @returns SVG representation of unitary box.
  */
-const _unitaryBox = (label: string, x: number, y: number, width: number, height: number = gateHeight, argStr?: string): string => {
+const _unitaryBox = (label: string, x: number, y: number, width: number, height: number = gateHeight, displayArgs?: string): string => {
     y -= gateHeight / 2;
     const uBox: string = box(x - width / 2, y, width, height);
-    const labelY = y + height / 2 - ((argStr == null) ? 0 : 7);
+    const labelY = y + height / 2 - ((displayArgs == null) ? 0 : 7);
     const labelText: string = text(label, x, labelY);
     const elems = [uBox, labelText];
-    if (argStr != null) {
+    if (displayArgs != null) {
         const argStrY = y + height / 2 + 8;
-        const argText: string = text(argStr, x, argStrY, argsFontSize);
+        const argText: string = text(displayArgs, x, argStrY, argsFontSize);
         elems.push(argText);
     }
     const svg: string = group(elems);
@@ -194,7 +194,7 @@ const _cross = (x: number, y: number): string => {
  */
 const _controlledGate = (metadata: Metadata): string => {
     const targetGateSvgs: string[] = [];
-    const { type, x, controlsY, targetsY, label, argStr, width } = metadata;
+    const { type, x, controlsY, targetsY, label, displayArgs, width } = metadata;
     // Get SVG for target gates
     switch (type) {
         case GateType.Cnot:
@@ -204,7 +204,7 @@ const _controlledGate = (metadata: Metadata): string => {
             targetsY.forEach(y => targetGateSvgs.push(_cross(x, y)));
             break;
         case GateType.ControlledUnitary:
-            targetGateSvgs.push(_unitary(label, x, targetsY, width, argStr, false));
+            targetGateSvgs.push(_unitary(label, x, targetsY, width, displayArgs, false));
             break;
         default:
             throw new Error(`ERROR: Unrecognized gate: ${label} of type ${type}`);

--- a/src/Kernel/client/ExecutionPathVisualizer/metadata.ts
+++ b/src/Kernel/client/ExecutionPathVisualizer/metadata.ts
@@ -16,7 +16,7 @@ export interface Metadata {
     /** Gate label. */
     label: string;
     /** Gate arguments as string. */
-    argStr?: string,
+    displayArgs?: string,
     /** Gate width. */
     width: number;
     /** Classically-controlled gates.

--- a/src/Kernel/client/ExecutionPathVisualizer/process.ts
+++ b/src/Kernel/client/ExecutionPathVisualizer/process.ts
@@ -185,7 +185,7 @@ const _opToMetadata = (op: Operation | null, registers: RegisterMap): Metadata =
 
     if (op == null) return metadata;
 
-    let { gate, argStr, controlled, adjoint, controls, targets, children } = op;
+    let { gate, displayArgs, controlled, adjoint, controls, targets, children } = op;
 
     // Set y coords
     metadata.controlsY = controls.map(reg => _getRegY(reg, registers));
@@ -233,7 +233,7 @@ const _opToMetadata = (op: Operation | null, registers: RegisterMap): Metadata =
     if (adjoint && metadata.label.length > 0) metadata.label += "'";
 
     // If gate has extra arguments, display them
-    if (argStr != null) metadata.argStr = argStr;
+    if (displayArgs != null) metadata.displayArgs = displayArgs;
 
     // Set gate width
     metadata.width = getGateWidth(metadata);

--- a/src/Kernel/client/ExecutionPathVisualizer/utils.ts
+++ b/src/Kernel/client/ExecutionPathVisualizer/utils.ts
@@ -14,7 +14,7 @@ import {
  * 
  * @returns Width of given gate (in pixels).
  */
-const getGateWidth = ({ type, label, argStr, width }: Metadata): number => {
+const getGateWidth = ({ type, label, displayArgs, width }: Metadata): number => {
     switch (type) {
         case GateType.ClassicalControlled:
             // Already computed before.
@@ -25,7 +25,7 @@ const getGateWidth = ({ type, label, argStr, width }: Metadata): number => {
             return minGateWidth;
         default:
             const labelWidth = _getStringWidth(label);
-            const argsWidth = (argStr != null) ? _getStringWidth(argStr, argsFontSize) : 0;
+            const argsWidth = (displayArgs != null) ? _getStringWidth(displayArgs, argsFontSize) : 0;
             const textWidth = Math.max(labelWidth, argsWidth) + labelPadding * 2;
             return Math.max(minGateWidth, textWidth);
     }

--- a/src/Kernel/client/__tests__/ExecutionPathVisualizerTests/gateFormatter.test.ts
+++ b/src/Kernel/client/__tests__/ExecutionPathVisualizerTests/gateFormatter.test.ts
@@ -449,7 +449,7 @@ describe("Testing _formatGate", () => {
             controlsY: [],
             targetsY: [startY],
             label: 'Ry',
-            argStr: '(0.25)',
+            displayArgs: '(0.25)',
             width: 52,
         };
         expect(_formatGate(metadata)).toMatchSnapshot();
@@ -473,7 +473,7 @@ describe("Testing _formatGate", () => {
             controlsY: [],
             targetsY: [startY, startY + registerHeight],
             label: 'U',
-            argStr: "('foo', 'bar')",
+            displayArgs: "('foo', 'bar')",
             width: 77,
         };
         expect(_formatGate(metadata)).toMatchSnapshot();
@@ -529,7 +529,7 @@ describe("Testing _formatGate", () => {
             controlsY: [startY],
             targetsY: [startY + registerHeight],
             label: 'U',
-            argStr: "('foo', 'bar')",
+            displayArgs: "('foo', 'bar')",
             width: 77,
         };
         expect(_formatGate(metadata)).toMatchSnapshot();

--- a/src/Kernel/client/__tests__/ExecutionPathVisualizerTests/process.test.ts
+++ b/src/Kernel/client/__tests__/ExecutionPathVisualizerTests/process.test.ts
@@ -513,7 +513,7 @@ describe("Testing _opToMetadata", () => {
         };
         let op: Operation = {
             gate: "RX",
-            argStr: "(0.25)",
+            displayArgs: "(0.25)",
             controlled: false,
             adjoint: false,
             controls: [],
@@ -525,7 +525,7 @@ describe("Testing _opToMetadata", () => {
             controlsY: [],
             targetsY: [startY],
             label: "RX",
-            argStr: "(0.25)",
+            displayArgs: "(0.25)",
             width: 52
         };
         expect(_opToMetadata(op, registers)).toEqual(metadata);
@@ -533,7 +533,7 @@ describe("Testing _opToMetadata", () => {
         // Test long argument
         op = {
             gate: "RX",
-            argStr: "(0.25, 1.0, 'foobar', (3.14, 6.67))",
+            displayArgs: "(0.25, 1.0, 'foobar', (3.14, 6.67))",
             controlled: false,
             adjoint: false,
             controls: [],
@@ -545,7 +545,7 @@ describe("Testing _opToMetadata", () => {
             controlsY: [],
             targetsY: [startY],
             label: "RX",
-            argStr: "(0.25, 1.0, 'foobar', (3.14, 6.67))",
+            displayArgs: "(0.25, 1.0, 'foobar', (3.14, 6.67))",
             width: 188
         };
         expect(_opToMetadata(op, registers)).toEqual(metadata);
@@ -553,7 +553,7 @@ describe("Testing _opToMetadata", () => {
         // Test controlled
         op = {
             gate: "RX",
-            argStr: "(0.25)",
+            displayArgs: "(0.25)",
             controlled: true,
             adjoint: false,
             controls: [{ type: RegisterType.Qubit, qId: 1 }],
@@ -565,7 +565,7 @@ describe("Testing _opToMetadata", () => {
             controlsY: [startY + registerHeight],
             targetsY: [startY],
             label: "RX",
-            argStr: "(0.25)",
+            displayArgs: "(0.25)",
             width: 52
         };
         expect(_opToMetadata(op, registers)).toEqual(metadata);
@@ -578,7 +578,7 @@ describe("Testing _opToMetadata", () => {
         };
         let op: Operation = {
             gate: "U",
-            argStr: "('foo', 'bar')",
+            displayArgs: "('foo', 'bar')",
             controlled: false,
             adjoint: false,
             controls: [],
@@ -593,7 +593,7 @@ describe("Testing _opToMetadata", () => {
             controlsY: [],
             targetsY: [startY, startY + registerHeight],
             label: "U",
-            argStr: "('foo', 'bar')",
+            displayArgs: "('foo', 'bar')",
             width: 77
         };
         expect(_opToMetadata(op, registers)).toEqual(metadata);
@@ -601,7 +601,7 @@ describe("Testing _opToMetadata", () => {
         // Test long argument
         op = {
             gate: "U",
-            argStr: "(0.25, 1.0, 'foobar', (3.14, 6.67))",
+            displayArgs: "(0.25, 1.0, 'foobar', (3.14, 6.67))",
             controlled: false,
             adjoint: false,
             controls: [],
@@ -616,7 +616,7 @@ describe("Testing _opToMetadata", () => {
             controlsY: [],
             targetsY: [startY, startY + registerHeight],
             label: "U",
-            argStr: "(0.25, 1.0, 'foobar', (3.14, 6.67))",
+            displayArgs: "(0.25, 1.0, 'foobar', (3.14, 6.67))",
             width: 188
         };
         expect(_opToMetadata(op, registers)).toEqual(metadata);
@@ -624,7 +624,7 @@ describe("Testing _opToMetadata", () => {
         // Test controlled
         op = {
             gate: "U",
-            argStr: "('foo', 'bar')",
+            displayArgs: "('foo', 'bar')",
             controlled: true,
             adjoint: false,
             controls: [{ type: RegisterType.Qubit, qId: 1 }],
@@ -639,7 +639,7 @@ describe("Testing _opToMetadata", () => {
             controlsY: [startY + registerHeight],
             targetsY: [startY, startY + registerHeight * 2],
             label: "U",
-            argStr: "('foo', 'bar')",
+            displayArgs: "('foo', 'bar')",
             width: 77
         };
         expect(_opToMetadata(op, registers)).toEqual(metadata);
@@ -1192,7 +1192,7 @@ describe("Testing processOperations", () => {
             },
             {
                 gate: "RX",
-                argStr: "(0.25)",
+                displayArgs: "(0.25)",
                 controlled: false,
                 adjoint: false,
                 controls: [],
@@ -1234,7 +1234,7 @@ describe("Testing processOperations", () => {
                 controlsY: [],
                 targetsY: [startY + registerHeight],
                 label: "RX",
-                argStr: "(0.25)",
+                displayArgs: "(0.25)",
                 width: rxWidth,
             }
         ];

--- a/src/Kernel/client/__tests__/ExecutionPathVisualizerTests/utils.test.ts
+++ b/src/Kernel/client/__tests__/ExecutionPathVisualizerTests/utils.test.ts
@@ -27,7 +27,7 @@ describe("Testing getGateWidth", () => {
         expect(getGateWidth(Object.assign({ type: GateType.Unitary, label: 'zz' })))
             .toEqual(minGateWidth));
     test("unitary gate with arguments", () =>
-        expect(getGateWidth(Object.assign({ type: GateType.Unitary, argStr: '(0.25)', label: 'RX' })))
+        expect(getGateWidth(Object.assign({ type: GateType.Unitary, displayArgs: '(0.25)', label: 'RX' })))
             .toEqual(52));
     test("invalid", () =>
         expect(getGateWidth(Object.assign({ type: GateType.Invalid, label: '' })))

--- a/src/Kernel/tsconfig.json
+++ b/src/Kernel/tsconfig.json
@@ -12,6 +12,6 @@
     "module": "AMD",
     "moduleResolution": "node"
   },
-  "exclude": ["node_modules", "wwwroot", "client/__test__"],
+  "exclude": ["node_modules", "wwwroot", "client/__tests__"],
   "include": ["client/**/*"]
 }

--- a/src/Tests/ExecutionPathTracerTests.cs
+++ b/src/Tests/ExecutionPathTracerTests.cs
@@ -159,7 +159,7 @@ namespace Tests.IQSharp
                 new Operation()
                 {
                     Gate = "Rx",
-                    ArgStr = "(2)",
+                    DisplayArgs = "(2)",
                     Targets = new List<Register>() { new QubitRegister(0) },
                 },
             };
@@ -252,7 +252,7 @@ namespace Tests.IQSharp
                 new Operation()
                 {
                     Gate = "Foo",
-                    ArgStr = "(2.1,(bar))",
+                    DisplayArgs = "(2.1, (bar))",
                     Targets = new List<Register>() { new QubitRegister(0) },
                 },
             };
@@ -274,7 +274,7 @@ namespace Tests.IQSharp
                 new Operation()
                 {
                     Gate = "Foo",
-                    ArgStr = "(2.1,(bar))",
+                    DisplayArgs = "(2.1, (bar))",
                     Controlled = true,
                     Controls = new List<Register>() { new QubitRegister(0) },
                     Targets = new List<Register>() { new QubitRegister(1) },
@@ -365,7 +365,7 @@ namespace Tests.IQSharp
                 new Operation()
                 {
                     Gate = "Ry",
-                    ArgStr = "(2.5)",
+                    DisplayArgs = "(2.5)",
                     Targets = new List<Register>() { new QubitRegister(0) },
                 },
             };
@@ -403,13 +403,13 @@ namespace Tests.IQSharp
                 new Operation()
                 {
                     Gate = "Ry",
-                    ArgStr = "(2.5)",
+                    DisplayArgs = "(2.5)",
                     Targets = new List<Register>() { new QubitRegister(1) },
                 },
                 new Operation()
                 {
                     Gate = "Bar",
-                    ArgStr = "((1,2.1),(foo))",
+                    DisplayArgs = "((1, 2.1), (foo))",
                     Targets = new List<Register>() { new QubitRegister(0) },
                 },
                 new Operation()
@@ -434,7 +434,7 @@ namespace Tests.IQSharp
                 new Operation()
                 {
                     Gate = "Bar",
-                    ArgStr = "((1,2.1),(foo))",
+                    DisplayArgs = "((1, 2.1), (foo))",
                     Controlled = true,
                     Adjoint = true,
                     Controls = new List<Register>() { new QubitRegister(2) },

--- a/src/Tests/ExecutionPathTracerTests.cs
+++ b/src/Tests/ExecutionPathTracerTests.cs
@@ -24,9 +24,7 @@ namespace Tests.IQSharp
         public ExecutionPath GetExecutionPath(string name, int depth = 1)
         {
             var ws = InitWorkspace();
-            var ops = ws.AssemblyInfo.Operations;
-            var names = ws.AssemblyInfo.Operations.Select(o => o.FullName);
-            var op = ws.AssemblyInfo.Operations.Single(o => o.FullName == name);
+            var op = ws.AssemblyInfo.Operations.SingleOrDefault(o => o.FullName == $"Tests.ExecutionPathTracer.{name}");
             Assert.IsNotNull(op);
 
             var tracer = new ExecutionPathTracer(depth);
@@ -52,9 +50,15 @@ namespace Tests.IQSharp
                     Gate = "H",
                     Targets = new List<Register>() { new QubitRegister(0) },
                 },
+                // TODO: Remove Reset/ResetAll gates once we don't need to zero out qubits
+                new Operation()
+                {
+                    Gate = "Reset",
+                    Targets = new List<Register>() { new QubitRegister(0) },
+                },
             };
             var expected = new ExecutionPath(qubits, operations);
-            Assert.AreEqual(path.ToJson(), expected.ToJson());
+            Assert.AreEqual(expected.ToJson(), path.ToJson());
         }
 
         [TestMethod]
@@ -75,7 +79,7 @@ namespace Tests.IQSharp
                 },
             };
             var expected = new ExecutionPath(qubits, operations);
-            Assert.AreEqual(path.ToJson(), expected.ToJson());
+            Assert.AreEqual(expected.ToJson(), path.ToJson());
         }
 
         [TestMethod]
@@ -96,9 +100,14 @@ namespace Tests.IQSharp
                     Controls = new List<Register>() { new QubitRegister(0) },
                     Targets = new List<Register>() { new QubitRegister(1) },
                 },
+                new Operation()
+                {
+                    Gate = "ResetAll",
+                    Targets = new List<Register>() { new QubitRegister(0), new QubitRegister(1) },
+                },
             };
             var expected = new ExecutionPath(qubits, operations);
-            Assert.AreEqual(path.ToJson(), expected.ToJson());
+            Assert.AreEqual(expected.ToJson(), path.ToJson());
         }
 
         [TestMethod]
@@ -120,9 +129,19 @@ namespace Tests.IQSharp
                     Controls = new List<Register>() { new QubitRegister(0), new QubitRegister(2) },
                     Targets = new List<Register>() { new QubitRegister(1) },
                 },
+                new Operation()
+                {
+                    Gate = "ResetAll",
+                    Targets = new List<Register>()
+                    {
+                        new QubitRegister(0),
+                        new QubitRegister(1),
+                        new QubitRegister(2),
+                    },
+                },
             };
             var expected = new ExecutionPath(qubits, operations);
-            Assert.AreEqual(path.ToJson(), expected.ToJson());
+            Assert.AreEqual(expected.ToJson(), path.ToJson());
         }
 
         [TestMethod]
@@ -143,7 +162,7 @@ namespace Tests.IQSharp
                 },
             };
             var expected = new ExecutionPath(qubits, operations);
-            Assert.AreEqual(path.ToJson(), expected.ToJson());
+            Assert.AreEqual(expected.ToJson(), path.ToJson());
         }
 
         [TestMethod]
@@ -162,9 +181,14 @@ namespace Tests.IQSharp
                     DisplayArgs = "(2)",
                     Targets = new List<Register>() { new QubitRegister(0) },
                 },
+                new Operation()
+                {
+                    Gate = "Reset",
+                    Targets = new List<Register>() { new QubitRegister(0) },
+                },
             };
             var expected = new ExecutionPath(qubits, operations);
-            Assert.AreEqual(path.ToJson(), expected.ToJson());
+            Assert.AreEqual(expected.ToJson(), path.ToJson());
         }
 
         [TestMethod]
@@ -183,9 +207,14 @@ namespace Tests.IQSharp
                     Adjoint = true,
                     Targets = new List<Register>() { new QubitRegister(0) },
                 },
+                new Operation()
+                {
+                    Gate = "Reset",
+                    Targets = new List<Register>() { new QubitRegister(0) },
+                },
             };
             var expected = new ExecutionPath(qubits, operations);
-            Assert.AreEqual(path.ToJson(), expected.ToJson());
+            Assert.AreEqual(expected.ToJson(), path.ToJson());
         }
 
         [TestMethod]
@@ -206,9 +235,14 @@ namespace Tests.IQSharp
                     Controls = new List<Register>() { new QubitRegister(0) },
                     Targets = new List<Register>() { new QubitRegister(1) },
                 },
+                new Operation()
+                {
+                    Gate = "ResetAll",
+                    Targets = new List<Register>() { new QubitRegister(0), new QubitRegister(1) },
+                },
             };
             var expected = new ExecutionPath(qubits, operations);
-            Assert.AreEqual(path.ToJson(), expected.ToJson());
+            Assert.AreEqual(expected.ToJson(), path.ToJson());
 
             // JSON should be the same as CNOT's
             var path2 = GetExecutionPath("CnotCirc");
@@ -234,9 +268,14 @@ namespace Tests.IQSharp
                     Controls = new List<Register>() { new QubitRegister(0) },
                     Targets = new List<Register>() { new QubitRegister(1) },
                 },
+                new Operation()
+                {
+                    Gate = "ResetAll",
+                    Targets = new List<Register>() { new QubitRegister(0), new QubitRegister(1) },
+                },
             };
             var expected = new ExecutionPath(qubits, operations);
-            Assert.AreEqual(path.ToJson(), expected.ToJson());
+            Assert.AreEqual(expected.ToJson(), path.ToJson());
         }
 
         [TestMethod]
@@ -252,12 +291,12 @@ namespace Tests.IQSharp
                 new Operation()
                 {
                     Gate = "Foo",
-                    DisplayArgs = "(2.1, (bar))",
+                    DisplayArgs = "(2.1, (\"bar\"))",
                     Targets = new List<Register>() { new QubitRegister(0) },
                 },
             };
             var expected = new ExecutionPath(qubits, operations);
-            Assert.AreEqual(path.ToJson(), expected.ToJson());
+            Assert.AreEqual(expected.ToJson(), path.ToJson());
         }
 
         [TestMethod]
@@ -274,14 +313,14 @@ namespace Tests.IQSharp
                 new Operation()
                 {
                     Gate = "Foo",
-                    DisplayArgs = "(2.1, (bar))",
+                    DisplayArgs = "(2.1, (\"bar\"))",
                     Controlled = true,
                     Controls = new List<Register>() { new QubitRegister(0) },
                     Targets = new List<Register>() { new QubitRegister(1) },
                 },
             };
             var expected = new ExecutionPath(qubits, operations);
-            Assert.AreEqual(path.ToJson(), expected.ToJson());
+            Assert.AreEqual(expected.ToJson(), path.ToJson());
         }
 
         [TestMethod]
@@ -302,9 +341,19 @@ namespace Tests.IQSharp
                     Controls = new List<Register>() { new QubitRegister(2) },
                     Targets = new List<Register>() { new QubitRegister(0) },
                 },
+                new Operation()
+                {
+                    Gate = "Reset",
+                    Targets = new List<Register>() { new QubitRegister(0) },
+                },
+                new Operation()
+                {
+                    Gate = "Reset",
+                    Targets = new List<Register>() { new QubitRegister(2) },
+                },
             };
             var expected = new ExecutionPath(qubits, operations);
-            Assert.AreEqual(path.ToJson(), expected.ToJson());
+            Assert.AreEqual(expected.ToJson(), path.ToJson());
         }
 
         [TestMethod]
@@ -340,7 +389,7 @@ namespace Tests.IQSharp
                 },
             };
             var expected = new ExecutionPath(qubits, operations);
-            Assert.AreEqual(path.ToJson(), expected.ToJson());
+            Assert.AreEqual(expected.ToJson(), path.ToJson());
         }
 
         [TestMethod]
@@ -368,9 +417,18 @@ namespace Tests.IQSharp
                     DisplayArgs = "(2.5)",
                     Targets = new List<Register>() { new QubitRegister(0) },
                 },
+                new Operation()
+                {
+                    Gate = "ResetAll",
+                    Targets = new List<Register>() {
+                        new QubitRegister(0),
+                        new QubitRegister(1),
+                        new QubitRegister(2),
+                    },
+                },
             };
             var expected = new ExecutionPath(qubits, operations);
-            Assert.AreEqual(path.ToJson(), expected.ToJson());
+            Assert.AreEqual(expected.ToJson(), path.ToJson());
         }
 
         [TestMethod]
@@ -380,7 +438,7 @@ namespace Tests.IQSharp
             var qubits = new QubitDeclaration[] { };
             var operations = new Operation[] { };
             var expected = new ExecutionPath(qubits, operations);
-            Assert.AreEqual(path.ToJson(), expected.ToJson());
+            Assert.AreEqual(expected.ToJson(), path.ToJson());
         }
 
         [TestMethod]
@@ -409,7 +467,7 @@ namespace Tests.IQSharp
                 new Operation()
                 {
                     Gate = "Bar",
-                    DisplayArgs = "((1, 2.1), (foo))",
+                    DisplayArgs = "((1, 2.1), (\"foo\"))",
                     Targets = new List<Register>() { new QubitRegister(0) },
                 },
                 new Operation()
@@ -434,7 +492,7 @@ namespace Tests.IQSharp
                 new Operation()
                 {
                     Gate = "Bar",
-                    DisplayArgs = "((1, 2.1), (foo))",
+                    DisplayArgs = "((1, 2.1), (\"foo\"))",
                     Controlled = true,
                     Adjoint = true,
                     Controls = new List<Register>() { new QubitRegister(2) },
@@ -446,9 +504,18 @@ namespace Tests.IQSharp
                     Controls = new List<Register>() { new QubitRegister(0) },
                     Targets = new List<Register>() { new ClassicalRegister(0, 0) },
                 },
+                new Operation()
+                {
+                    Gate = "ResetAll",
+                    Targets = new List<Register>() {
+                        new QubitRegister(0),
+                        new QubitRegister(1),
+                        new QubitRegister(2),
+                    },
+                },
             };
             var expected = new ExecutionPath(qubits, operations);
-            Assert.AreEqual(path.ToJson(), expected.ToJson());
+            Assert.AreEqual(expected.ToJson(), path.ToJson());
         }
     }
 }

--- a/src/Tests/ExecutionPathTracerTests.cs
+++ b/src/Tests/ExecutionPathTracerTests.cs
@@ -1,0 +1,454 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.Quantum.IQSharp;
+using Microsoft.Quantum.Simulation.Simulators;
+using Microsoft.Quantum.IQSharp.Core.ExecutionPathTracer;
+
+namespace Tests.IQSharp
+{
+    [TestClass]
+    public class IntrinsicTests
+    {
+        public Workspace InitWorkspace()
+        {
+            var ws = Startup.Create<Workspace>("Workspace.ExecutionPathTracer");
+            ws.Reload();
+            Assert.IsFalse(ws.HasErrors);
+            return ws;
+        }
+
+        public ExecutionPath GetExecutionPath(string name, int depth = 1)
+        {
+            var ws = InitWorkspace();
+            var ops = ws.AssemblyInfo.Operations;
+            var names = ws.AssemblyInfo.Operations.Select(o => o.FullName);
+            var op = ws.AssemblyInfo.Operations.Single(o => o.FullName == name);
+            Assert.IsNotNull(op);
+
+            var tracer = new ExecutionPathTracer(depth);
+            using var qsim = new QuantumSimulator().WithExecutionPathTracer(tracer);
+            op.RunAsync(qsim, new Dictionary<string, string>()).Wait();
+
+            return tracer.GetExecutionPath();
+        }
+
+
+        [TestMethod]
+        public void HTest()
+        {
+            var path = GetExecutionPath("HCirc");
+            var qubits = new QubitDeclaration[]
+            {
+                new QubitDeclaration(0),
+            };
+            var operations = new Operation[]
+            {
+                new Operation()
+                {
+                    Gate = "H",
+                    Targets = new List<Register>() { new QubitRegister(0) },
+                },
+            };
+            var expected = new ExecutionPath(qubits, operations);
+            Assert.AreEqual(path.ToJson(), expected.ToJson());
+        }
+
+        [TestMethod]
+        public void MTest()
+        {
+            var path = GetExecutionPath("MCirc");
+            var qubits = new QubitDeclaration[]
+            {
+                new QubitDeclaration(0, 1),
+            };
+            var operations = new Operation[]
+            {
+                new Operation()
+                {
+                    Gate = "measure",
+                    Controls = new List<Register>() { new QubitRegister(0) },
+                    Targets = new List<Register>() { new ClassicalRegister(0, 0) },
+                },
+            };
+            var expected = new ExecutionPath(qubits, operations);
+            Assert.AreEqual(path.ToJson(), expected.ToJson());
+        }
+
+        [TestMethod]
+        public void CnotTest()
+        {
+            var path = GetExecutionPath("CnotCirc");
+            var qubits = new QubitDeclaration[]
+            {
+                new QubitDeclaration(0),
+                new QubitDeclaration(1),
+            };
+            var operations = new Operation[]
+            {
+                new Operation()
+                {
+                    Gate = "X",
+                    Controlled = true,
+                    Controls = new List<Register>() { new QubitRegister(0) },
+                    Targets = new List<Register>() { new QubitRegister(1) },
+                },
+            };
+            var expected = new ExecutionPath(qubits, operations);
+            Assert.AreEqual(path.ToJson(), expected.ToJson());
+        }
+
+        [TestMethod]
+        public void CcnotTest()
+        {
+            var path = GetExecutionPath("CcnotCirc");
+            var qubits = new QubitDeclaration[]
+            {
+                new QubitDeclaration(0),
+                new QubitDeclaration(1),
+                new QubitDeclaration(2),
+            };
+            var operations = new Operation[]
+            {
+                new Operation()
+                {
+                    Gate = "X",
+                    Controlled = true,
+                    Controls = new List<Register>() { new QubitRegister(0), new QubitRegister(2) },
+                    Targets = new List<Register>() { new QubitRegister(1) },
+                },
+            };
+            var expected = new ExecutionPath(qubits, operations);
+            Assert.AreEqual(path.ToJson(), expected.ToJson());
+        }
+
+        [TestMethod]
+        public void SwapTest()
+        {
+            var path = GetExecutionPath("SwapCirc");
+            var qubits = new QubitDeclaration[]
+            {
+                new QubitDeclaration(0),
+                new QubitDeclaration(1),
+            };
+            var operations = new Operation[]
+            {
+                new Operation()
+                {
+                    Gate = "SWAP",
+                    Targets = new List<Register>() { new QubitRegister(0), new QubitRegister(1) },
+                },
+            };
+            var expected = new ExecutionPath(qubits, operations);
+            Assert.AreEqual(path.ToJson(), expected.ToJson());
+        }
+
+        [TestMethod]
+        public void RxTest()
+        {
+            var path = GetExecutionPath("RxCirc");
+            var qubits = new QubitDeclaration[]
+            {
+                new QubitDeclaration(0),
+            };
+            var operations = new Operation[]
+            {
+                new Operation()
+                {
+                    Gate = "Rx",
+                    ArgStr = "(2)",
+                    Targets = new List<Register>() { new QubitRegister(0) },
+                },
+            };
+            var expected = new ExecutionPath(qubits, operations);
+            Assert.AreEqual(path.ToJson(), expected.ToJson());
+        }
+
+        [TestMethod]
+        public void AdjointHTest()
+        {
+            var path = GetExecutionPath("AdjointHCirc");
+            var qubits = new QubitDeclaration[]
+            {
+                new QubitDeclaration(0),
+            };
+            var operations = new Operation[]
+            {
+                new Operation()
+                {
+                    Gate = "H",
+                    Adjoint = true,
+                    Targets = new List<Register>() { new QubitRegister(0) },
+                },
+            };
+            var expected = new ExecutionPath(qubits, operations);
+            Assert.AreEqual(path.ToJson(), expected.ToJson());
+        }
+
+        [TestMethod]
+        public void ControlledXTest()
+        {
+            var path = GetExecutionPath("ControlledXCirc");
+            var qubits = new QubitDeclaration[]
+            {
+                new QubitDeclaration(0),
+                new QubitDeclaration(1),
+            };
+            var operations = new Operation[]
+            {
+                new Operation()
+                {
+                    Gate = "X",
+                    Controlled = true,
+                    Controls = new List<Register>() { new QubitRegister(0) },
+                    Targets = new List<Register>() { new QubitRegister(1) },
+                },
+            };
+            var expected = new ExecutionPath(qubits, operations);
+            Assert.AreEqual(path.ToJson(), expected.ToJson());
+
+            // JSON should be the same as CNOT's
+            var path2 = GetExecutionPath("CnotCirc");
+            Assert.AreEqual(path.ToJson(), path2.ToJson());
+        }
+
+        [TestMethod]
+        public void ControlledAdjointSTest()
+        {
+            var path = GetExecutionPath("ControlledAdjointSCirc");
+            var qubits = new QubitDeclaration[]
+            {
+                new QubitDeclaration(0),
+                new QubitDeclaration(1),
+            };
+            var operations = new Operation[]
+            {
+                new Operation()
+                {
+                    Gate = "S",
+                    Controlled = true,
+                    Adjoint = true,
+                    Controls = new List<Register>() { new QubitRegister(0) },
+                    Targets = new List<Register>() { new QubitRegister(1) },
+                },
+            };
+            var expected = new ExecutionPath(qubits, operations);
+            Assert.AreEqual(path.ToJson(), expected.ToJson());
+        }
+
+        [TestMethod]
+        public void FooTest()
+        {
+            var path = GetExecutionPath("FooCirc");
+            var qubits = new QubitDeclaration[]
+            {
+                new QubitDeclaration(0),
+            };
+            var operations = new Operation[]
+            {
+                new Operation()
+                {
+                    Gate = "Foo",
+                    ArgStr = "(2.1,(bar))",
+                    Targets = new List<Register>() { new QubitRegister(0) },
+                },
+            };
+            var expected = new ExecutionPath(qubits, operations);
+            Assert.AreEqual(path.ToJson(), expected.ToJson());
+        }
+
+        [TestMethod]
+        public void ControlledFooTest()
+        {
+            var path = GetExecutionPath("ControlledFooCirc");
+            var qubits = new QubitDeclaration[]
+            {
+                new QubitDeclaration(0),
+                new QubitDeclaration(1),
+            };
+            var operations = new Operation[]
+            {
+                new Operation()
+                {
+                    Gate = "Foo",
+                    ArgStr = "(2.1,(bar))",
+                    Controlled = true,
+                    Controls = new List<Register>() { new QubitRegister(0) },
+                    Targets = new List<Register>() { new QubitRegister(1) },
+                },
+            };
+            var expected = new ExecutionPath(qubits, operations);
+            Assert.AreEqual(path.ToJson(), expected.ToJson());
+        }
+
+        [TestMethod]
+        public void UnusedQubitTest()
+        {
+            var path = GetExecutionPath("UnusedQubitCirc");
+            var qubits = new QubitDeclaration[]
+            {
+                new QubitDeclaration(0),
+                new QubitDeclaration(2),
+            };
+            var operations = new Operation[]
+            {
+                new Operation()
+                {
+                    Gate = "X",
+                    Controlled = true,
+                    Controls = new List<Register>() { new QubitRegister(2) },
+                    Targets = new List<Register>() { new QubitRegister(0) },
+                },
+            };
+            var expected = new ExecutionPath(qubits, operations);
+            Assert.AreEqual(path.ToJson(), expected.ToJson());
+        }
+
+        [TestMethod]
+        public void Depth2Test()
+        {
+            var path = GetExecutionPath("Depth2Circ", 2);
+            var qubits = new QubitDeclaration[]
+            {
+                new QubitDeclaration(0, 1),
+            };
+            var operations = new Operation[]
+            {
+                new Operation()
+                {
+                    Gate = "H",
+                    Targets = new List<Register>() { new QubitRegister(0) },
+                },
+                new Operation()
+                {
+                    Gate = "X",
+                    Targets = new List<Register>() { new QubitRegister(0) },
+                },
+                new Operation()
+                {
+                    Gate = "H",
+                    Targets = new List<Register>() { new QubitRegister(0) },
+                },
+                new Operation()
+                {
+                    Gate = "measure",
+                    Controls = new List<Register>() { new QubitRegister(0) },
+                    Targets = new List<Register>() { new ClassicalRegister(0, 0) },
+                },
+            };
+            var expected = new ExecutionPath(qubits, operations);
+            Assert.AreEqual(path.ToJson(), expected.ToJson());
+        }
+
+        [TestMethod]
+        public void PartialOpTest()
+        {
+            var path = GetExecutionPath("PartialOpCirc");
+            var qubits = new QubitDeclaration[]
+            {
+                new QubitDeclaration(0),
+                new QubitDeclaration(1),
+                new QubitDeclaration(2),
+            };
+            var operations = new Operation[]
+            {
+                new Operation()
+                {
+                    Gate = "H",
+                    Controlled = true,
+                    Controls = new List<Register>() { new QubitRegister(0), new QubitRegister(1) },
+                    Targets = new List<Register>() { new QubitRegister(2) },
+                },
+                new Operation()
+                {
+                    Gate = "Ry",
+                    ArgStr = "(2.5)",
+                    Targets = new List<Register>() { new QubitRegister(0) },
+                },
+            };
+            var expected = new ExecutionPath(qubits, operations);
+            Assert.AreEqual(path.ToJson(), expected.ToJson());
+        }
+
+        [TestMethod]
+        public void EmptyTest()
+        {
+            var path = GetExecutionPath("EmptyCirc");
+            var qubits = new QubitDeclaration[] { };
+            var operations = new Operation[] { };
+            var expected = new ExecutionPath(qubits, operations);
+            Assert.AreEqual(path.ToJson(), expected.ToJson());
+        }
+
+        [TestMethod]
+        public void BigTest()
+        {
+            var path = GetExecutionPath("BigCirc");
+            var qubits = new QubitDeclaration[]
+            {
+                new QubitDeclaration(0, 1),
+                new QubitDeclaration(1),
+                new QubitDeclaration(2),
+            };
+            var operations = new Operation[]
+            {
+                new Operation()
+                {
+                    Gate = "H",
+                    Targets = new List<Register>() { new QubitRegister(0) },
+                },
+                new Operation()
+                {
+                    Gate = "Ry",
+                    ArgStr = "(2.5)",
+                    Targets = new List<Register>() { new QubitRegister(1) },
+                },
+                new Operation()
+                {
+                    Gate = "Bar",
+                    ArgStr = "((1,2.1),(foo))",
+                    Targets = new List<Register>() { new QubitRegister(0) },
+                },
+                new Operation()
+                {
+                    Gate = "X",
+                    Targets = new List<Register>() { new QubitRegister(0) },
+                },
+                new Operation()
+                {
+                    Gate = "X",
+                    Controlled = true,
+                    Controls = new List<Register>() { new QubitRegister(0), new QubitRegister(1) },
+                    Targets = new List<Register>() { new QubitRegister(2) },
+                },
+                new Operation()
+                {
+                    Gate = "X",
+                    Controlled = true,
+                    Controls = new List<Register>() { new QubitRegister(0), new QubitRegister(1) },
+                    Targets = new List<Register>() { new QubitRegister(2) },
+                },
+                new Operation()
+                {
+                    Gate = "Bar",
+                    ArgStr = "((1,2.1),(foo))",
+                    Controlled = true,
+                    Adjoint = true,
+                    Controls = new List<Register>() { new QubitRegister(2) },
+                    Targets = new List<Register>() { new QubitRegister(0) },
+                },
+                new Operation()
+                {
+                    Gate = "measure",
+                    Controls = new List<Register>() { new QubitRegister(0) },
+                    Targets = new List<Register>() { new ClassicalRegister(0, 0) },
+                },
+            };
+            var expected = new ExecutionPath(qubits, operations);
+            Assert.AreEqual(path.ToJson(), expected.ToJson());
+        }
+    }
+}

--- a/src/Tests/Tests.IQsharp.csproj
+++ b/src/Tests/Tests.IQsharp.csproj
@@ -48,6 +48,12 @@
     <None Update="Workspace\NoOp.qs">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="Workspace.ExecutionPathTracer\Intrinsic.qs">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Workspace.ExecutionPathTracer\Measurement.qs">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
 </Project>

--- a/src/Tests/Workspace.ExecutionPathTracer/Intrinsic.qs
+++ b/src/Tests/Workspace.ExecutionPathTracer/Intrinsic.qs
@@ -86,7 +86,8 @@ namespace Tests.ExecutionPathTracer {
     operation UnusedQubitCirc() : Unit {
         using (qs = Qubit[3]) {
             CNOT(qs[2], qs[0]);
-            ResetAll(qs);
+            Reset(qs[0]);
+            Reset(qs[2]);
         }
     }
 

--- a/src/Tests/Workspace.ExecutionPathTracer/Intrinsic.qs
+++ b/src/Tests/Workspace.ExecutionPathTracer/Intrinsic.qs
@@ -1,0 +1,139 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Tests.ExecutionPathTracer {
+    
+    open Microsoft.Quantum.Intrinsic;
+
+    operation HCirc() : Unit {
+        using (q = Qubit()) {
+            H(q);
+            Reset(q);
+        }
+    }
+
+    operation MCirc() : Unit {
+        using (q = Qubit()) {
+            let res = M(q);
+        }
+    }
+
+    operation CnotCirc() : Unit {
+        using (qs = Qubit[2]) {
+            CNOT(qs[0], qs[1]);
+            ResetAll(qs);
+        }
+    }
+
+    operation CcnotCirc() : Unit {
+        using (qs = Qubit[3]) {
+            CCNOT(qs[0], qs[2], qs[1]);
+            ResetAll(qs);
+        }
+    }
+
+    operation SwapCirc() : Unit {
+        using (qs = Qubit[2]) {
+            SWAP(qs[0], qs[1]);
+        }
+    }
+
+    operation RxCirc() : Unit {
+        using (q = Qubit()) {
+            Rx(2.0, q);
+            Reset(q);
+        }
+    }
+
+    operation AdjointHCirc() : Unit {
+        using (q = Qubit()) {
+            Adjoint H(q);
+            Reset(q);
+        }
+    }
+
+    operation ControlledXCirc() : Unit {
+        using (qs = Qubit[2]) {
+            Controlled X([qs[0]], qs[1]);
+            ResetAll(qs);
+        }
+    }
+
+    operation ControlledAdjointSCirc() : Unit {
+        using (qs = Qubit[2]) {
+            Controlled Adjoint S([qs[0]], qs[1]);
+            ResetAll(qs);
+        }
+    }
+
+    // Custom operation
+    operation Foo(theta : Double, (qubit : Qubit, bar : String)) : Unit
+    is Adj + Ctl {
+    }
+
+    operation FooCirc() : Unit {
+        using (q = Qubit()) {
+            Foo(2.1, (q, "bar"));
+        }
+    }
+
+    operation ControlledFooCirc() : Unit {
+        using (qs = Qubit[2]) {
+            Controlled Foo([qs[0]], (2.1, (qs[1], "bar")));
+        }
+    }
+
+    operation UnusedQubitCirc() : Unit {
+        using (qs = Qubit[3]) {
+            CNOT(qs[2], qs[0]);
+            ResetAll(qs);
+        }
+    }
+
+    operation EmptyCirc() : Unit {
+        using (qs = Qubit[3]) {
+        }
+    }
+
+    operation FooBar(q : Qubit) : Unit {
+        H(q);
+        X(q);
+        H(q);
+    }
+
+    operation Depth2Circ() : Unit {
+        using (q = Qubit()) {
+            FooBar(q);
+            Reset(q);
+        }
+    }
+
+    operation PartialOpCirc() : Unit {
+        using (qs = Qubit[3]) {
+            (Controlled H(qs[0..1], _))(qs[2]);
+            ((Ry(_, _))(2.5, _))(qs[0]);
+            ResetAll(qs);
+        }
+    }
+
+    operation Bar((alpha : Double, beta : Double), (q : Qubit, name : String)) : Unit
+    is Adj + Ctl {
+    }
+
+    operation BigCirc() : Unit {
+        using (qs = Qubit[3]) {
+            H(qs[0]);
+            Ry(2.5, qs[1]);
+            Bar((1.0, 2.1), (qs[0], "foo"));
+            X(qs[0]);
+            CCNOT(qs[0], qs[1], qs[2]);
+            Controlled CNOT([qs[0]], (qs[1], qs[2]));
+            Controlled Adjoint Bar([qs[2]], ((1.0, 2.1), (qs[0], "foo")));
+            let res = M(qs[0]);
+            ResetAll(qs);
+        }
+    }
+    
+}
+
+

--- a/src/Tests/Workspace.ExecutionPathTracer/Measurement.qs
+++ b/src/Tests/Workspace.ExecutionPathTracer/Measurement.qs
@@ -1,0 +1,28 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Tests.ExecutionPathTracer {
+    
+    open Microsoft.Quantum.Measurement;
+    
+    operation MResetXCirc() : Unit {
+        using (q = Qubit()) {
+            let res = MResetX(q);
+        }
+    }
+
+    operation MResetYCirc() : Unit {
+        using (q = Qubit()) {
+            let res = MResetY(q);
+        }
+    }
+
+    operation MResetZCirc() : Unit {
+        using (q = Qubit()) {
+            let res = MResetZ(q);
+        }
+    }
+    
+}
+
+


### PR DESCRIPTION
This PR addresses the first out of 3 components (Simulator, JavaScript renderer, magic command) required to implement #158 .

This PR adds the `ExecutionPathTracer` files and the extension method to attach to any simulator and trace out the operations performed in a given execution path.

This will be merged in to the feature branch (`feature/path_visualizer`).

Note: This should be merged in after updating the `qsharp-runtime` version to include [this PR](https://github.com/microsoft/qsharp-runtime/pull/301).