### PR TITLE
Add syntax highlighting for %trace and %lsopen commands

### DIFF
--- a/src/Kernel/client/kernel.ts
+++ b/src/Kernel/client/kernel.ts
@@ -67,7 +67,7 @@ function defineQSharpMode() {
         {
             // built-in magic commands
             token: "builtin",
-            regex: String.raw`(%(config|estimate|lsmagic|package|performance|simulate|toffoli|version|who|workspace|trace))\b`,
+            regex: String.raw`(%(config|estimate|lsmagic|lsopen|package|performance|simulate|toffoli|trace|version|who|workspace))\b`,
             beginWord: true,
         },
         {

--- a/src/Kernel/client/kernel.ts
+++ b/src/Kernel/client/kernel.ts
@@ -67,7 +67,7 @@ function defineQSharpMode() {
         {
             // built-in magic commands
             token: "builtin",
-            regex: String.raw`(%(config|estimate|lsmagic|package|performance|simulate|toffoli|version|who|workspace))\b`,
+            regex: String.raw`(%(config|estimate|lsmagic|package|performance|simulate|toffoli|version|who|workspace|trace))\b`,
             beginWord: true,
         },
         {


### PR DESCRIPTION
This PR adds syntax highlighting for the `%trace` and `%lsopen` command:

![image](https://user-images.githubusercontent.com/19257435/89051661-96c40900-d322-11ea-94dc-71c97cb68c23.png)

