### PR TITLE
Allow overriding builtin packages and namespaces

### DIFF
--- a/src/Core/Compiler/CompilerService.cs
+++ b/src/Core/Compiler/CompilerService.cs
@@ -15,6 +15,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Microsoft.Quantum.IQSharp.Common;
 using Microsoft.Quantum.QsCompiler;
 using Microsoft.Quantum.QsCompiler.CompilationBuilder;
@@ -33,10 +34,7 @@ using QsReferences = Microsoft.Quantum.QsCompiler.CompilationBuilder.References;
 
 namespace Microsoft.Quantum.IQSharp
 {
-    internal class CompilerOptions
-    {
-        public string? AutoOpenNamespaces { get; set; }
-    }
+
 
     /// <summary>
     /// Default implementation of ICompilerService.
@@ -44,6 +42,20 @@ namespace Microsoft.Quantum.IQSharp
     /// </summary>
     public class CompilerService : ICompilerService
     {
+        /// <summary>
+        ///     Settings for controlling how the compiler service creates
+        ///     assemblies from snippets.
+        /// </summary>
+        public class Settings
+        {
+            /// <summary>
+            ///     A list of namespaces to be automatically opened in snippets,
+            ///     separated by <c>,</c>. If <c>"$null"</c>, then no namespaces
+            ///     are opened. Aliases can be provided by using <c>=</c>.
+            /// </summary>
+            public string? AutoOpenNamespaces { get; set; }
+        }
+
         /// <inheritdoc/>
         public IDictionary<string, string?> AutoOpenNamespaces { get; set; } = new Dictionary<string, string?>
         {
@@ -51,14 +63,13 @@ namespace Microsoft.Quantum.IQSharp
             ["Microsoft.Quantum.Canon"] = null
         };
 
-        public CompilerService(ILogger<CompilerService>? logger, IConfiguration? configuration)
+        public CompilerService(ILogger<CompilerService>? logger, IOptions<Settings>? options)
         {
-            var options = configuration?.Get<CompilerOptions>();
-            if (options?.AutoOpenNamespaces is string namespaces)
+            if (options?.Value?.AutoOpenNamespaces is string namespaces)
             {
                 logger?.LogInformation(
                     "Auto-open namespaces overridden by startup options: \"{0}\"",
-                    options.AutoOpenNamespaces
+                    namespaces
                 );
                 AutoOpenNamespaces =
                     namespaces.Trim() == "$null"

--- a/src/Core/Compiler/CompilerService.cs
+++ b/src/Core/Compiler/CompilerService.cs
@@ -51,12 +51,12 @@ namespace Microsoft.Quantum.IQSharp
             ["Microsoft.Quantum.Canon"] = null
         };
 
-        public CompilerService(ILogger<CompilerService> logger, IConfiguration configuration)
+        public CompilerService(ILogger<CompilerService>? logger, IConfiguration? configuration)
         {
-            var options = configuration.Get<CompilerOptions>();
+            var options = configuration?.Get<CompilerOptions>();
             if (options?.AutoOpenNamespaces is string namespaces)
             {
-                logger.LogInformation(
+                logger?.LogInformation(
                     "Auto-open namespaces overridden by startup options: \"{0}\"",
                     options.AutoOpenNamespaces
                 );

--- a/src/Core/References/References.cs
+++ b/src/Core/References/References.cs
@@ -68,13 +68,19 @@ namespace Microsoft.Quantum.IQSharp
             eventService?.TriggerServiceInitialized<IReferences>(this);
 
             var referencesOptions = configuration.Get<ReferencesOptions>();
-            if (!(referencesOptions?.BuiltInPackages is null))
+            if (referencesOptions?.BuiltInPackages is string pkgs)
             {
-                BUILT_IN_PACKAGES = referencesOptions
-                    .BuiltInPackages
-                    .Split(",")
-                    .Select(pkg => pkg.Trim())
-                    .ToImmutableList();
+                logger.LogInformation(
+                    "Built-in packages overridden by startup options: \"{0}\"",
+                    referencesOptions.BuiltInPackages
+                );
+                BUILT_IN_PACKAGES =
+                    pkgs.Trim() == "$null"
+                    ? ImmutableList<string>.Empty
+                    : pkgs
+                      .Split(",")
+                      .Select(pkg => pkg.Trim())
+                      .ToImmutableList();
             }
 
             foreach (var pkg in BUILT_IN_PACKAGES)

--- a/src/Core/References/References.cs
+++ b/src/Core/References/References.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Quantum.IQSharp
         /// The list of Packages that are automatically included for compilation. Namely:
         ///   * Microsoft.Quantum.Standard
         /// </summary>
-        public readonly ImmutableList<string> BUILT_IN_PACKAGES =
+        public readonly ImmutableList<string> BuiltInPackages =
             ImmutableList.Create(
                 "Microsoft.Quantum.Standard"
             );
@@ -74,7 +74,7 @@ namespace Microsoft.Quantum.IQSharp
                     "Built-in packages overridden by startup options: \"{0}\"",
                     referencesOptions.BuiltInPackages
                 );
-                BUILT_IN_PACKAGES =
+                BuiltInPackages =
                     pkgs.Trim() == "$null"
                     ? ImmutableList<string>.Empty
                     : pkgs
@@ -83,7 +83,7 @@ namespace Microsoft.Quantum.IQSharp
                       .ToImmutableList();
             }
 
-            foreach (var pkg in BUILT_IN_PACKAGES)
+            foreach (var pkg in BuiltInPackages)
             {
                 try
                 {

--- a/src/Core/References/References.cs
+++ b/src/Core/References/References.cs
@@ -18,10 +18,6 @@ using NuGet.Packaging.Core;
 
 namespace Microsoft.Quantum.IQSharp
 {
-    internal class ReferencesOptions
-    {
-        public string? AutoLoadPackages { get; set; }
-    }
 
     /// <summary>
     /// Default implementation of IReferences.
@@ -31,6 +27,21 @@ namespace Microsoft.Quantum.IQSharp
     /// </summary>
     public class References : IReferences
     {
+        /// <summary>
+        ///     Settings that control how references are discovered and loaded.
+        /// </summary>
+        public class Settings
+        {
+            /// <summary>
+            ///      A list of packages to be loaded when the kernel initially
+            ///      starts. Package names should be seperated by <c>,</c>, and
+            ///      may have optional version specifiers. To suppress all
+            ///      automatic package loading, the string <c>"$null"</c> can
+            ///      be provided.
+            /// </summary>
+            public string? AutoLoadPackages { get; set; }
+        }
+
         /// <summary>
         /// The list of assemblies that are automatically included for compilation. Namely:
         ///   * Quantum.Core
@@ -59,7 +70,7 @@ namespace Microsoft.Quantum.IQSharp
                 INugetPackages packages,
                 IEventService eventService,
                 ILogger<References> logger,
-                IConfiguration configuration
+                IOptions<Settings> options
                 )
         {
             Assemblies = QUANTUM_CORE_ASSEMBLIES.ToImmutableArray();
@@ -67,7 +78,7 @@ namespace Microsoft.Quantum.IQSharp
 
             eventService?.TriggerServiceInitialized<IReferences>(this);
 
-            var referencesOptions = configuration.Get<ReferencesOptions>();
+            var referencesOptions = options.Value;
             if (referencesOptions?.AutoLoadPackages is string pkgs)
             {
                 logger.LogInformation(

--- a/src/Core/References/References.cs
+++ b/src/Core/References/References.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Quantum.IQSharp
 {
     internal class ReferencesOptions
     {
-        public string? BuiltInPackages { get; set; }
+        public string? AutoLoadPackages { get; set; }
     }
 
     /// <summary>
@@ -47,7 +47,7 @@ namespace Microsoft.Quantum.IQSharp
         /// The list of Packages that are automatically included for compilation. Namely:
         ///   * Microsoft.Quantum.Standard
         /// </summary>
-        public readonly ImmutableList<string> BuiltInPackages =
+        public readonly ImmutableList<string> AutoLoadPackages =
             ImmutableList.Create(
                 "Microsoft.Quantum.Standard"
             );
@@ -68,13 +68,13 @@ namespace Microsoft.Quantum.IQSharp
             eventService?.TriggerServiceInitialized<IReferences>(this);
 
             var referencesOptions = configuration.Get<ReferencesOptions>();
-            if (referencesOptions?.BuiltInPackages is string pkgs)
+            if (referencesOptions?.AutoLoadPackages is string pkgs)
             {
                 logger.LogInformation(
-                    "Built-in packages overridden by startup options: \"{0}\"",
-                    referencesOptions.BuiltInPackages
+                    "Auto-load packages overridden by startup options: \"{0}\"",
+                    referencesOptions.AutoLoadPackages
                 );
-                BuiltInPackages =
+                AutoLoadPackages =
                     pkgs.Trim() == "$null"
                     ? ImmutableList<string>.Empty
                     : pkgs
@@ -83,7 +83,7 @@ namespace Microsoft.Quantum.IQSharp
                       .ToImmutableList();
             }
 
-            foreach (var pkg in BuiltInPackages)
+            foreach (var pkg in AutoLoadPackages)
             {
                 try
                 {

--- a/src/Jupyter/Extensions.cs
+++ b/src/Jupyter/Extensions.cs
@@ -97,7 +97,6 @@ namespace Microsoft.Quantum.IQSharp.Jupyter
             // Next, we attach the display channel's standard output handling
             // to the log event.
             simulator.OnLog += channel.Stdout;
-            simulator.OnDisplayableDiagnostic += channel.Display;
 
             // Next, we register the generic version of the DumpMachine callable
             // as an ICallable with the simulator. Below, we'll provide our

--- a/src/Tests/SnippetsControllerTests.cs
+++ b/src/Tests/SnippetsControllerTests.cs
@@ -176,7 +176,7 @@ namespace Tests.IQSharp
         [TestMethod]
         public void IdentifyOperations()
         {
-            var compiler = new CompilerService();
+            var compiler = new CompilerService(null, null);
 
             var elements = compiler.IdentifyElements(SNIPPETS.Op1_Op2).Select(Extensions.ToFullName).ToArray();
 

--- a/src/Tests/Startup.cs
+++ b/src/Tests/Startup.cs
@@ -27,6 +27,7 @@ namespace Tests.IQSharp
 
             var services = new ServiceCollection();
 
+            services.AddSingleton<IConfiguration>(config);
             services.Configure<Workspace.Settings>(config);
             services.Configure<NugetPackages.Settings>(config);
 

--- a/src/Tool/Program.cs
+++ b/src/Tool/Program.cs
@@ -82,7 +82,7 @@ namespace Microsoft.Quantum.IQSharp
                     .Build();
 
                 var app = new IQSharpKernelApp(
-                    Kernel.Constants.IQSharpKernelProperties, new Startup().ConfigureServices
+                    Kernel.Constants.IQSharpKernelProperties, new Startup(Configuration).ConfigureServices
                 )
                 .ConfigureLogging(
                     loggingBuilder => {

--- a/src/Tool/Program.cs
+++ b/src/Tool/Program.cs
@@ -74,7 +74,9 @@ namespace Microsoft.Quantum.IQSharp
                             ["TELEMETRY_OPT_OUT"] = nameof(TelemetryOptOut),
                             ["USER_AGENT"] = "UserAgent",
                             ["HOSTING_ENV"] = "HostingEnvironment",
-                            ["LOG_PATH"] = "LogPath"
+                            ["LOG_PATH"] = "LogPath",
+                            ["BUILTIN_PACKAGES"] = "BuiltinPackages",
+                            ["AUTO_OPEN_NAMESPACES"] = "AutoOpenNamespaces"
                         }
                     })
                     .Build();

--- a/src/Tool/Program.cs
+++ b/src/Tool/Program.cs
@@ -75,7 +75,7 @@ namespace Microsoft.Quantum.IQSharp
                             ["USER_AGENT"] = "UserAgent",
                             ["HOSTING_ENV"] = "HostingEnvironment",
                             ["LOG_PATH"] = "LogPath",
-                            ["BUILTIN_PACKAGES"] = "BuiltinPackages",
+                            ["AUTO_LOAD_PACKAGES"] = "AutoLoadPackages",
                             ["AUTO_OPEN_NAMESPACES"] = "AutoOpenNamespaces"
                         }
                     })

--- a/src/Tool/Startup.cs
+++ b/src/Tool/Startup.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Quantum.IQSharp.Kernel;
 using Microsoft.Quantum.IQSharp.AzureClient;
 using System;
+using Microsoft.Extensions.Configuration;
 
 namespace Microsoft.Quantum.IQSharp
 {
@@ -15,12 +16,19 @@ namespace Microsoft.Quantum.IQSharp
     /// </summary>
     public class Startup
     {
+        private readonly IConfiguration Configuration;
+        public Startup(IConfiguration configuration)
+        {
+            this.Configuration = configuration;
+        }
+
         // This method gets called by the runtime. Use this method to add services to the container.
         public virtual void ConfigureServices(IServiceCollection services)
         {
-            services.Configure<Workspace.Settings>(Program.Configuration);
-            services.Configure<NugetPackages.Settings>(Program.Configuration);
-            services.Configure<ClientInformation>(Program.Configuration);
+            services.Configure<Workspace.Settings>(Configuration);
+            services.Configure<NugetPackages.Settings>(Configuration);
+            services.Configure<ClientInformation>(Configuration);
+            services.AddSingleton<IConfiguration>(Configuration);
 
             services.AddSingleton(typeof(ITelemetryService), GetTelemetryServiceType());
             services.AddIQSharp();

--- a/src/Tool/Startup.cs
+++ b/src/Tool/Startup.cs
@@ -27,8 +27,9 @@ namespace Microsoft.Quantum.IQSharp
         {
             services.Configure<Workspace.Settings>(Configuration);
             services.Configure<NugetPackages.Settings>(Configuration);
+            services.Configure<References.Settings>(Configuration);
+            services.Configure<CompilerService.Settings>(Configuration);
             services.Configure<ClientInformation>(Configuration);
-            services.AddSingleton<IConfiguration>(Configuration);
 
             services.AddSingleton(typeof(ITelemetryService), GetTelemetryServiceType());
             services.AddIQSharp();


### PR DESCRIPTION
This feature helps with local development of IQ# and libraries used within IQ# by allowing for automatic loading of packages and namespaces to either be disabled, modified, or extended by the use of environment variables. Note that since on Windows, environment variables cannot be empty strings, the special string `"$null"` is recognized in both cases as disabling all built-in defaults (useful for manually setting versions of Microsoft.Quantum.Standard on a per-instance basis).