### PR TITLE
No build when running iqsharp tests

### DIFF
--- a/build/test.ps1
+++ b/build/test.ps1
@@ -37,7 +37,7 @@ function Test-Python {
 
     Write-Host "##[info]Installing IQ# kernel"
     Push-Location (Join-Path $PSScriptRoot '../src/Tool')
-        dotnet run --no-build -- install --user
+        dotnet run -c $Env:BUILD_CONFIGURATION --no-build -- install --user
     Pop-Location
 
     Write-Host "##[info]Testing Python inside $testFolder"    

--- a/build/test.ps1
+++ b/build/test.ps1
@@ -35,7 +35,7 @@ function Test-Python {
 
     Write-Host "##[info]Installing IQ# kernel"
     Push-Location (Join-Path $PSScriptRoot '../src/Tool')
-        dotnet run -- install --user
+        dotnet run  -c $Env:BUILD_CONFIGURATION -- install --user
     Pop-Location
 
     Write-Host "##[info]Testing Python inside $testFolder"    

--- a/build/test.ps1
+++ b/build/test.ps1
@@ -15,6 +15,7 @@ function Test-One {
     dotnet test $project `
         -c $Env:BUILD_CONFIGURATION `
         -v $Env:BUILD_VERBOSITY `
+        --no-build `
         --logger trx `
         /property:DefineConstants=$Env:ASSEMBLY_CONSTANTS `
         /property:Version=$Env:ASSEMBLY_VERSION
@@ -35,7 +36,7 @@ function Test-Python {
 
     Write-Host "##[info]Installing IQ# kernel"
     Push-Location (Join-Path $PSScriptRoot '../src/Tool')
-        dotnet run  -c $Env:BUILD_CONFIGURATION -- install --user
+        dotnet run --no-build -- install --user
     Pop-Location
 
     Write-Host "##[info]Testing Python inside $testFolder"    


### PR DESCRIPTION
The tests are using `dotnet run` to install iq# for Python testing, this is causing IQ# to be rebuilt (in debug mode) and creating some other problems in end-to-end builds.
Adding the `--no-build` argument so it uses the already built version of iq#