### PR TITLE
Fix bug in ExecutionPathTracer not rendering correct depth for composite operations

### DIFF
--- a/src/ExecutionPathTracer/ExecutionPathTracer.cs
+++ b/src/ExecutionPathTracer/ExecutionPathTracer.cs
@@ -73,7 +73,8 @@ namespace Microsoft.Quantum.IQSharp.ExecutionPathTracer
             // we recursively create a tracer that traces its components instead
             if (metadata != null && metadata.IsComposite)
             {
-                this.compositeTracer = new ExecutionPathTracer(0);
+                var remainingDepth = this.renderDepth - this.currentDepth;
+                this.compositeTracer = new ExecutionPathTracer(remainingDepth);
                 // Attach our registers by reference to compositeTracer
                 this.compositeTracer.qubitRegisters = this.qubitRegisters;
                 this.compositeTracer.classicalRegisters = this.classicalRegisters;

--- a/src/Tests/ExecutionPathTracerTests.cs
+++ b/src/Tests/ExecutionPathTracerTests.cs
@@ -665,6 +665,86 @@ namespace Tests.IQSharp
             var expected = new ExecutionPath(qubits, operations);
             Assert.AreEqual(expected.ToJson(), path.ToJson());
         }
+
+        [TestMethod]
+        public void ApplyToEachDepth2Test()
+        {
+            // Test depth 1
+            var path = GetExecutionPath("ApplyToEachDepth2Circ");
+            var qubits = new QubitDeclaration[]
+            {
+                new QubitDeclaration(0),
+                new QubitDeclaration(1),
+            };
+            var operations = new Operation[]
+            {
+                new Operation()
+                {
+                    Gate = "ApplyDoubleX",
+                    Targets = new List<Register>() { new QubitRegister(0) },
+                },
+                new Operation()
+                {
+                    Gate = "ApplyDoubleX",
+                    Targets = new List<Register>() { new QubitRegister(1) },
+                },
+                new Operation()
+                {
+                    Gate = "Reset",
+                    Targets = new List<Register>() { new QubitRegister(0) },
+                },
+                new Operation()
+                {
+                    Gate = "Reset",
+                    Targets = new List<Register>() { new QubitRegister(1) },
+                },
+            };
+            var expected = new ExecutionPath(qubits, operations);
+            Assert.AreEqual(expected.ToJson(), path.ToJson());
+
+            // Test depth 2
+            path = GetExecutionPath("ApplyToEachDepth2Circ", 2);
+            qubits = new QubitDeclaration[]
+            {
+                new QubitDeclaration(0),
+                new QubitDeclaration(1),
+            };
+            operations = new Operation[]
+            {
+                new Operation()
+                {
+                    Gate = "X",
+                    Targets = new List<Register>() { new QubitRegister(0) },
+                },
+                new Operation()
+                {
+                    Gate = "X",
+                    Targets = new List<Register>() { new QubitRegister(0) },
+                },
+                new Operation()
+                {
+                    Gate = "X",
+                    Targets = new List<Register>() { new QubitRegister(1) },
+                },
+                new Operation()
+                {
+                    Gate = "X",
+                    Targets = new List<Register>() { new QubitRegister(1) },
+                },
+                new Operation()
+                {
+                    Gate = "Reset",
+                    Targets = new List<Register>() { new QubitRegister(0) },
+                },
+                new Operation()
+                {
+                    Gate = "Reset",
+                    Targets = new List<Register>() { new QubitRegister(1) },
+                },
+            };
+            expected = new ExecutionPath(qubits, operations);
+            Assert.AreEqual(expected.ToJson(), path.ToJson());
+        }
     }
 
     [TestClass]

--- a/src/Tests/ExecutionPathTracerTests.cs
+++ b/src/Tests/ExecutionPathTracerTests.cs
@@ -706,8 +706,8 @@ namespace Tests.IQSharp
             path = GetExecutionPath("ApplyToEachDepth2Circ", 2);
             qubits = new QubitDeclaration[]
             {
-                new QubitDeclaration(0),
-                new QubitDeclaration(1),
+                new QubitDeclaration(0, 1),
+                new QubitDeclaration(1, 1),
             };
             operations = new Operation[]
             {
@@ -733,13 +733,17 @@ namespace Tests.IQSharp
                 },
                 new Operation()
                 {
-                    Gate = "Reset",
-                    Targets = new List<Register>() { new QubitRegister(0) },
+                    Gate = "M",
+                    IsMeasurement = true,
+                    Controls = new List<Register>() { new QubitRegister(0) },
+                    Targets = new List<Register>() { new ClassicalRegister(0, 0) },
                 },
                 new Operation()
                 {
-                    Gate = "Reset",
-                    Targets = new List<Register>() { new QubitRegister(1) },
+                    Gate = "M",
+                    IsMeasurement = true,
+                    Controls = new List<Register>() { new QubitRegister(1) },
+                    Targets = new List<Register>() { new ClassicalRegister(1, 0) },
                 },
             };
             expected = new ExecutionPath(qubits, operations);

--- a/src/Tests/Workspace.ExecutionPathTracer/Canon.qs
+++ b/src/Tests/Workspace.ExecutionPathTracer/Canon.qs
@@ -13,6 +13,18 @@ namespace Tests.ExecutionPathTracer {
         }
     }
 
+    operation ApplyDoubleX(q : Qubit) : Unit {
+        X(q);
+        X(q);
+    }
+
+    operation ApplyToEachDepth2Circ() : Unit {
+        using (qs = Qubit[2]) {
+            ApplyToEach(ApplyDoubleX, qs);
+            ResetAll(qs);
+        }
+    }
+
 }
 
 


### PR DESCRIPTION
This PR fixes a bug in which the correct depth is not being passed into the composite operations. For example, given the following operations:
```C#
    operation ApplyDoubleX(q : Qubit) : Unit {
        X(q);
        X(q);
    }

    operation ApplyToEachDepth2Circ() : Unit {
        using (qs = Qubit[2]) {
            ApplyToEach(ApplyDoubleX, qs);
            ResetAll(qs);
        }
    }
```

the tracer would only print `ApplyDoubleX` even at depth 2, when the expected result is to print `X` twice for each application of `ApplyDoubleX`. This example is also implemented as a test case to catch this.