### PR TITLE
Make GetOptionOrDefault public.

### DIFF
--- a/src/Jupyter/ConfigurationSource.cs
+++ b/src/Jupyter/ConfigurationSource.cs
@@ -32,7 +32,27 @@ namespace Microsoft.Quantum.IQSharp.Jupyter
         /// </summary>
         void Persist();
 
-        private T GetOptionOrDefault<T>(string optionName, T defaultValue) =>
+        /// <summary>
+        ///     Given the name for a configuration and a default value,
+        ///     returns the given option if it exists, or the default if the
+        ///     user has not specified that option.
+        /// </summary>
+        /// <param name="optionName">
+        ///     Name of the option to be retrieved.
+        /// </param>
+        /// <param name="defaultValue">
+        ///     Value to be returned when the option specified by
+        ///     <paramref name="optionName" /> has not been set.
+        /// </param>
+        /// <typeparam name="T">
+        ///     The expected type of the given option.
+        /// </typeparam>
+        /// <returns>
+        ///     The value of the option specified by
+        ///     <paramref name="optionName" /> if it exists, otherwise
+        ///     the value of <paramref name="defaultValue" />.
+        /// </returns>
+        public T GetOptionOrDefault<T>(string optionName, T defaultValue) =>
             Configuration.TryGetValue(optionName, out var token)
             ? token.ToObject<T>() ?? defaultValue
             : defaultValue;


### PR DESCRIPTION
This PR makes `IConfigurationSource.GetOptionOrDefault<T>` public, as that allows for separating configuration option handling into different assemblies (see the work at https://github.com/microsoft/QuantumLibraries/tree/cgranade/experimental/diagnostics for an example of where this is useful).