### PR TITLE
Fix depth bug and render all ops at or above desired depth

### DIFF
--- a/src/Tests/ExecutionPathTracerTests.cs
+++ b/src/Tests/ExecutionPathTracerTests.cs
@@ -432,7 +432,12 @@ namespace Tests.IQSharp
         {
             var path = GetExecutionPath("EmptyCirc");
             var qubits = new QubitDeclaration[] { };
-            var operations = new Operation[] { };
+            var operations = new Operation[] {
+                new Operation()
+                {
+                    Gate = "EmptyCirc",
+                },
+            };
             var expected = new ExecutionPath(qubits, operations);
             Assert.AreEqual(expected.ToJson(), path.ToJson());
         }

--- a/src/Tests/IQsharpEngineTests.cs
+++ b/src/Tests/IQsharpEngineTests.cs
@@ -510,6 +510,11 @@ namespace Tests.IQSharp
                         Gate = "FooBar",
                         Targets = new List<Register>() { new QubitRegister(0) },
                     },
+                    new Operation()
+                    {
+                        Gate = "H",
+                        Targets = new List<Register>() { new QubitRegister(0) },
+                    },
                 }
             ));
 

--- a/src/Tests/Workspace.ExecutionPathTracer/Circuits.qs
+++ b/src/Tests/Workspace.ExecutionPathTracer/Circuits.qs
@@ -53,12 +53,12 @@ namespace Tests.ExecutionPathTracer {
     operation FooBar(q : Qubit) : Unit {
         H(q);
         X(q);
-        H(q);
     }
 
     operation Depth2Circ() : Unit {
         using (q = Qubit()) {
             FooBar(q);
+            H(q);
         }
     }
 


### PR DESCRIPTION
Currently, only operations at the given input depth is rendered. That is, if we had an operation like:
```C#
operation Depth2Circ() : Unit {
        using (q = Qubit()) {
            FooBar(q);
            H(q);
        }
}
```
our visualizer would only render the internals of `FooBar` if we select a `depth` of `2` and not `H` (ideally, we also want to render `H`).

This PR fixes that by keeping a running track of the latest parsed operation in the stack and adds it to the list of operations in the `onOperationEnd` call.