### PR TITLE
Ensure OnDisplayableDiagnostic is handled.

### DIFF
--- a/src/Kernel/Magic/EstimateMagic.cs
+++ b/src/Kernel/Magic/EstimateMagic.cs
@@ -112,6 +112,7 @@ namespace Microsoft.Quantum.IQSharp.Kernel
             if (symbol == null) throw new InvalidOperationException($"Invalid operation name: {name}");
 
             var qsim = new ResourcesEstimator().WithStackTraceDisplay(channel);
+            qsim.OnDisplayableDiagnostic += channel.Display;
             qsim.DisableLogToConsole();
 
             await symbol.Operation.RunAsync(qsim, inputParameters);

--- a/src/Kernel/Magic/Simulate.cs
+++ b/src/Kernel/Magic/Simulate.cs
@@ -97,6 +97,7 @@ namespace Microsoft.Quantum.IQSharp.Kernel
             using var qsim = new QuantumSimulator()
                 .WithJupyterDisplay(channel, ConfigurationSource)
                 .WithStackTraceDisplay(channel);
+            qsim.OnDisplayableDiagnostic += channel.Display;
             var value = await symbol.Operation.RunAsync(qsim, inputParameters);
             return value.ToExecutionResult();
         }

--- a/src/Kernel/Magic/ToffoliMagic.cs
+++ b/src/Kernel/Magic/ToffoliMagic.cs
@@ -85,6 +85,7 @@ namespace Microsoft.Quantum.IQSharp.Kernel
             if (symbol == null) throw new InvalidOperationException($"Invalid operation name: {name}");
 
             var qsim = new ToffoliSimulator().WithStackTraceDisplay(channel);
+            qsim.OnDisplayableDiagnostic += channel.Display;
             qsim.DisableLogToConsole();
             qsim.OnLog += channel.Stdout;
 


### PR DESCRIPTION
This PR ensures that the `OnDisplayableDiagnostics` event is handled when creating new simulators, so that any diagnostic data emitted from simulators and the simulation runtime makes it through to the Jupyter display pipeline.