### PR TITLE
Add test for operations with no qubits

### DIFF
--- a/src/Kernel/client/__tests__/ExecutionPathVisualizerTests/process.test.ts
+++ b/src/Kernel/client/__tests__/ExecutionPathVisualizerTests/process.test.ts
@@ -185,6 +185,13 @@ describe("Testing _groupOperations", () => {
         ];
         expect(_groupOperations(operations, registers)).toEqual([[0], [0, 1], [1], []]);
     });
+    test("no qubits", () => {
+        const operations: Operation[] = [
+            { gate: "NoOp1", controlled: false, adjoint: false, controls: [], targets: [] },
+            { gate: "NoOp2", controlled: false, adjoint: false, controls: [], targets: [] },
+        ];
+        expect(_groupOperations(operations, registers)).toEqual([[], [], [], []]);
+    });
 });
 
 describe("Testing _alignOps", () => {


### PR DESCRIPTION
This PR adds a test for the visualizer that checks that operations with no qubits (in both controls and targets) are handled gracefully (no errors, not visualized).