### PR TITLE
Implement `IsMeasurement` flag for execution path operations

### DIFF
--- a/src/Core/ExecutionPathTracer/ExecutionPath.cs
+++ b/src/Core/ExecutionPathTracer/ExecutionPath.cs
@@ -132,14 +132,14 @@ namespace Microsoft.Quantum.IQSharp.Core.ExecutionPathTracer
         /// <summary>
         /// True if operation is a controlled operations.
         /// </summary>
-        [JsonProperty("controlled")]
-        public bool Controlled { get; set; }
+        [JsonProperty("isControlled")]
+        public bool IsControlled { get; set; }
 
         /// <summary>
         /// True if operation is an adjoint operations.
         /// </summary>
-        [JsonProperty("adjoint")]
-        public bool Adjoint { get; set; }
+        [JsonProperty("isAdjoint")]
+        public bool IsAdjoint { get; set; }
 
         /// <summary>
         /// List of control registers.

--- a/src/Core/ExecutionPathTracer/ExecutionPath.cs
+++ b/src/Core/ExecutionPathTracer/ExecutionPath.cs
@@ -124,6 +124,12 @@ namespace Microsoft.Quantum.IQSharp.Core.ExecutionPathTracer
         public IEnumerable<IEnumerable<Operation>>? Children { get; set; }
 
         /// <summary>
+        /// True if operation is a measurement operations.
+        /// </summary>
+        [JsonProperty("isMeasurement")]
+        public bool IsMeasurement { get; set; }
+
+        /// <summary>
         /// True if operation is a controlled operations.
         /// </summary>
         [JsonProperty("controlled")]

--- a/src/Core/ExecutionPathTracer/ExecutionPathTracer.cs
+++ b/src/Core/ExecutionPathTracer/ExecutionPathTracer.cs
@@ -159,8 +159,7 @@ namespace Microsoft.Quantum.IQSharp.Core.ExecutionPathTracer
             {
                 var measureQubit = metadata.Targets.ElementAt(0);
                 var clsReg = this.CreateClassicalRegister(measureQubit);
-                // TODO: Change this to using IsMeasurement
-                op.Gate = "measure";
+                op.IsMeasurement = true;
                 op.Controls = op.Targets;
                 op.Targets = new List<Register>() { clsReg };
             }

--- a/src/Core/ExecutionPathTracer/ExecutionPathTracer.cs
+++ b/src/Core/ExecutionPathTracer/ExecutionPathTracer.cs
@@ -148,8 +148,8 @@ namespace Microsoft.Quantum.IQSharp.Core.ExecutionPathTracer
                 Gate = metadata.Label,
                 DisplayArgs = displayArgs,
                 Children = metadata.Children?.Select(child => child.Select(this.MetadataToOperation).WhereNotNull()),
-                Controlled = metadata.IsControlled,
-                Adjoint = metadata.IsAdjoint,
+                IsControlled = metadata.IsControlled,
+                IsAdjoint = metadata.IsAdjoint,
                 Controls = this.GetQubitRegisters(metadata.Controls),
                 Targets = this.GetQubitRegisters(metadata.Targets),
             };

