### PR TITLE
Bump qsharp-runtime version and add tests for operations as args

### DIFF
--- a/images/iqsharp-base/Dockerfile
+++ b/images/iqsharp-base/Dockerfile
@@ -109,7 +109,7 @@ ENV PATH=$PATH:${HOME}/dotnet:${HOME}/.dotnet/tools \
 # Install IQ# and the project templates, using the NuGet packages from the
 # build context.
 ARG IQSHARP_VERSION
-RUN dotnet new -i "Microsoft.Quantum.ProjectTemplates::0.12.20071622-beta" && \
+RUN dotnet new -i "Microsoft.Quantum.ProjectTemplates::0.12.20072301-beta" && \
     dotnet tool install \
            --global \
            Microsoft.Quantum.IQSharp \

--- a/src/AzureClient/AzureClient.csproj
+++ b/src/AzureClient/AzureClient.csproj
@@ -13,7 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Quantum.Client" Version="0.12.20071622-beta" />
+    <PackageReference Include="Microsoft.Azure.Quantum.Client" Version="0.12.20072301-beta" />
     <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.21" />
     <PackageReference Include="Microsoft.Rest.ClientRuntime.Azure" Version="3.3.19" />
     <PackageReference Include="System.Reactive" Version="4.3.2" />

--- a/src/Core/Core.csproj
+++ b/src/Core/Core.csproj
@@ -34,9 +34,9 @@
     <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="3.0.0" />
-    <PackageReference Include="Microsoft.Quantum.Compiler" Version="0.12.20071622-beta" />
-    <PackageReference Include="Microsoft.Quantum.CsharpGeneration" Version="0.12.20071622-beta" />
-    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.12.20071622-beta" />
+    <PackageReference Include="Microsoft.Quantum.Compiler" Version="0.12.20072301-beta" />
+    <PackageReference Include="Microsoft.Quantum.CsharpGeneration" Version="0.12.20072301-beta" />
+    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.12.20072301-beta" />
     <PackageReference Include="NuGet.Resolver" Version="5.1.0" />
     <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
   </ItemGroup>

--- a/src/Tests/ExecutionPathTracerTests.cs
+++ b/src/Tests/ExecutionPathTracerTests.cs
@@ -441,13 +441,30 @@ namespace Tests.IQSharp
         public void NoQubitArgsTest()
         {
             var path = GetExecutionPath("NoQubitArgsCirc");
-            var qubits = new QubitDeclaration[] {};
+            var qubits = new QubitDeclaration[] { };
             var operations = new Operation[]
             {
                 new Operation()
                 {
                     Gate = "NoQubitCirc",
                     DisplayArgs = "(2)",
+                },
+            };
+            var expected = new ExecutionPath(qubits, operations);
+            Assert.AreEqual(expected.ToJson(), path.ToJson());
+        }
+
+        [TestMethod]
+        public void OperationArgsTest()
+        {
+            var path = GetExecutionPath("OperationArgsCirc");
+            var qubits = new QubitDeclaration[] { };
+            var operations = new Operation[]
+            {
+                new Operation()
+                {
+                    Gate = "OperationCirc",
+                    DisplayArgs = "(H, 5)",
                 },
             };
             var expected = new ExecutionPath(qubits, operations);

--- a/src/Tests/Workspace.ExecutionPathTracer/Circuits.qs
+++ b/src/Tests/Workspace.ExecutionPathTracer/Circuits.qs
@@ -42,6 +42,13 @@ namespace Tests.ExecutionPathTracer {
         NoQubitCirc(2);
     }
 
+    operation OperationCirc(op : (Qubit => Unit), n : Int) : Unit {
+    }
+
+    operation OperationArgsCirc() : Unit {
+        OperationCirc(H, 5);
+    }
+
     operation NestedCirc() : Unit {
         using (q = Qubit()) {
             H(q);

--- a/src/Tool/appsettings.json
+++ b/src/Tool/appsettings.json
@@ -6,25 +6,25 @@
     },
     "AllowedHosts": "*",
   "DefaultPackageVersions": [
-    "Microsoft.Quantum.Compiler::0.12.20071622-beta",
+    "Microsoft.Quantum.Compiler::0.12.20072301-beta",
 
-    "Microsoft.Quantum.CsharpGeneration::0.12.20071622-beta",
-    "Microsoft.Quantum.Development.Kit::0.12.20071622-beta",
-    "Microsoft.Quantum.Simulators::0.12.20071622-beta",
-    "Microsoft.Quantum.Xunit::0.12.20071622-beta",
+    "Microsoft.Quantum.CsharpGeneration::0.12.20072301-beta",
+    "Microsoft.Quantum.Development.Kit::0.12.20072301-beta",
+    "Microsoft.Quantum.Simulators::0.12.20072301-beta",
+    "Microsoft.Quantum.Xunit::0.12.20072301-beta",
 
-    "Microsoft.Quantum.Standard::0.12.20071622-beta",
-    "Microsoft.Quantum.Chemistry::0.12.20071622-beta",
-    "Microsoft.Quantum.Chemistry.Jupyter::0.12.20071622-beta",
-    "Microsoft.Quantum.MachineLearning::0.12.20071622-beta",
-    "Microsoft.Quantum.Numerics::0.12.20071622-beta",
+    "Microsoft.Quantum.Standard::0.12.20072301-beta",
+    "Microsoft.Quantum.Chemistry::0.12.20072301-beta",
+    "Microsoft.Quantum.Chemistry.Jupyter::0.12.20072301-beta",
+    "Microsoft.Quantum.MachineLearning::0.12.20072301-beta",
+    "Microsoft.Quantum.Numerics::0.12.20072301-beta",
 
-    "Microsoft.Quantum.Katas::0.12.20071622-beta",
+    "Microsoft.Quantum.Katas::0.12.20072301-beta",
 
-    "Microsoft.Quantum.Research::0.12.20071622-beta",
+    "Microsoft.Quantum.Research::0.12.20072301-beta",
 
-    "Microsoft.Quantum.Providers.IonQ::0.12.20071622-beta",
-    "Microsoft.Quantum.Providers.Honeywell::0.12.20071622-beta",
-    "Microsoft.Quantum.Providers.QCI::0.12.20071622-beta"
+    "Microsoft.Quantum.Providers.IonQ::0.12.20072301-beta",
+    "Microsoft.Quantum.Providers.Honeywell::0.12.20072301-beta",
+    "Microsoft.Quantum.Providers.QCI::0.12.20072301-beta"
   ]
 }


### PR DESCRIPTION
This PR bumps up the qsharp-runtime version to fix the bug with passing in operations as an argument.
We also add tests to catch this edge case.