### PR TITLE
Fix bundle.js load when opening notebook in subdirectory.

### DIFF
--- a/src/Kernel/res/kernel.js
+++ b/src/Kernel/res/kernel.js
@@ -1,6 +1,6 @@
 requirejs.config({
     bundles: {
-        '../kernelspecs/iqsharp/bundle.js': ['kernel'],
+        '/kernelspecs/iqsharp/bundle.js': ['kernel'],
     }
 });
 


### PR DESCRIPTION
Using the improvements in #187, `kernel.js` now loads `bundle.js` using RequireJS from within the client. The URL from `kernel.js` to `bundle.js` requires a relative link, however, since the base URL with which `kernel.js` is executed does not refer to the kernelspec directory. Since this relative link was formatted as path-relative (`../`) rather than domain-relative (`/`), the RequireJS call failed when running a notebook nested at least one level down from the current working directory in which Jupyter Notebook was launched. Changing the link fixes this behavior.