--- a/src/Kernel/client/ExecutionPathVisualizer/executionPath.ts
+++ b/src/Kernel/client/ExecutionPathVisualizer/executionPath.ts
@@ -35,9 +35,9 @@ export interface Operation {
     /** Whether gate is a measurement operation. */
     isMeasurement: boolean;
     /** Whether gate is a controlled operation. */
-    controlled: boolean;
+    isControlled: boolean;
     /** Whether gate is an adjoint operation. */
-    adjoint: boolean;
+    isAdjoint: boolean;
     /** Control registers the gate acts on. */
     controls: Register[];
     /** Target registers the gate acts on. */

--- a/src/Kernel/client/ExecutionPathVisualizer/executionPath.ts
+++ b/src/Kernel/client/ExecutionPathVisualizer/executionPath.ts
@@ -32,6 +32,8 @@ export interface Operation {
      *  - children[1]: gates when classical control bit is 1.
     */
     children?: Operation[][];
+    /** Whether gate is a measurement operation. */
+    isMeasurement: boolean;
     /** Whether gate is a controlled operation. */
     controlled: boolean;
     /** Whether gate is an adjoint operation. */

--- a/src/Kernel/client/ExecutionPathVisualizer/process.ts
+++ b/src/Kernel/client/ExecutionPathVisualizer/process.ts
@@ -189,8 +189,8 @@ const _opToMetadata = (op: Operation | null, registers: RegisterMap): Metadata =
         gate,
         displayArgs,
         isMeasurement,
-        controlled,
-        adjoint,
+        isControlled,
+        isAdjoint,
         controls,
         targets,
         children
@@ -229,7 +229,7 @@ const _opToMetadata = (op: Operation | null, registers: RegisterMap): Metadata =
         metadata.type = GateType.Measure;
     } else if (gate === 'SWAP') {
         metadata.type = GateType.Swap;
-    } else if (controlled) {
+    } else if (isControlled) {
         metadata.type = (gate === 'X') ? GateType.Cnot : GateType.ControlledUnitary;
         metadata.label = gate;
     } else {
@@ -239,7 +239,7 @@ const _opToMetadata = (op: Operation | null, registers: RegisterMap): Metadata =
     }
 
     // If adjoint, add ' to the end of gate label
-    if (adjoint && metadata.label.length > 0) metadata.label += "'";
+    if (isAdjoint && metadata.label.length > 0) metadata.label += "'";
 
     // If gate has extra arguments, display them
     if (displayArgs != null) metadata.displayArgs = displayArgs;

--- a/src/Kernel/client/ExecutionPathVisualizer/process.ts
+++ b/src/Kernel/client/ExecutionPathVisualizer/process.ts
@@ -185,7 +185,16 @@ const _opToMetadata = (op: Operation | null, registers: RegisterMap): Metadata =
 
     if (op == null) return metadata;
 
-    let { gate, displayArgs, controlled, adjoint, controls, targets, children } = op;
+    let {
+        gate,
+        displayArgs,
+        isMeasurement,
+        controlled,
+        adjoint,
+        controls,
+        targets,
+        children
+    } = op;
 
     // Set y coords
     metadata.controlsY = controls.map(reg => _getRegY(reg, registers));
@@ -216,7 +225,7 @@ const _opToMetadata = (op: Operation | null, registers: RegisterMap): Metadata =
         // around all quantum registers.
         const qubitsY: number[] = Object.values(registers).map(({ y }) => y);
         metadata.targetsY = [Math.min(...qubitsY), Math.max(...qubitsY)];
-    } else if (gate === 'measure') {
+    } else if (isMeasurement) {
         metadata.type = GateType.Measure;
     } else if (gate === 'SWAP') {
         metadata.type = GateType.Swap;

--- a/src/Kernel/client/__tests__/ExecutionPathVisualizerTests/process.test.ts
+++ b/src/Kernel/client/__tests__/ExecutionPathVisualizerTests/process.test.ts
@@ -34,62 +34,62 @@ describe("Testing _groupOperations", () => {
     };
     test("single qubit gates on 1 qubit register", () => {
         const operations: Operation[] = [
-            { gate: "X", isMeasurement: false, controlled: false, adjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
-            { gate: "Y", isMeasurement: false, controlled: false, adjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
-            { gate: "Z", isMeasurement: false, controlled: false, adjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
+            { gate: "X", isMeasurement: false, isControlled: false, isAdjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
+            { gate: "Y", isMeasurement: false, isControlled: false, isAdjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
+            { gate: "Z", isMeasurement: false, isControlled: false, isAdjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
         ];
         expect(_groupOperations(operations, registers)).toEqual([[0, 1, 2], [], [], []]);
     });
     test("single qubit gates on multiple qubit registers", () => {
         const operations: Operation[] = [
-            { gate: "X", isMeasurement: false, controlled: false, adjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
-            { gate: "Y", isMeasurement: false, controlled: false, adjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 1 }] },
-            { gate: "Z", isMeasurement: false, controlled: false, adjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 2 }] },
-            { gate: "H", isMeasurement: false, controlled: false, adjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
-            { gate: "T", isMeasurement: false, controlled: false, adjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 1 }] },
+            { gate: "X", isMeasurement: false, isControlled: false, isAdjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
+            { gate: "Y", isMeasurement: false, isControlled: false, isAdjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 1 }] },
+            { gate: "Z", isMeasurement: false, isControlled: false, isAdjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 2 }] },
+            { gate: "H", isMeasurement: false, isControlled: false, isAdjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
+            { gate: "T", isMeasurement: false, isControlled: false, isAdjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 1 }] },
         ];
         expect(_groupOperations(operations, registers)).toEqual([[0, 3], [1, 4], [2], []]);
     });
     test("single and multiple qubit(s) gates", () => {
         let operations: Operation[] = [
-            { gate: "X", isMeasurement: false, controlled: false, adjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
-            { gate: "Y", isMeasurement: false, controlled: true, adjoint: false, controls: [{ type: RegisterType.Qubit, qId: 0 }], targets: [{ type: RegisterType.Qubit, qId: 1 }] },
-            { gate: "Z", isMeasurement: false, controlled: false, adjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
+            { gate: "X", isMeasurement: false, isControlled: false, isAdjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
+            { gate: "Y", isMeasurement: false, isControlled: true, isAdjoint: false, controls: [{ type: RegisterType.Qubit, qId: 0 }], targets: [{ type: RegisterType.Qubit, qId: 1 }] },
+            { gate: "Z", isMeasurement: false, isControlled: false, isAdjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
         ];
         expect(_groupOperations(operations, registers)).toEqual([[0, 1, 2], [1], [], []]);
         operations = [
-            { gate: "X", isMeasurement: false, controlled: false, adjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
-            { gate: "Y", isMeasurement: false, controlled: true, adjoint: false, controls: [{ type: RegisterType.Qubit, qId: 1 }], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
-            { gate: "Z", isMeasurement: false, controlled: false, adjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
+            { gate: "X", isMeasurement: false, isControlled: false, isAdjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
+            { gate: "Y", isMeasurement: false, isControlled: true, isAdjoint: false, controls: [{ type: RegisterType.Qubit, qId: 1 }], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
+            { gate: "Z", isMeasurement: false, isControlled: false, isAdjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
         ];
         expect(_groupOperations(operations, registers)).toEqual([[0, 1, 2], [1], [], []]);
         operations = [
-            { gate: "X", isMeasurement: false, controlled: false, adjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
-            { gate: "Z", isMeasurement: false, controlled: false, adjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
-            { gate: "Y", isMeasurement: false, controlled: true, adjoint: false, controls: [{ type: RegisterType.Qubit, qId: 1 }], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
+            { gate: "X", isMeasurement: false, isControlled: false, isAdjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
+            { gate: "Z", isMeasurement: false, isControlled: false, isAdjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
+            { gate: "Y", isMeasurement: false, isControlled: true, isAdjoint: false, controls: [{ type: RegisterType.Qubit, qId: 1 }], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
         ];
         expect(_groupOperations(operations, registers)).toEqual([[0, 1, 2], [2], [], []]);
         operations = [
-            { gate: "Y", isMeasurement: false, controlled: true, adjoint: false, controls: [{ type: RegisterType.Qubit, qId: 1 }], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
-            { gate: "X", isMeasurement: false, controlled: false, adjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
-            { gate: "Z", isMeasurement: false, controlled: false, adjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
+            { gate: "Y", isMeasurement: false, isControlled: true, isAdjoint: false, controls: [{ type: RegisterType.Qubit, qId: 1 }], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
+            { gate: "X", isMeasurement: false, isControlled: false, isAdjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
+            { gate: "Z", isMeasurement: false, isControlled: false, isAdjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
         ];
         expect(_groupOperations(operations, registers)).toEqual([[0, 1, 2], [0], [], []]);
         operations = [
-            { gate: "Y", isMeasurement: false, controlled: true, adjoint: false, controls: [{ type: RegisterType.Qubit, qId: 1 }], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
-            { gate: "X", isMeasurement: false, controlled: false, adjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
-            { gate: "Z", isMeasurement: false, controlled: false, adjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 1 }] },
+            { gate: "Y", isMeasurement: false, isControlled: true, isAdjoint: false, controls: [{ type: RegisterType.Qubit, qId: 1 }], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
+            { gate: "X", isMeasurement: false, isControlled: false, isAdjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
+            { gate: "Z", isMeasurement: false, isControlled: false, isAdjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 1 }] },
         ];
         expect(_groupOperations(operations, registers)).toEqual([[0, 1], [0, 2], [], []]);
     });
     test("multiple qubit gates in ladder format", () => {
         const operations: Operation[] = [
-            { gate: "X", isMeasurement: false, controlled: true, adjoint: false, controls: [{ type: RegisterType.Qubit, qId: 1 }], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
-            { gate: "Y", isMeasurement: false, controlled: true, adjoint: false, controls: [{ type: RegisterType.Qubit, qId: 1 }], targets: [{ type: RegisterType.Qubit, qId: 2 }] },
-            { gate: "Z", isMeasurement: false, controlled: true, adjoint: false, controls: [{ type: RegisterType.Qubit, qId: 2 }], targets: [{ type: RegisterType.Qubit, qId: 3 }] },
-            { gate: "H", isMeasurement: false, controlled: true, adjoint: false, controls: [{ type: RegisterType.Qubit, qId: 2 }], targets: [{ type: RegisterType.Qubit, qId: 3 }] },
-            { gate: "T", isMeasurement: false, controlled: true, adjoint: false, controls: [{ type: RegisterType.Qubit, qId: 2 }], targets: [{ type: RegisterType.Qubit, qId: 1 }] },
-            { gate: "X", isMeasurement: false, controlled: true, adjoint: false, controls: [{ type: RegisterType.Qubit, qId: 0 }], targets: [{ type: RegisterType.Qubit, qId: 1 }] },
+            { gate: "X", isMeasurement: false, isControlled: true, isAdjoint: false, controls: [{ type: RegisterType.Qubit, qId: 1 }], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
+            { gate: "Y", isMeasurement: false, isControlled: true, isAdjoint: false, controls: [{ type: RegisterType.Qubit, qId: 1 }], targets: [{ type: RegisterType.Qubit, qId: 2 }] },
+            { gate: "Z", isMeasurement: false, isControlled: true, isAdjoint: false, controls: [{ type: RegisterType.Qubit, qId: 2 }], targets: [{ type: RegisterType.Qubit, qId: 3 }] },
+            { gate: "H", isMeasurement: false, isControlled: true, isAdjoint: false, controls: [{ type: RegisterType.Qubit, qId: 2 }], targets: [{ type: RegisterType.Qubit, qId: 3 }] },
+            { gate: "T", isMeasurement: false, isControlled: true, isAdjoint: false, controls: [{ type: RegisterType.Qubit, qId: 2 }], targets: [{ type: RegisterType.Qubit, qId: 1 }] },
+            { gate: "X", isMeasurement: false, isControlled: true, isAdjoint: false, controls: [{ type: RegisterType.Qubit, qId: 0 }], targets: [{ type: RegisterType.Qubit, qId: 1 }] },
         ];
         expect(_groupOperations(operations, registers)).toEqual([[0, 5], [0, 1, 4, 5], [1, 2, 3, 4], [2, 3]]);
 
@@ -97,48 +97,48 @@ describe("Testing _groupOperations", () => {
     test("multiple qubit gates in ladder format with single qubit gate", () => {
         let numRegs: number = 4;
         let operations: Operation[] = [
-            { gate: "X", isMeasurement: false, controlled: true, adjoint: false, controls: [{ type: RegisterType.Qubit, qId: 1 }], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
-            { gate: "Y", isMeasurement: false, controlled: false, adjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 1 }] },
-            { gate: "Y", isMeasurement: false, controlled: true, adjoint: false, controls: [{ type: RegisterType.Qubit, qId: 1 }], targets: [{ type: RegisterType.Qubit, qId: 2 }] },
-            { gate: "Z", isMeasurement: false, controlled: true, adjoint: false, controls: [{ type: RegisterType.Qubit, qId: 2 }], targets: [{ type: RegisterType.Qubit, qId: 3 }] },
-            { gate: "Z", isMeasurement: false, controlled: false, adjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 2 }] },
-            { gate: "H", isMeasurement: false, controlled: true, adjoint: false, controls: [{ type: RegisterType.Qubit, qId: 2 }], targets: [{ type: RegisterType.Qubit, qId: 3 }] },
-            { gate: "T", isMeasurement: false, controlled: true, adjoint: false, controls: [{ type: RegisterType.Qubit, qId: 2 }], targets: [{ type: RegisterType.Qubit, qId: 1 }] },
-            { gate: "Y", isMeasurement: false, controlled: false, adjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 1 }] },
-            { gate: "X", isMeasurement: false, controlled: true, adjoint: false, controls: [{ type: RegisterType.Qubit, qId: 0 }], targets: [{ type: RegisterType.Qubit, qId: 1 }] },
+            { gate: "X", isMeasurement: false, isControlled: true, isAdjoint: false, controls: [{ type: RegisterType.Qubit, qId: 1 }], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
+            { gate: "Y", isMeasurement: false, isControlled: false, isAdjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 1 }] },
+            { gate: "Y", isMeasurement: false, isControlled: true, isAdjoint: false, controls: [{ type: RegisterType.Qubit, qId: 1 }], targets: [{ type: RegisterType.Qubit, qId: 2 }] },
+            { gate: "Z", isMeasurement: false, isControlled: true, isAdjoint: false, controls: [{ type: RegisterType.Qubit, qId: 2 }], targets: [{ type: RegisterType.Qubit, qId: 3 }] },
+            { gate: "Z", isMeasurement: false, isControlled: false, isAdjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 2 }] },
+            { gate: "H", isMeasurement: false, isControlled: true, isAdjoint: false, controls: [{ type: RegisterType.Qubit, qId: 2 }], targets: [{ type: RegisterType.Qubit, qId: 3 }] },
+            { gate: "T", isMeasurement: false, isControlled: true, isAdjoint: false, controls: [{ type: RegisterType.Qubit, qId: 2 }], targets: [{ type: RegisterType.Qubit, qId: 1 }] },
+            { gate: "Y", isMeasurement: false, isControlled: false, isAdjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 1 }] },
+            { gate: "X", isMeasurement: false, isControlled: true, isAdjoint: false, controls: [{ type: RegisterType.Qubit, qId: 0 }], targets: [{ type: RegisterType.Qubit, qId: 1 }] },
         ];
         expect(_groupOperations(operations, registers)).toEqual([[0, 8], [0, 1, 2, 6, 7, 8], [2, 3, 4, 5, 6], [3, 5]]);
 
         numRegs = 3;
         operations = [
-            { gate: "X", isMeasurement: false, controlled: true, adjoint: false, controls: [{ type: RegisterType.Qubit, qId: 1 }], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
-            { gate: "Y", isMeasurement: false, controlled: false, adjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 1 }] },
-            { gate: "Y", isMeasurement: false, controlled: true, adjoint: false, controls: [{ type: RegisterType.Qubit, qId: 1 }], targets: [{ type: RegisterType.Qubit, qId: 2 }] },
-            { gate: "Z", isMeasurement: false, controlled: false, adjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 2 }] },
-            { gate: "T", isMeasurement: false, controlled: true, adjoint: false, controls: [{ type: RegisterType.Qubit, qId: 2 }], targets: [{ type: RegisterType.Qubit, qId: 1 }] },
-            { gate: "Y", isMeasurement: false, controlled: false, adjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 1 }] },
-            { gate: "H", isMeasurement: false, controlled: false, adjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
-            { gate: "H", isMeasurement: false, controlled: false, adjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
-            { gate: "H", isMeasurement: false, controlled: false, adjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
-            { gate: "H", isMeasurement: false, controlled: false, adjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
-            { gate: "X", isMeasurement: false, controlled: true, adjoint: false, controls: [{ type: RegisterType.Qubit, qId: 0 }], targets: [{ type: RegisterType.Qubit, qId: 1 }] },
+            { gate: "X", isMeasurement: false, isControlled: true, isAdjoint: false, controls: [{ type: RegisterType.Qubit, qId: 1 }], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
+            { gate: "Y", isMeasurement: false, isControlled: false, isAdjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 1 }] },
+            { gate: "Y", isMeasurement: false, isControlled: true, isAdjoint: false, controls: [{ type: RegisterType.Qubit, qId: 1 }], targets: [{ type: RegisterType.Qubit, qId: 2 }] },
+            { gate: "Z", isMeasurement: false, isControlled: false, isAdjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 2 }] },
+            { gate: "T", isMeasurement: false, isControlled: true, isAdjoint: false, controls: [{ type: RegisterType.Qubit, qId: 2 }], targets: [{ type: RegisterType.Qubit, qId: 1 }] },
+            { gate: "Y", isMeasurement: false, isControlled: false, isAdjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 1 }] },
+            { gate: "H", isMeasurement: false, isControlled: false, isAdjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
+            { gate: "H", isMeasurement: false, isControlled: false, isAdjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
+            { gate: "H", isMeasurement: false, isControlled: false, isAdjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
+            { gate: "H", isMeasurement: false, isControlled: false, isAdjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
+            { gate: "X", isMeasurement: false, isControlled: true, isAdjoint: false, controls: [{ type: RegisterType.Qubit, qId: 0 }], targets: [{ type: RegisterType.Qubit, qId: 1 }] },
         ];
         expect(_groupOperations(operations, registers)).toEqual([[0, 6, 7, 8, 9, 10], [0, 1, 2, 4, 5, 10], [2, 3, 4], []]);
     });
     test("interleaved multiqubit gates", () => {
         let operations: Operation[] = [
-            { gate: "X", isMeasurement: false, controlled: true, adjoint: false, controls: [{ type: RegisterType.Qubit, qId: 1 }], targets: [{ type: RegisterType.Qubit, qId: 3 }] },
-            { gate: "X", isMeasurement: false, controlled: true, adjoint: false, controls: [{ type: RegisterType.Qubit, qId: 0 }], targets: [{ type: RegisterType.Qubit, qId: 2 }] },
+            { gate: "X", isMeasurement: false, isControlled: true, isAdjoint: false, controls: [{ type: RegisterType.Qubit, qId: 1 }], targets: [{ type: RegisterType.Qubit, qId: 3 }] },
+            { gate: "X", isMeasurement: false, isControlled: true, isAdjoint: false, controls: [{ type: RegisterType.Qubit, qId: 0 }], targets: [{ type: RegisterType.Qubit, qId: 2 }] },
         ];
         expect(_groupOperations(operations, registers)).toEqual([[1], [0, 1], [0, 1], [0]]);
         operations = [
-            { gate: "X", isMeasurement: false, controlled: true, adjoint: false, controls: [{ type: RegisterType.Qubit, qId: 0 }, { type: RegisterType.Qubit, qId: 1 }], targets: [{ type: RegisterType.Qubit, qId: 3 }] },
-            { gate: "X", isMeasurement: false, controlled: true, adjoint: false, controls: [{ type: RegisterType.Qubit, qId: 0 }], targets: [{ type: RegisterType.Qubit, qId: 2 }, { type: RegisterType.Qubit, qId: 3 }] },
+            { gate: "X", isMeasurement: false, isControlled: true, isAdjoint: false, controls: [{ type: RegisterType.Qubit, qId: 0 }, { type: RegisterType.Qubit, qId: 1 }], targets: [{ type: RegisterType.Qubit, qId: 3 }] },
+            { gate: "X", isMeasurement: false, isControlled: true, isAdjoint: false, controls: [{ type: RegisterType.Qubit, qId: 0 }], targets: [{ type: RegisterType.Qubit, qId: 2 }, { type: RegisterType.Qubit, qId: 3 }] },
         ];
         expect(_groupOperations(operations, registers)).toEqual([[0, 1], [0, 1], [0, 1], [0, 1]]);
         operations = [
-            { gate: "Foo", isMeasurement: false, controlled: false, adjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 0 }, { type: RegisterType.Qubit, qId: 2 }, { type: RegisterType.Qubit, qId: 3 }] },
-            { gate: "Bar", isMeasurement: false, controlled: false, adjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 0 }, { type: RegisterType.Qubit, qId: 1 }, { type: RegisterType.Qubit, qId: 2 }] },
+            { gate: "Foo", isMeasurement: false, isControlled: false, isAdjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 0 }, { type: RegisterType.Qubit, qId: 2 }, { type: RegisterType.Qubit, qId: 3 }] },
+            { gate: "Bar", isMeasurement: false, isControlled: false, isAdjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 0 }, { type: RegisterType.Qubit, qId: 1 }, { type: RegisterType.Qubit, qId: 2 }] },
         ];
         expect(_groupOperations(operations, registers)).toEqual([[0, 1], [0, 1], [0, 1], [0]]);
     });
@@ -158,37 +158,37 @@ describe("Testing _groupOperations", () => {
             3: { type: RegisterType.Qubit, y: startY + registerHeight + classicalRegHeight * 4 },
         }
         let operations: Operation[] = [
-            { gate: "X", isMeasurement: false, controlled: true, adjoint: false, controls: [{ type: RegisterType.Classical, qId: 2, cId: 0 }], targets: [{ type: RegisterType.Qubit, qId: 1 }] },
-            { gate: "X", isMeasurement: false, controlled: false, adjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
+            { gate: "X", isMeasurement: false, isControlled: true, isAdjoint: false, controls: [{ type: RegisterType.Classical, qId: 2, cId: 0 }], targets: [{ type: RegisterType.Qubit, qId: 1 }] },
+            { gate: "X", isMeasurement: false, isControlled: false, isAdjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
         ];
         expect(_groupOperations(operations, registers)).toEqual([[0, 1], [0], [0], [0]]);
         operations = [
-            { gate: "X", isMeasurement: false, controlled: true, adjoint: false, controls: [{ type: RegisterType.Classical, qId: 2, cId: 0 }], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
-            { gate: "X", isMeasurement: false, controlled: false, adjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 1 }] },
+            { gate: "X", isMeasurement: false, isControlled: true, isAdjoint: false, controls: [{ type: RegisterType.Classical, qId: 2, cId: 0 }], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
+            { gate: "X", isMeasurement: false, isControlled: false, isAdjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 1 }] },
         ];
         expect(_groupOperations(operations, registers)).toEqual([[0], [0, 1], [0], [0]]);
         operations = [
-            { gate: "X", isMeasurement: false, controlled: false, adjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 1 }] },
-            { gate: "X", isMeasurement: false, controlled: true, adjoint: false, controls: [{ type: RegisterType.Classical, qId: 1, cId: 0 }], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
+            { gate: "X", isMeasurement: false, isControlled: false, isAdjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 1 }] },
+            { gate: "X", isMeasurement: false, isControlled: true, isAdjoint: false, controls: [{ type: RegisterType.Classical, qId: 1, cId: 0 }], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
         ];
         expect(_groupOperations(operations, registers)).toEqual([[1], [0, 1], [1], [1]]);
     });
     test("skipped registers", () => {
         let operations: Operation[] = [
-            { gate: "X", isMeasurement: false, controlled: false, adjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
-            { gate: "Z", isMeasurement: false, controlled: false, adjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 2 }] },
+            { gate: "X", isMeasurement: false, isControlled: false, isAdjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
+            { gate: "Z", isMeasurement: false, isControlled: false, isAdjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 2 }] },
         ];
         expect(_groupOperations(operations, registers)).toEqual([[0], [], [1], []]);
         operations = [
-            { gate: "X", isMeasurement: false, controlled: true, adjoint: false, controls: [{ type: RegisterType.Qubit, qId: 1 }], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
-            { gate: "Z", isMeasurement: false, controlled: true, adjoint: false, controls: [{ type: RegisterType.Qubit, qId: 1 }], targets: [{ type: RegisterType.Qubit, qId: 2 }] },
+            { gate: "X", isMeasurement: false, isControlled: true, isAdjoint: false, controls: [{ type: RegisterType.Qubit, qId: 1 }], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
+            { gate: "Z", isMeasurement: false, isControlled: true, isAdjoint: false, controls: [{ type: RegisterType.Qubit, qId: 1 }], targets: [{ type: RegisterType.Qubit, qId: 2 }] },
         ];
         expect(_groupOperations(operations, registers)).toEqual([[0], [0, 1], [1], []]);
     });
     test("no qubits", () => {
         const operations: Operation[] = [
-            { gate: "NoOp1", isMeasurement: false, controlled: false, adjoint: false, controls: [], targets: [] },
-            { gate: "NoOp2", isMeasurement: false, controlled: false, adjoint: false, controls: [], targets: [] },
+            { gate: "NoOp1", isMeasurement: false, isControlled: false, isAdjoint: false, controls: [], targets: [] },
+            { gate: "NoOp2", isMeasurement: false, isControlled: false, isAdjoint: false, controls: [], targets: [] },
         ];
         expect(_groupOperations(operations, registers)).toEqual([[], [], [], []]);
     });
@@ -263,8 +263,8 @@ describe("Testing _opToMetadata", () => {
         const op: Operation = {
             gate: "X",
             isMeasurement: false,
-            controlled: false,
-            adjoint: false,
+            isControlled: false,
+            isAdjoint: false,
             controls: [],
             targets: [{ type: RegisterType.Qubit, qId: 1 }]
         };
@@ -282,12 +282,12 @@ describe("Testing _opToMetadata", () => {
         };
         expect(_opToMetadata(op, registers)).toEqual(metadata);
     });
-    test("adjoint gate", () => {
+    test("isAdjoint gate", () => {
         const op: Operation = {
             gate: "Foo",
             isMeasurement: false,
-            controlled: false,
-            adjoint: true,
+            isControlled: false,
+            isAdjoint: true,
             controls: [],
             targets: [{ type: RegisterType.Qubit, qId: 1 }]
         };
@@ -309,8 +309,8 @@ describe("Testing _opToMetadata", () => {
         const op: Operation = {
             gate: "M",
             isMeasurement: true,
-            controlled: false,
-            adjoint: false,
+            isControlled: false,
+            isAdjoint: false,
             controls: [{ type: RegisterType.Qubit, qId: 0 }],
             targets: [{ type: RegisterType.Classical, qId: 0, cId: 0 }]
         };
@@ -331,8 +331,8 @@ describe("Testing _opToMetadata", () => {
         const op: Operation = {
             gate: "SWAP",
             isMeasurement: false,
-            controlled: false,
-            adjoint: false,
+            isControlled: false,
+            isAdjoint: false,
             controls: [],
             targets: [
                 { type: RegisterType.Qubit, qId: 0 },
@@ -353,12 +353,12 @@ describe("Testing _opToMetadata", () => {
         };
         expect(_opToMetadata(op, registers)).toEqual(metadata);
     });
-    test("controlled swap gate", () => {
+    test("isControlled swap gate", () => {
         const op: Operation = {
             gate: "SWAP",
             isMeasurement: false,
-            controlled: false,
-            adjoint: false,
+            isControlled: false,
+            isAdjoint: false,
             controls: [{ type: RegisterType.Qubit, qId: 0 }],
             targets: [
                 { type: RegisterType.Qubit, qId: 1 },
@@ -384,8 +384,8 @@ describe("Testing _opToMetadata", () => {
         const op: Operation = {
             gate: "X",
             isMeasurement: false,
-            controlled: false,
-            adjoint: false,
+            isControlled: false,
+            isAdjoint: false,
             controls: [],
             targets: [{ type: RegisterType.Qubit, qId: 0 }]
         };
@@ -411,8 +411,8 @@ describe("Testing _opToMetadata", () => {
         let op: Operation = {
             gate: "ZZ",
             isMeasurement: false,
-            controlled: false,
-            adjoint: false,
+            isControlled: false,
+            isAdjoint: false,
             controls: [],
             targets: [
                 { type: RegisterType.Qubit, qId: 0 },
@@ -431,8 +431,8 @@ describe("Testing _opToMetadata", () => {
         op = {
             gate: "XX",
             isMeasurement: false,
-            controlled: false,
-            adjoint: false,
+            isControlled: false,
+            isAdjoint: false,
             controls: [],
             targets: [
                 { type: RegisterType.Qubit, qId: 1 },
@@ -449,7 +449,7 @@ describe("Testing _opToMetadata", () => {
         };
         expect(_opToMetadata(op, registers)).toEqual(metadata);
     });
-    test("controlled unitary gates", () => {
+    test("isControlled unitary gates", () => {
         const registers: RegisterMap = {
             0: { type: RegisterType.Qubit, y: startY },
             1: { type: RegisterType.Qubit, y: startY + registerHeight },
@@ -459,8 +459,8 @@ describe("Testing _opToMetadata", () => {
         let op: Operation = {
             gate: "ZZ",
             isMeasurement: false,
-            controlled: true,
-            adjoint: false,
+            isControlled: true,
+            isAdjoint: false,
             controls: [{ type: RegisterType.Qubit, qId: 1 }],
             targets: [{ type: RegisterType.Qubit, qId: 0 }]
         };
@@ -476,8 +476,8 @@ describe("Testing _opToMetadata", () => {
         op = {
             gate: "XX",
             isMeasurement: false,
-            controlled: true,
-            adjoint: false,
+            isControlled: true,
+            isAdjoint: false,
             controls: [{ type: RegisterType.Qubit, qId: 0 }],
             targets: [
                 { type: RegisterType.Qubit, qId: 1 },
@@ -496,8 +496,8 @@ describe("Testing _opToMetadata", () => {
         op = {
             gate: "Foo",
             isMeasurement: false,
-            controlled: true,
-            adjoint: false,
+            isControlled: true,
+            isAdjoint: false,
             controls: [
                 { type: RegisterType.Qubit, qId: 2 },
                 { type: RegisterType.Qubit, qId: 3 },
@@ -526,8 +526,8 @@ describe("Testing _opToMetadata", () => {
             gate: "RX",
             displayArgs: "(0.25)",
             isMeasurement: false,
-            controlled: false,
-            adjoint: false,
+            isControlled: false,
+            isAdjoint: false,
             controls: [],
             targets: [{ type: RegisterType.Qubit, qId: 0 }]
         };
@@ -547,8 +547,8 @@ describe("Testing _opToMetadata", () => {
             gate: "RX",
             displayArgs: "(0.25, 1.0, 'foobar', (3.14, 6.67))",
             isMeasurement: false,
-            controlled: false,
-            adjoint: false,
+            isControlled: false,
+            isAdjoint: false,
             controls: [],
             targets: [{ type: RegisterType.Qubit, qId: 0 }]
         };
@@ -563,13 +563,13 @@ describe("Testing _opToMetadata", () => {
         };
         expect(_opToMetadata(op, registers)).toEqual(metadata);
 
-        // Test controlled
+        // Test isControlled
         op = {
             gate: "RX",
             displayArgs: "(0.25)",
             isMeasurement: false,
-            controlled: true,
-            adjoint: false,
+            isControlled: true,
+            isAdjoint: false,
             controls: [{ type: RegisterType.Qubit, qId: 1 }],
             targets: [{ type: RegisterType.Qubit, qId: 0 }]
         };
@@ -594,8 +594,8 @@ describe("Testing _opToMetadata", () => {
             gate: "U",
             displayArgs: "('foo', 'bar')",
             isMeasurement: false,
-            controlled: false,
-            adjoint: false,
+            isControlled: false,
+            isAdjoint: false,
             controls: [],
             targets: [
                 { type: RegisterType.Qubit, qId: 0 },
@@ -618,8 +618,8 @@ describe("Testing _opToMetadata", () => {
             gate: "U",
             displayArgs: "(0.25, 1.0, 'foobar', (3.14, 6.67))",
             isMeasurement: false,
-            controlled: false,
-            adjoint: false,
+            isControlled: false,
+            isAdjoint: false,
             controls: [],
             targets: [
                 { type: RegisterType.Qubit, qId: 0 },
@@ -637,13 +637,13 @@ describe("Testing _opToMetadata", () => {
         };
         expect(_opToMetadata(op, registers)).toEqual(metadata);
 
-        // Test controlled
+        // Test isControlled
         op = {
             gate: "U",
             displayArgs: "('foo', 'bar')",
             isMeasurement: false,
-            controlled: true,
-            adjoint: false,
+            isControlled: true,
+            isAdjoint: false,
             controls: [{ type: RegisterType.Qubit, qId: 1 }],
             targets: [
                 { type: RegisterType.Qubit, qId: 0 },
@@ -661,12 +661,12 @@ describe("Testing _opToMetadata", () => {
         };
         expect(_opToMetadata(op, registers)).toEqual(metadata);
     });
-    test("classically controlled gates", () => {
+    test("classically isControlled gates", () => {
         const op: Operation = {
             gate: "X",
             isMeasurement: false,
-            controlled: true,
-            adjoint: false,
+            isControlled: true,
+            isAdjoint: false,
             controls: [{ type: RegisterType.Classical, qId: 0, cId: 0 }],
             targets: [
                 { type: RegisterType.Qubit, qId: 0 },
@@ -676,16 +676,16 @@ describe("Testing _opToMetadata", () => {
                 [{
                     gate: "X",
                     isMeasurement: false,
-                    controlled: false,
-                    adjoint: false,
+                    isControlled: false,
+                    isAdjoint: false,
                     controls: [],
                     targets: [{ type: RegisterType.Qubit, qId: 0 }]
                 }],
                 [{
                     gate: "H",
                     isMeasurement: false,
-                    controlled: false,
-                    adjoint: false,
+                    isControlled: false,
+                    isAdjoint: false,
                     controls: [],
                     targets: [{ type: RegisterType.Qubit, qId: 1 }]
                 }]
@@ -738,8 +738,8 @@ describe("Testing _opToMetadata", () => {
         let op: Operation = {
             gate: "X",
             isMeasurement: false,
-            controlled: false,
-            adjoint: false,
+            isControlled: false,
+            isAdjoint: false,
             controls: [],
             targets: [{ type: RegisterType.Qubit, qId: 1 }]
         };
@@ -752,8 +752,8 @@ describe("Testing _opToMetadata", () => {
         op = {
             gate: "X",
             isMeasurement: false,
-            controlled: false,
-            adjoint: false,
+            isControlled: false,
+            isAdjoint: false,
             controls: [{ type: RegisterType.Classical, qId: 0, cId: 2 }],
             targets: []
         };
@@ -764,8 +764,8 @@ describe("Testing _opToMetadata", () => {
         const op: Operation = {
             gate: "X",
             isMeasurement: false,
-            controlled: false,
-            adjoint: false,
+            isControlled: false,
+            isAdjoint: false,
             controls: [],
             targets: [{ type: RegisterType.Qubit, qId: 2 }]
         };
@@ -1078,7 +1078,7 @@ describe("Testing _offsetChildrenX", () => {
 });
 
 describe("Testing _fillMetadataX", () => {
-    test("Non-classically-controlled gate", () => {
+    test("Non-classically-isControlled gate", () => {
         const columnWidths: number[] = Array(1).fill(minGateWidth);
         const expectedEndX = startX + minGateWidth + gatePadding * 2;
         const opsMetadata: Metadata[][] = [
@@ -1105,7 +1105,7 @@ describe("Testing _fillMetadataX", () => {
         expect(opsMetadata).toEqual(expected);
         expect(endX).toEqual(expectedEndX);
     });
-    test("classically-controlled gate with no children", () => {
+    test("classically-isControlled gate with no children", () => {
         const columnWidths: number[] = Array(1).fill(minGateWidth);
         const expectedEndX = startX + minGateWidth + gatePadding * 2;
         const opsMetadata: Metadata[][] = [
@@ -1195,24 +1195,24 @@ describe("Testing processOperations", () => {
             {
                 gate: "H",
                 isMeasurement: false,
-                controlled: false,
-                adjoint: false,
+                isControlled: false,
+                isAdjoint: false,
                 controls: [],
                 targets: [{ type: RegisterType.Qubit, qId: 0 }]
             },
             {
                 gate: "H",
                 isMeasurement: false,
-                controlled: false,
-                adjoint: false,
+                isControlled: false,
+                isAdjoint: false,
                 controls: [],
                 targets: [{ type: RegisterType.Qubit, qId: 0 }]
             },
             {
                 gate: "H",
                 isMeasurement: false,
-                controlled: false,
-                adjoint: false,
+                isControlled: false,
+                isAdjoint: false,
                 controls: [],
                 targets: [{ type: RegisterType.Qubit, qId: 1 }]
             },
@@ -1220,8 +1220,8 @@ describe("Testing processOperations", () => {
                 gate: "RX",
                 displayArgs: "(0.25)",
                 isMeasurement: false,
-                controlled: false,
-                adjoint: false,
+                isControlled: false,
+                isAdjoint: false,
                 controls: [],
                 targets: [{ type: RegisterType.Qubit, qId: 1 }]
             },
@@ -1276,24 +1276,24 @@ describe("Testing processOperations", () => {
             {
                 gate: "H",
                 isMeasurement: false,
-                controlled: false,
-                adjoint: false,
+                isControlled: false,
+                isAdjoint: false,
                 controls: [],
                 targets: [{ type: RegisterType.Qubit, qId: 0 }]
             },
             {
                 gate: "FooBar",
                 isMeasurement: false,
-                controlled: false,
-                adjoint: false,
+                isControlled: false,
+                isAdjoint: false,
                 controls: [],
                 targets: [{ type: RegisterType.Qubit, qId: 0 }]
             },
             {
                 gate: "H",
                 isMeasurement: false,
-                controlled: false,
-                adjoint: false,
+                isControlled: false,
+                isAdjoint: false,
                 controls: [],
                 targets: [{ type: RegisterType.Qubit, qId: 1 }]
             },
@@ -1338,24 +1338,24 @@ describe("Testing processOperations", () => {
             {
                 gate: "H",
                 isMeasurement: false,
-                controlled: false,
-                adjoint: false,
+                isControlled: false,
+                isAdjoint: false,
                 controls: [],
                 targets: [{ type: RegisterType.Qubit, qId: 0 }]
             },
             {
                 gate: "X",
                 isMeasurement: false,
-                controlled: true,
-                adjoint: false,
+                isControlled: true,
+                isAdjoint: false,
                 controls: [{ type: RegisterType.Qubit, qId: 1 }],
                 targets: [{ type: RegisterType.Qubit, qId: 0 }]
             },
             {
                 gate: "H",
                 isMeasurement: false,
-                controlled: false,
-                adjoint: false,
+                isControlled: false,
+                isAdjoint: false,
                 controls: [],
                 targets: [{ type: RegisterType.Qubit, qId: 1 }]
             },
@@ -1400,32 +1400,32 @@ describe("Testing processOperations", () => {
             {
                 gate: "H",
                 isMeasurement: false,
-                controlled: false,
-                adjoint: false,
+                isControlled: false,
+                isAdjoint: false,
                 controls: [],
                 targets: [{ type: RegisterType.Qubit, qId: 0 }]
             },
             {
                 gate: "M",
                 isMeasurement: true,
-                controlled: false,
-                adjoint: false,
+                isControlled: false,
+                isAdjoint: false,
                 controls: [{ type: RegisterType.Qubit, qId: 0 }],
                 targets: [{ type: RegisterType.Classical, qId: 0, cId: 0 }]
             },
             {
                 gate: "H",
                 isMeasurement: false,
-                controlled: false,
-                adjoint: false,
+                isControlled: false,
+                isAdjoint: false,
                 controls: [],
                 targets: [{ type: RegisterType.Qubit, qId: 1 }]
             },
             {
                 gate: "M",
                 isMeasurement: true,
-                controlled: false,
-                adjoint: false,
+                isControlled: false,
+                isAdjoint: false,
                 controls: [{ type: RegisterType.Qubit, qId: 0 }],
                 targets: [{ type: RegisterType.Classical, qId: 0, cId: 1 }]
             },
@@ -1485,16 +1485,16 @@ describe("Testing processOperations", () => {
             {
                 gate: "H",
                 isMeasurement: false,
-                controlled: false,
-                adjoint: false,
+                isControlled: false,
+                isAdjoint: false,
                 controls: [],
                 targets: [{ type: RegisterType.Qubit, qId: 0 }]
             },
             {
                 gate: "H",
                 isMeasurement: false,
-                controlled: false,
-                adjoint: false,
+                isControlled: false,
+                isAdjoint: false,
                 controls: [],
                 targets: [{ type: RegisterType.Qubit, qId: 2 }]
             },

--- a/src/Kernel/client/__tests__/ExecutionPathVisualizerTests/process.test.ts
+++ b/src/Kernel/client/__tests__/ExecutionPathVisualizerTests/process.test.ts
@@ -34,62 +34,62 @@ describe("Testing _groupOperations", () => {
     };
     test("single qubit gates on 1 qubit register", () => {
         const operations: Operation[] = [
-            { gate: "X", controlled: false, adjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
-            { gate: "Y", controlled: false, adjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
-            { gate: "Z", controlled: false, adjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
+            { gate: "X", isMeasurement: false, controlled: false, adjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
+            { gate: "Y", isMeasurement: false, controlled: false, adjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
+            { gate: "Z", isMeasurement: false, controlled: false, adjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
         ];
         expect(_groupOperations(operations, registers)).toEqual([[0, 1, 2], [], [], []]);
     });
     test("single qubit gates on multiple qubit registers", () => {
         const operations: Operation[] = [
-            { gate: "X", controlled: false, adjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
-            { gate: "Y", controlled: false, adjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 1 }] },
-            { gate: "Z", controlled: false, adjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 2 }] },
-            { gate: "H", controlled: false, adjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
-            { gate: "T", controlled: false, adjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 1 }] },
+            { gate: "X", isMeasurement: false, controlled: false, adjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
+            { gate: "Y", isMeasurement: false, controlled: false, adjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 1 }] },
+            { gate: "Z", isMeasurement: false, controlled: false, adjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 2 }] },
+            { gate: "H", isMeasurement: false, controlled: false, adjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
+            { gate: "T", isMeasurement: false, controlled: false, adjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 1 }] },
         ];
         expect(_groupOperations(operations, registers)).toEqual([[0, 3], [1, 4], [2], []]);
     });
     test("single and multiple qubit(s) gates", () => {
         let operations: Operation[] = [
-            { gate: "X", controlled: false, adjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
-            { gate: "Y", controlled: true, adjoint: false, controls: [{ type: RegisterType.Qubit, qId: 0 }], targets: [{ type: RegisterType.Qubit, qId: 1 }] },
-            { gate: "Z", controlled: false, adjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
+            { gate: "X", isMeasurement: false, controlled: false, adjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
+            { gate: "Y", isMeasurement: false, controlled: true, adjoint: false, controls: [{ type: RegisterType.Qubit, qId: 0 }], targets: [{ type: RegisterType.Qubit, qId: 1 }] },
+            { gate: "Z", isMeasurement: false, controlled: false, adjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
         ];
         expect(_groupOperations(operations, registers)).toEqual([[0, 1, 2], [1], [], []]);
         operations = [
-            { gate: "X", controlled: false, adjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
-            { gate: "Y", controlled: true, adjoint: false, controls: [{ type: RegisterType.Qubit, qId: 1 }], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
-            { gate: "Z", controlled: false, adjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
+            { gate: "X", isMeasurement: false, controlled: false, adjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
+            { gate: "Y", isMeasurement: false, controlled: true, adjoint: false, controls: [{ type: RegisterType.Qubit, qId: 1 }], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
+            { gate: "Z", isMeasurement: false, controlled: false, adjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
         ];
         expect(_groupOperations(operations, registers)).toEqual([[0, 1, 2], [1], [], []]);
         operations = [
-            { gate: "X", controlled: false, adjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
-            { gate: "Z", controlled: false, adjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
-            { gate: "Y", controlled: true, adjoint: false, controls: [{ type: RegisterType.Qubit, qId: 1 }], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
+            { gate: "X", isMeasurement: false, controlled: false, adjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
+            { gate: "Z", isMeasurement: false, controlled: false, adjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
+            { gate: "Y", isMeasurement: false, controlled: true, adjoint: false, controls: [{ type: RegisterType.Qubit, qId: 1 }], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
         ];
         expect(_groupOperations(operations, registers)).toEqual([[0, 1, 2], [2], [], []]);
         operations = [
-            { gate: "Y", controlled: true, adjoint: false, controls: [{ type: RegisterType.Qubit, qId: 1 }], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
-            { gate: "X", controlled: false, adjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
-            { gate: "Z", controlled: false, adjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
+            { gate: "Y", isMeasurement: false, controlled: true, adjoint: false, controls: [{ type: RegisterType.Qubit, qId: 1 }], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
+            { gate: "X", isMeasurement: false, controlled: false, adjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
+            { gate: "Z", isMeasurement: false, controlled: false, adjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
         ];
         expect(_groupOperations(operations, registers)).toEqual([[0, 1, 2], [0], [], []]);
         operations = [
-            { gate: "Y", controlled: true, adjoint: false, controls: [{ type: RegisterType.Qubit, qId: 1 }], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
-            { gate: "X", controlled: false, adjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
-            { gate: "Z", controlled: false, adjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 1 }] },
+            { gate: "Y", isMeasurement: false, controlled: true, adjoint: false, controls: [{ type: RegisterType.Qubit, qId: 1 }], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
+            { gate: "X", isMeasurement: false, controlled: false, adjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
+            { gate: "Z", isMeasurement: false, controlled: false, adjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 1 }] },
         ];
         expect(_groupOperations(operations, registers)).toEqual([[0, 1], [0, 2], [], []]);
     });
     test("multiple qubit gates in ladder format", () => {
         const operations: Operation[] = [
-            { gate: "X", controlled: true, adjoint: false, controls: [{ type: RegisterType.Qubit, qId: 1 }], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
-            { gate: "Y", controlled: true, adjoint: false, controls: [{ type: RegisterType.Qubit, qId: 1 }], targets: [{ type: RegisterType.Qubit, qId: 2 }] },
-            { gate: "Z", controlled: true, adjoint: false, controls: [{ type: RegisterType.Qubit, qId: 2 }], targets: [{ type: RegisterType.Qubit, qId: 3 }] },
-            { gate: "H", controlled: true, adjoint: false, controls: [{ type: RegisterType.Qubit, qId: 2 }], targets: [{ type: RegisterType.Qubit, qId: 3 }] },
-            { gate: "T", controlled: true, adjoint: false, controls: [{ type: RegisterType.Qubit, qId: 2 }], targets: [{ type: RegisterType.Qubit, qId: 1 }] },
-            { gate: "X", controlled: true, adjoint: false, controls: [{ type: RegisterType.Qubit, qId: 0 }], targets: [{ type: RegisterType.Qubit, qId: 1 }] },
+            { gate: "X", isMeasurement: false, controlled: true, adjoint: false, controls: [{ type: RegisterType.Qubit, qId: 1 }], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
+            { gate: "Y", isMeasurement: false, controlled: true, adjoint: false, controls: [{ type: RegisterType.Qubit, qId: 1 }], targets: [{ type: RegisterType.Qubit, qId: 2 }] },
+            { gate: "Z", isMeasurement: false, controlled: true, adjoint: false, controls: [{ type: RegisterType.Qubit, qId: 2 }], targets: [{ type: RegisterType.Qubit, qId: 3 }] },
+            { gate: "H", isMeasurement: false, controlled: true, adjoint: false, controls: [{ type: RegisterType.Qubit, qId: 2 }], targets: [{ type: RegisterType.Qubit, qId: 3 }] },
+            { gate: "T", isMeasurement: false, controlled: true, adjoint: false, controls: [{ type: RegisterType.Qubit, qId: 2 }], targets: [{ type: RegisterType.Qubit, qId: 1 }] },
+            { gate: "X", isMeasurement: false, controlled: true, adjoint: false, controls: [{ type: RegisterType.Qubit, qId: 0 }], targets: [{ type: RegisterType.Qubit, qId: 1 }] },
         ];
         expect(_groupOperations(operations, registers)).toEqual([[0, 5], [0, 1, 4, 5], [1, 2, 3, 4], [2, 3]]);
 
@@ -97,48 +97,48 @@ describe("Testing _groupOperations", () => {
     test("multiple qubit gates in ladder format with single qubit gate", () => {
         let numRegs: number = 4;
         let operations: Operation[] = [
-            { gate: "X", controlled: true, adjoint: false, controls: [{ type: RegisterType.Qubit, qId: 1 }], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
-            { gate: "Y", controlled: false, adjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 1 }] },
-            { gate: "Y", controlled: true, adjoint: false, controls: [{ type: RegisterType.Qubit, qId: 1 }], targets: [{ type: RegisterType.Qubit, qId: 2 }] },
-            { gate: "Z", controlled: true, adjoint: false, controls: [{ type: RegisterType.Qubit, qId: 2 }], targets: [{ type: RegisterType.Qubit, qId: 3 }] },
-            { gate: "Z", controlled: false, adjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 2 }] },
-            { gate: "H", controlled: true, adjoint: false, controls: [{ type: RegisterType.Qubit, qId: 2 }], targets: [{ type: RegisterType.Qubit, qId: 3 }] },
-            { gate: "T", controlled: true, adjoint: false, controls: [{ type: RegisterType.Qubit, qId: 2 }], targets: [{ type: RegisterType.Qubit, qId: 1 }] },
-            { gate: "Y", controlled: false, adjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 1 }] },
-            { gate: "X", controlled: true, adjoint: false, controls: [{ type: RegisterType.Qubit, qId: 0 }], targets: [{ type: RegisterType.Qubit, qId: 1 }] },
+            { gate: "X", isMeasurement: false, controlled: true, adjoint: false, controls: [{ type: RegisterType.Qubit, qId: 1 }], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
+            { gate: "Y", isMeasurement: false, controlled: false, adjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 1 }] },
+            { gate: "Y", isMeasurement: false, controlled: true, adjoint: false, controls: [{ type: RegisterType.Qubit, qId: 1 }], targets: [{ type: RegisterType.Qubit, qId: 2 }] },
+            { gate: "Z", isMeasurement: false, controlled: true, adjoint: false, controls: [{ type: RegisterType.Qubit, qId: 2 }], targets: [{ type: RegisterType.Qubit, qId: 3 }] },
+            { gate: "Z", isMeasurement: false, controlled: false, adjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 2 }] },
+            { gate: "H", isMeasurement: false, controlled: true, adjoint: false, controls: [{ type: RegisterType.Qubit, qId: 2 }], targets: [{ type: RegisterType.Qubit, qId: 3 }] },
+            { gate: "T", isMeasurement: false, controlled: true, adjoint: false, controls: [{ type: RegisterType.Qubit, qId: 2 }], targets: [{ type: RegisterType.Qubit, qId: 1 }] },
+            { gate: "Y", isMeasurement: false, controlled: false, adjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 1 }] },
+            { gate: "X", isMeasurement: false, controlled: true, adjoint: false, controls: [{ type: RegisterType.Qubit, qId: 0 }], targets: [{ type: RegisterType.Qubit, qId: 1 }] },
         ];
         expect(_groupOperations(operations, registers)).toEqual([[0, 8], [0, 1, 2, 6, 7, 8], [2, 3, 4, 5, 6], [3, 5]]);
 
         numRegs = 3;
         operations = [
-            { gate: "X", controlled: true, adjoint: false, controls: [{ type: RegisterType.Qubit, qId: 1 }], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
-            { gate: "Y", controlled: false, adjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 1 }] },
-            { gate: "Y", controlled: true, adjoint: false, controls: [{ type: RegisterType.Qubit, qId: 1 }], targets: [{ type: RegisterType.Qubit, qId: 2 }] },
-            { gate: "Z", controlled: false, adjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 2 }] },
-            { gate: "T", controlled: true, adjoint: false, controls: [{ type: RegisterType.Qubit, qId: 2 }], targets: [{ type: RegisterType.Qubit, qId: 1 }] },
-            { gate: "Y", controlled: false, adjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 1 }] },
-            { gate: "H", controlled: false, adjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
-            { gate: "H", controlled: false, adjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
-            { gate: "H", controlled: false, adjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
-            { gate: "H", controlled: false, adjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
-            { gate: "X", controlled: true, adjoint: false, controls: [{ type: RegisterType.Qubit, qId: 0 }], targets: [{ type: RegisterType.Qubit, qId: 1 }] },
+            { gate: "X", isMeasurement: false, controlled: true, adjoint: false, controls: [{ type: RegisterType.Qubit, qId: 1 }], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
+            { gate: "Y", isMeasurement: false, controlled: false, adjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 1 }] },
+            { gate: "Y", isMeasurement: false, controlled: true, adjoint: false, controls: [{ type: RegisterType.Qubit, qId: 1 }], targets: [{ type: RegisterType.Qubit, qId: 2 }] },
+            { gate: "Z", isMeasurement: false, controlled: false, adjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 2 }] },
+            { gate: "T", isMeasurement: false, controlled: true, adjoint: false, controls: [{ type: RegisterType.Qubit, qId: 2 }], targets: [{ type: RegisterType.Qubit, qId: 1 }] },
+            { gate: "Y", isMeasurement: false, controlled: false, adjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 1 }] },
+            { gate: "H", isMeasurement: false, controlled: false, adjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
+            { gate: "H", isMeasurement: false, controlled: false, adjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
+            { gate: "H", isMeasurement: false, controlled: false, adjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
+            { gate: "H", isMeasurement: false, controlled: false, adjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
+            { gate: "X", isMeasurement: false, controlled: true, adjoint: false, controls: [{ type: RegisterType.Qubit, qId: 0 }], targets: [{ type: RegisterType.Qubit, qId: 1 }] },
         ];
         expect(_groupOperations(operations, registers)).toEqual([[0, 6, 7, 8, 9, 10], [0, 1, 2, 4, 5, 10], [2, 3, 4], []]);
     });
     test("interleaved multiqubit gates", () => {
         let operations: Operation[] = [
-            { gate: "X", controlled: true, adjoint: false, controls: [{ type: RegisterType.Qubit, qId: 1 }], targets: [{ type: RegisterType.Qubit, qId: 3 }] },
-            { gate: "X", controlled: true, adjoint: false, controls: [{ type: RegisterType.Qubit, qId: 0 }], targets: [{ type: RegisterType.Qubit, qId: 2 }] },
+            { gate: "X", isMeasurement: false, controlled: true, adjoint: false, controls: [{ type: RegisterType.Qubit, qId: 1 }], targets: [{ type: RegisterType.Qubit, qId: 3 }] },
+            { gate: "X", isMeasurement: false, controlled: true, adjoint: false, controls: [{ type: RegisterType.Qubit, qId: 0 }], targets: [{ type: RegisterType.Qubit, qId: 2 }] },
         ];
         expect(_groupOperations(operations, registers)).toEqual([[1], [0, 1], [0, 1], [0]]);
         operations = [
-            { gate: "X", controlled: true, adjoint: false, controls: [{ type: RegisterType.Qubit, qId: 0 }, { type: RegisterType.Qubit, qId: 1 }], targets: [{ type: RegisterType.Qubit, qId: 3 }] },
-            { gate: "X", controlled: true, adjoint: false, controls: [{ type: RegisterType.Qubit, qId: 0 }], targets: [{ type: RegisterType.Qubit, qId: 2 }, { type: RegisterType.Qubit, qId: 3 }] },
+            { gate: "X", isMeasurement: false, controlled: true, adjoint: false, controls: [{ type: RegisterType.Qubit, qId: 0 }, { type: RegisterType.Qubit, qId: 1 }], targets: [{ type: RegisterType.Qubit, qId: 3 }] },
+            { gate: "X", isMeasurement: false, controlled: true, adjoint: false, controls: [{ type: RegisterType.Qubit, qId: 0 }], targets: [{ type: RegisterType.Qubit, qId: 2 }, { type: RegisterType.Qubit, qId: 3 }] },
         ];
         expect(_groupOperations(operations, registers)).toEqual([[0, 1], [0, 1], [0, 1], [0, 1]]);
         operations = [
-            { gate: "Foo", controlled: false, adjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 0 }, { type: RegisterType.Qubit, qId: 2 }, { type: RegisterType.Qubit, qId: 3 }] },
-            { gate: "Bar", controlled: false, adjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 0 }, { type: RegisterType.Qubit, qId: 1 }, { type: RegisterType.Qubit, qId: 2 }] },
+            { gate: "Foo", isMeasurement: false, controlled: false, adjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 0 }, { type: RegisterType.Qubit, qId: 2 }, { type: RegisterType.Qubit, qId: 3 }] },
+            { gate: "Bar", isMeasurement: false, controlled: false, adjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 0 }, { type: RegisterType.Qubit, qId: 1 }, { type: RegisterType.Qubit, qId: 2 }] },
         ];
         expect(_groupOperations(operations, registers)).toEqual([[0, 1], [0, 1], [0, 1], [0]]);
     });
@@ -158,37 +158,37 @@ describe("Testing _groupOperations", () => {
             3: { type: RegisterType.Qubit, y: startY + registerHeight + classicalRegHeight * 4 },
         }
         let operations: Operation[] = [
-            { gate: "X", controlled: true, adjoint: false, controls: [{ type: RegisterType.Classical, qId: 2, cId: 0 }], targets: [{ type: RegisterType.Qubit, qId: 1 }] },
-            { gate: "X", controlled: false, adjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
+            { gate: "X", isMeasurement: false, controlled: true, adjoint: false, controls: [{ type: RegisterType.Classical, qId: 2, cId: 0 }], targets: [{ type: RegisterType.Qubit, qId: 1 }] },
+            { gate: "X", isMeasurement: false, controlled: false, adjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
         ];
         expect(_groupOperations(operations, registers)).toEqual([[0, 1], [0], [0], [0]]);
         operations = [
-            { gate: "X", controlled: true, adjoint: false, controls: [{ type: RegisterType.Classical, qId: 2, cId: 0 }], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
-            { gate: "X", controlled: false, adjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 1 }] },
+            { gate: "X", isMeasurement: false, controlled: true, adjoint: false, controls: [{ type: RegisterType.Classical, qId: 2, cId: 0 }], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
+            { gate: "X", isMeasurement: false, controlled: false, adjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 1 }] },
         ];
         expect(_groupOperations(operations, registers)).toEqual([[0], [0, 1], [0], [0]]);
         operations = [
-            { gate: "X", controlled: false, adjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 1 }] },
-            { gate: "X", controlled: true, adjoint: false, controls: [{ type: RegisterType.Classical, qId: 1, cId: 0 }], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
+            { gate: "X", isMeasurement: false, controlled: false, adjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 1 }] },
+            { gate: "X", isMeasurement: false, controlled: true, adjoint: false, controls: [{ type: RegisterType.Classical, qId: 1, cId: 0 }], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
         ];
         expect(_groupOperations(operations, registers)).toEqual([[1], [0, 1], [1], [1]]);
     });
     test("skipped registers", () => {
         let operations: Operation[] = [
-            { gate: "X", controlled: false, adjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
-            { gate: "Z", controlled: false, adjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 2 }] },
+            { gate: "X", isMeasurement: false, controlled: false, adjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
+            { gate: "Z", isMeasurement: false, controlled: false, adjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 2 }] },
         ];
         expect(_groupOperations(operations, registers)).toEqual([[0], [], [1], []]);
         operations = [
-            { gate: "X", controlled: true, adjoint: false, controls: [{ type: RegisterType.Qubit, qId: 1 }], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
-            { gate: "Z", controlled: true, adjoint: false, controls: [{ type: RegisterType.Qubit, qId: 1 }], targets: [{ type: RegisterType.Qubit, qId: 2 }] },
+            { gate: "X", isMeasurement: false, controlled: true, adjoint: false, controls: [{ type: RegisterType.Qubit, qId: 1 }], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
+            { gate: "Z", isMeasurement: false, controlled: true, adjoint: false, controls: [{ type: RegisterType.Qubit, qId: 1 }], targets: [{ type: RegisterType.Qubit, qId: 2 }] },
         ];
         expect(_groupOperations(operations, registers)).toEqual([[0], [0, 1], [1], []]);
     });
     test("no qubits", () => {
         const operations: Operation[] = [
-            { gate: "NoOp1", controlled: false, adjoint: false, controls: [], targets: [] },
-            { gate: "NoOp2", controlled: false, adjoint: false, controls: [], targets: [] },
+            { gate: "NoOp1", isMeasurement: false, controlled: false, adjoint: false, controls: [], targets: [] },
+            { gate: "NoOp2", isMeasurement: false, controlled: false, adjoint: false, controls: [], targets: [] },
         ];
         expect(_groupOperations(operations, registers)).toEqual([[], [], [], []]);
     });
@@ -262,6 +262,7 @@ describe("Testing _opToMetadata", () => {
     test("single qubit gate", () => {
         const op: Operation = {
             gate: "X",
+            isMeasurement: false,
             controlled: false,
             adjoint: false,
             controls: [],
@@ -284,6 +285,7 @@ describe("Testing _opToMetadata", () => {
     test("adjoint gate", () => {
         const op: Operation = {
             gate: "Foo",
+            isMeasurement: false,
             controlled: false,
             adjoint: true,
             controls: [],
@@ -305,7 +307,8 @@ describe("Testing _opToMetadata", () => {
     });
     test("measure gate", () => {
         const op: Operation = {
-            gate: "measure",
+            gate: "M",
+            isMeasurement: true,
             controlled: false,
             adjoint: false,
             controls: [{ type: RegisterType.Qubit, qId: 0 }],
@@ -327,6 +330,7 @@ describe("Testing _opToMetadata", () => {
     test("swap gate", () => {
         const op: Operation = {
             gate: "SWAP",
+            isMeasurement: false,
             controlled: false,
             adjoint: false,
             controls: [],
@@ -352,6 +356,7 @@ describe("Testing _opToMetadata", () => {
     test("controlled swap gate", () => {
         const op: Operation = {
             gate: "SWAP",
+            isMeasurement: false,
             controlled: false,
             adjoint: false,
             controls: [{ type: RegisterType.Qubit, qId: 0 }],
@@ -378,6 +383,7 @@ describe("Testing _opToMetadata", () => {
     test("single qubit unitary gate", () => {
         const op: Operation = {
             gate: "X",
+            isMeasurement: false,
             controlled: false,
             adjoint: false,
             controls: [],
@@ -404,6 +410,7 @@ describe("Testing _opToMetadata", () => {
         };
         let op: Operation = {
             gate: "ZZ",
+            isMeasurement: false,
             controlled: false,
             adjoint: false,
             controls: [],
@@ -423,6 +430,7 @@ describe("Testing _opToMetadata", () => {
         expect(_opToMetadata(op, registers)).toEqual(metadata);
         op = {
             gate: "XX",
+            isMeasurement: false,
             controlled: false,
             adjoint: false,
             controls: [],
@@ -450,6 +458,7 @@ describe("Testing _opToMetadata", () => {
         };
         let op: Operation = {
             gate: "ZZ",
+            isMeasurement: false,
             controlled: true,
             adjoint: false,
             controls: [{ type: RegisterType.Qubit, qId: 1 }],
@@ -466,6 +475,7 @@ describe("Testing _opToMetadata", () => {
         expect(_opToMetadata(op, registers)).toEqual(metadata);
         op = {
             gate: "XX",
+            isMeasurement: false,
             controlled: true,
             adjoint: false,
             controls: [{ type: RegisterType.Qubit, qId: 0 }],
@@ -485,6 +495,7 @@ describe("Testing _opToMetadata", () => {
         expect(_opToMetadata(op, registers)).toEqual(metadata);
         op = {
             gate: "Foo",
+            isMeasurement: false,
             controlled: true,
             adjoint: false,
             controls: [
@@ -514,6 +525,7 @@ describe("Testing _opToMetadata", () => {
         let op: Operation = {
             gate: "RX",
             displayArgs: "(0.25)",
+            isMeasurement: false,
             controlled: false,
             adjoint: false,
             controls: [],
@@ -534,6 +546,7 @@ describe("Testing _opToMetadata", () => {
         op = {
             gate: "RX",
             displayArgs: "(0.25, 1.0, 'foobar', (3.14, 6.67))",
+            isMeasurement: false,
             controlled: false,
             adjoint: false,
             controls: [],
@@ -554,6 +567,7 @@ describe("Testing _opToMetadata", () => {
         op = {
             gate: "RX",
             displayArgs: "(0.25)",
+            isMeasurement: false,
             controlled: true,
             adjoint: false,
             controls: [{ type: RegisterType.Qubit, qId: 1 }],
@@ -579,6 +593,7 @@ describe("Testing _opToMetadata", () => {
         let op: Operation = {
             gate: "U",
             displayArgs: "('foo', 'bar')",
+            isMeasurement: false,
             controlled: false,
             adjoint: false,
             controls: [],
@@ -602,6 +617,7 @@ describe("Testing _opToMetadata", () => {
         op = {
             gate: "U",
             displayArgs: "(0.25, 1.0, 'foobar', (3.14, 6.67))",
+            isMeasurement: false,
             controlled: false,
             adjoint: false,
             controls: [],
@@ -625,6 +641,7 @@ describe("Testing _opToMetadata", () => {
         op = {
             gate: "U",
             displayArgs: "('foo', 'bar')",
+            isMeasurement: false,
             controlled: true,
             adjoint: false,
             controls: [{ type: RegisterType.Qubit, qId: 1 }],
@@ -647,6 +664,7 @@ describe("Testing _opToMetadata", () => {
     test("classically controlled gates", () => {
         const op: Operation = {
             gate: "X",
+            isMeasurement: false,
             controlled: true,
             adjoint: false,
             controls: [{ type: RegisterType.Classical, qId: 0, cId: 0 }],
@@ -657,6 +675,7 @@ describe("Testing _opToMetadata", () => {
             children: [
                 [{
                     gate: "X",
+                    isMeasurement: false,
                     controlled: false,
                     adjoint: false,
                     controls: [],
@@ -664,6 +683,7 @@ describe("Testing _opToMetadata", () => {
                 }],
                 [{
                     gate: "H",
+                    isMeasurement: false,
                     controlled: false,
                     adjoint: false,
                     controls: [],
@@ -717,6 +737,7 @@ describe("Testing _opToMetadata", () => {
     test("Invalid register", () => {
         let op: Operation = {
             gate: "X",
+            isMeasurement: false,
             controlled: false,
             adjoint: false,
             controls: [],
@@ -730,6 +751,7 @@ describe("Testing _opToMetadata", () => {
 
         op = {
             gate: "X",
+            isMeasurement: false,
             controlled: false,
             adjoint: false,
             controls: [{ type: RegisterType.Classical, qId: 0, cId: 2 }],
@@ -741,6 +763,7 @@ describe("Testing _opToMetadata", () => {
     test("skipped registers", () => {
         const op: Operation = {
             gate: "X",
+            isMeasurement: false,
             controlled: false,
             adjoint: false,
             controls: [],
@@ -1171,6 +1194,7 @@ describe("Testing processOperations", () => {
         const operations: Operation[] = [
             {
                 gate: "H",
+                isMeasurement: false,
                 controlled: false,
                 adjoint: false,
                 controls: [],
@@ -1178,6 +1202,7 @@ describe("Testing processOperations", () => {
             },
             {
                 gate: "H",
+                isMeasurement: false,
                 controlled: false,
                 adjoint: false,
                 controls: [],
@@ -1185,6 +1210,7 @@ describe("Testing processOperations", () => {
             },
             {
                 gate: "H",
+                isMeasurement: false,
                 controlled: false,
                 adjoint: false,
                 controls: [],
@@ -1193,6 +1219,7 @@ describe("Testing processOperations", () => {
             {
                 gate: "RX",
                 displayArgs: "(0.25)",
+                isMeasurement: false,
                 controlled: false,
                 adjoint: false,
                 controls: [],
@@ -1248,6 +1275,7 @@ describe("Testing processOperations", () => {
         const operations: Operation[] = [
             {
                 gate: "H",
+                isMeasurement: false,
                 controlled: false,
                 adjoint: false,
                 controls: [],
@@ -1255,6 +1283,7 @@ describe("Testing processOperations", () => {
             },
             {
                 gate: "FooBar",
+                isMeasurement: false,
                 controlled: false,
                 adjoint: false,
                 controls: [],
@@ -1262,6 +1291,7 @@ describe("Testing processOperations", () => {
             },
             {
                 gate: "H",
+                isMeasurement: false,
                 controlled: false,
                 adjoint: false,
                 controls: [],
@@ -1307,6 +1337,7 @@ describe("Testing processOperations", () => {
         const operations: Operation[] = [
             {
                 gate: "H",
+                isMeasurement: false,
                 controlled: false,
                 adjoint: false,
                 controls: [],
@@ -1314,6 +1345,7 @@ describe("Testing processOperations", () => {
             },
             {
                 gate: "X",
+                isMeasurement: false,
                 controlled: true,
                 adjoint: false,
                 controls: [{ type: RegisterType.Qubit, qId: 1 }],
@@ -1321,6 +1353,7 @@ describe("Testing processOperations", () => {
             },
             {
                 gate: "H",
+                isMeasurement: false,
                 controlled: false,
                 adjoint: false,
                 controls: [],
@@ -1366,13 +1399,15 @@ describe("Testing processOperations", () => {
         const operations: Operation[] = [
             {
                 gate: "H",
+                isMeasurement: false,
                 controlled: false,
                 adjoint: false,
                 controls: [],
                 targets: [{ type: RegisterType.Qubit, qId: 0 }]
             },
             {
-                gate: "measure",
+                gate: "M",
+                isMeasurement: true,
                 controlled: false,
                 adjoint: false,
                 controls: [{ type: RegisterType.Qubit, qId: 0 }],
@@ -1380,13 +1415,15 @@ describe("Testing processOperations", () => {
             },
             {
                 gate: "H",
+                isMeasurement: false,
                 controlled: false,
                 adjoint: false,
                 controls: [],
                 targets: [{ type: RegisterType.Qubit, qId: 1 }]
             },
             {
-                gate: "measure",
+                gate: "M",
+                isMeasurement: true,
                 controlled: false,
                 adjoint: false,
                 controls: [{ type: RegisterType.Qubit, qId: 0 }],
@@ -1447,6 +1484,7 @@ describe("Testing processOperations", () => {
         const operations: Operation[] = [
             {
                 gate: "H",
+                isMeasurement: false,
                 controlled: false,
                 adjoint: false,
                 controls: [],
@@ -1454,6 +1492,7 @@ describe("Testing processOperations", () => {
             },
             {
                 gate: "H",
+                isMeasurement: false,
                 controlled: false,
                 adjoint: false,
                 controls: [],

--- a/src/Tests/ExecutionPathTracerTests.cs
+++ b/src/Tests/ExecutionPathTracerTests.cs
@@ -74,7 +74,8 @@ namespace Tests.IQSharp
             {
                 new Operation()
                 {
-                    Gate = "measure",
+                    Gate = "M",
+                    IsMeasurement = true,
                     Controls = new List<Register>() { new QubitRegister(0) },
                     Targets = new List<Register>() { new ClassicalRegister(0, 0) },
                 },
@@ -561,7 +562,8 @@ namespace Tests.IQSharp
                 },
                 new Operation()
                 {
-                    Gate = "measure",
+                    Gate = "M",
+                    IsMeasurement = true,
                     Controls = new List<Register>() { new QubitRegister(0) },
                     Targets = new List<Register>() { new ClassicalRegister(0, 0) },
                 },
@@ -595,7 +597,8 @@ namespace Tests.IQSharp
             {
                     new Operation()
                     {
-                        Gate = "measure",
+                        Gate = "MResetX",
+                        IsMeasurement = true,
                         Controls = new List<Register>() { new QubitRegister(0) },
                         Targets = new List<Register>() { new ClassicalRegister(0, 0) },
                     },
@@ -616,7 +619,8 @@ namespace Tests.IQSharp
             {
                     new Operation()
                     {
-                        Gate = "measure",
+                        Gate = "MResetY",
+                        IsMeasurement = true,
                         Controls = new List<Register>() { new QubitRegister(0) },
                         Targets = new List<Register>() { new ClassicalRegister(0, 0) },
                     },
@@ -637,7 +641,8 @@ namespace Tests.IQSharp
             {
                     new Operation()
                     {
-                        Gate = "measure",
+                        Gate = "MResetZ",
+                        IsMeasurement = true,
                         Controls = new List<Register>() { new QubitRegister(0) },
                         Targets = new List<Register>() { new ClassicalRegister(0, 0) },
                     },

--- a/src/Tests/ExecutionPathTracerTests.cs
+++ b/src/Tests/ExecutionPathTracerTests.cs
@@ -98,7 +98,7 @@ namespace Tests.IQSharp
                 new Operation()
                 {
                     Gate = "X",
-                    Controlled = true,
+                    IsControlled = true,
                     Controls = new List<Register>() { new QubitRegister(0) },
                     Targets = new List<Register>() { new QubitRegister(1) },
                 },
@@ -127,7 +127,7 @@ namespace Tests.IQSharp
                 new Operation()
                 {
                     Gate = "X",
-                    Controlled = true,
+                    IsControlled = true,
                     Controls = new List<Register>() { new QubitRegister(0), new QubitRegister(2) },
                     Targets = new List<Register>() { new QubitRegister(1) },
                 },
@@ -206,7 +206,7 @@ namespace Tests.IQSharp
                 new Operation()
                 {
                     Gate = "H",
-                    Adjoint = true,
+                    IsAdjoint = true,
                     Targets = new List<Register>() { new QubitRegister(0) },
                 },
                 new Operation()
@@ -233,7 +233,7 @@ namespace Tests.IQSharp
                 new Operation()
                 {
                     Gate = "X",
-                    Controlled = true,
+                    IsControlled = true,
                     Controls = new List<Register>() { new QubitRegister(0) },
                     Targets = new List<Register>() { new QubitRegister(1) },
                 },
@@ -265,8 +265,8 @@ namespace Tests.IQSharp
                 new Operation()
                 {
                     Gate = "S",
-                    Controlled = true,
-                    Adjoint = true,
+                    IsControlled = true,
+                    IsAdjoint = true,
                     Controls = new List<Register>() { new QubitRegister(0) },
                     Targets = new List<Register>() { new QubitRegister(1) },
                 },
@@ -320,7 +320,7 @@ namespace Tests.IQSharp
                 {
                     Gate = "Foo",
                     DisplayArgs = "(2.1, (\"bar\"))",
-                    Controlled = true,
+                    IsControlled = true,
                     Controls = new List<Register>() { new QubitRegister(0) },
                     Targets = new List<Register>() { new QubitRegister(1) },
                 },
@@ -343,7 +343,7 @@ namespace Tests.IQSharp
                 new Operation()
                 {
                     Gate = "X",
-                    Controlled = true,
+                    IsControlled = true,
                     Controls = new List<Register>() { new QubitRegister(2) },
                     Targets = new List<Register>() { new QubitRegister(0) },
                 },
@@ -404,7 +404,7 @@ namespace Tests.IQSharp
                 new Operation()
                 {
                     Gate = "H",
-                    Controlled = true,
+                    IsControlled = true,
                     Controls = new List<Register>() { new QubitRegister(0), new QubitRegister(1) },
                     Targets = new List<Register>() { new QubitRegister(2) },
                 },
@@ -540,14 +540,14 @@ namespace Tests.IQSharp
                 new Operation()
                 {
                     Gate = "X",
-                    Controlled = true,
+                    IsControlled = true,
                     Controls = new List<Register>() { new QubitRegister(0), new QubitRegister(1) },
                     Targets = new List<Register>() { new QubitRegister(2) },
                 },
                 new Operation()
                 {
                     Gate = "X",
-                    Controlled = true,
+                    IsControlled = true,
                     Controls = new List<Register>() { new QubitRegister(0), new QubitRegister(1) },
                     Targets = new List<Register>() { new QubitRegister(2) },
                 },
@@ -555,8 +555,8 @@ namespace Tests.IQSharp
                 {
                     Gate = "Bar",
                     DisplayArgs = "((1, 2.1), (\"foo\"))",
-                    Controlled = true,
-                    Adjoint = true,
+                    IsControlled = true,
+                    IsAdjoint = true,
                     Controls = new List<Register>() { new QubitRegister(2) },
                     Targets = new List<Register>() { new QubitRegister(0) },
                 },


### PR DESCRIPTION
Currently, we set all measurement operations (e.g. `M`, `MResetX`) to have a fixed `Operation.Gate` as `"measure"`. However, a better approach would be to use an `IsMeasurement` flag that will be set to `true` if the given `Operation` is a measurement-type operation. This would allow future extensibility to render the measurement gate depending on what the actual gate is (e.g. render `MResetX` as measurement gate with `X` in lower-right of box).