### PR TITLE
Add ExecutionPathTracer to iqsharp.sln

### DIFF
--- a/iqsharp.sln
+++ b/iqsharp.sln
@@ -21,6 +21,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Mock.Chemistry", "src\MockL
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Mock.Standard", "src\MockLibraries\Mock.Standard\Mock.Standard.csproj", "{854E40D3-64A2-4864-AB79-AB9CC61DA1DE}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ExecutionPathTracer", "src\ExecutionPathTracer\ExecutionPathTracer.csproj", "{B136289B-FDCD-4354-BD7F-7FC195EE7CF3}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -139,6 +141,18 @@ Global
 		{854E40D3-64A2-4864-AB79-AB9CC61DA1DE}.Release|x64.Build.0 = Release|Any CPU
 		{854E40D3-64A2-4864-AB79-AB9CC61DA1DE}.Release|x86.ActiveCfg = Release|Any CPU
 		{854E40D3-64A2-4864-AB79-AB9CC61DA1DE}.Release|x86.Build.0 = Release|Any CPU
+		{B136289B-FDCD-4354-BD7F-7FC195EE7CF3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B136289B-FDCD-4354-BD7F-7FC195EE7CF3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B136289B-FDCD-4354-BD7F-7FC195EE7CF3}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{B136289B-FDCD-4354-BD7F-7FC195EE7CF3}.Debug|x64.Build.0 = Debug|Any CPU
+		{B136289B-FDCD-4354-BD7F-7FC195EE7CF3}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{B136289B-FDCD-4354-BD7F-7FC195EE7CF3}.Debug|x86.Build.0 = Debug|Any CPU
+		{B136289B-FDCD-4354-BD7F-7FC195EE7CF3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B136289B-FDCD-4354-BD7F-7FC195EE7CF3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B136289B-FDCD-4354-BD7F-7FC195EE7CF3}.Release|x64.ActiveCfg = Release|Any CPU
+		{B136289B-FDCD-4354-BD7F-7FC195EE7CF3}.Release|x64.Build.0 = Release|Any CPU
+		{B136289B-FDCD-4354-BD7F-7FC195EE7CF3}.Release|x86.ActiveCfg = Release|Any CPU
+		{B136289B-FDCD-4354-BD7F-7FC195EE7CF3}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
This adds the `ExecutionPathTracer` project to `iqsharp.sln`.