### PR TITLE
Allow default depth for %trace to be set in %config

### DIFF
--- a/src/Jupyter/ConfigurationSource.cs
+++ b/src/Jupyter/ConfigurationSource.cs
@@ -69,6 +69,13 @@ namespace Microsoft.Quantum.IQSharp.Jupyter
         /// </summary>
         public PhaseDisplayStyle PhaseDisplayStyle =>
             GetOptionOrDefault("dump.phaseDisplayStyle", PhaseDisplayStyle.ArrowOnly);
+
+        /// <summary>
+        ///     Allows for setting the default depth for visualizing Q# operations using the
+        ///     <c>%trace</c> command.
+        /// </summary>
+        public int TraceVisualizationDefaultDepth =>
+            GetOptionOrDefault("trace.defaultDepth", 1);
     }
 
     /// <summary>

--- a/src/Kernel/Magic/ConfigMagic.cs
+++ b/src/Kernel/Magic/ConfigMagic.cs
@@ -67,7 +67,7 @@ namespace Microsoft.Quantum.IQSharp.Kernel
 
                     **`trace.defaultDepth`**
 
-                    **Value:** integer (default `1`)
+                    **Value:** positive integer (default `1`)
 
                     Configures the default depth used in the `%trace` command for visualizing Q# operations.
                 ".Dedent(),

--- a/src/Kernel/Magic/ConfigMagic.cs
+++ b/src/Kernel/Magic/ConfigMagic.cs
@@ -6,9 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 
 using Microsoft.Jupyter.Core;
-using Microsoft.Quantum.IQSharp;
 using Microsoft.Quantum.IQSharp.Jupyter;
-using Microsoft.Quantum.IQSharp.Kernel;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
@@ -66,6 +64,12 @@ namespace Microsoft.Quantum.IQSharp.Kernel
 
                     Configures the phase visualization style in output from callables such as
                     `DumpMachine` or `DumpRegister`. Supports displaying phase as arrows, numbers (in radians), both, or neither.
+
+                    **`trace.defaultDepth`**
+
+                    **Value:** integer (default `1`)
+
+                    Configures the default depth used in the `%trace` command for visualizing Q# operations.
                 ".Dedent(),
                 Examples = new []
                 {

--- a/src/Kernel/Magic/TraceMagic.cs
+++ b/src/Kernel/Magic/TraceMagic.cs
@@ -77,7 +77,7 @@ namespace Microsoft.Quantum.IQSharp.Kernel
                     - `{ParameterNameDepth}=<integer>` (default=1): The depth at which to render operations along
                     the execution path.
                 ".Dedent(),
-                Examples = new []
+                Examples = new[]
                 {
                     @"
                         Visualize the execution path of a Q# operation defined as `operation MyOperation() : Result`:
@@ -137,7 +137,10 @@ namespace Microsoft.Quantum.IQSharp.Kernel
             var symbol = SymbolResolver.Resolve(name) as IQSharpSymbol;
             if (symbol == null) throw new InvalidOperationException($"Invalid operation name: {name}");
 
-            var depth = inputParameters.DecodeParameter<int>(ParameterNameDepth, defaultValue: 1);
+            var depth = inputParameters.DecodeParameter<int>(
+                ParameterNameDepth,
+                defaultValue: this.ConfigurationSource.TraceVisualizationDefaultDepth
+            );
             if (depth <= 0) throw new ArgumentOutOfRangeException($"Invalid depth: {depth}. Must be >= 1.");
 
             var tracer = new ExecutionPathTracer(depth);


### PR DESCRIPTION
As per @cgranade's suggestion during my midterm talk, this PR allows the user to set the default depth (`1` by default) using `%config trace.defaultDepth`.