### PR TITLE
Implement classically controlled operations

### DIFF
--- a/src/ExecutionPathTracer/ExecutionPath.cs
+++ b/src/ExecutionPathTracer/ExecutionPath.cs
@@ -118,9 +118,6 @@ namespace Microsoft.Quantum.IQSharp.ExecutionPathTracer
         /// <summary>
         /// Group of operations for each classical branch.
         /// </summary>
-        /// <remarks>
-        /// Currently not used as this is intended for classically-controlled operations.
-        /// </remarks>
         [JsonProperty("children")]
         public IEnumerable<IEnumerable<Operation>>? Children { get; set; }
 
@@ -129,6 +126,12 @@ namespace Microsoft.Quantum.IQSharp.ExecutionPathTracer
         /// </summary>
         [JsonProperty("isMeasurement")]
         public bool IsMeasurement { get; set; }
+
+        /// <summary>
+        /// True if operation is a classically-controlled operations.
+        /// </summary>
+        [JsonProperty("isConditional")]
+        public bool IsConditional { get; set; }
 
         /// <summary>
         /// True if operation is a controlled operations.

--- a/src/ExecutionPathTracer/Extensions.cs
+++ b/src/ExecutionPathTracer/Extensions.cs
@@ -3,11 +3,50 @@
 
 #nullable enable
 
+using System;
 using System.Collections.Generic;
 using Microsoft.Quantum.Simulation.Common;
+using Microsoft.Quantum.Simulation.Core;
+using Microsoft.Quantum.Simulation.QuantumProcessor.Extensions;
 
 namespace Microsoft.Quantum.IQSharp.ExecutionPathTracer
 {
+    /// <summary>
+    /// Custom ApplyIfElse used by Tracer to overrides the default behaviour and executes both branches
+    /// of the conditional statement.
+    /// </summary>
+    public class TracerApplyIfElse : ApplyIfElseR<Qubit, Qubit>
+    {
+        private SimulatorBase Simulator { get; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TracerApplyIfElse"/> class.
+        /// </summary>
+        public TracerApplyIfElse(SimulatorBase m) : base(m)
+        {
+            this.Simulator = m;
+        }
+
+        /// <inheritdoc />
+        public override Func<(Result, (ICallable, Qubit), (ICallable, Qubit)), QVoid> Body => (q) =>
+        {
+            (Result measurementResult, (ICallable onZero, Qubit one), (ICallable onOne, Qubit two)) = q;
+            onZero.Apply(one);
+            onOne.Apply(two);
+
+            return QVoid.Instance;
+        };
+
+        /// <inheritdoc />
+        public override RuntimeMetadata? GetRuntimeMetadata(IApplyData args)
+        {
+            var metadata = base.GetRuntimeMetadata(args);
+            if (metadata == null) throw new NullReferenceException($"Null RuntimeMetadata found for {this.ToString()}.");
+            metadata.IsComposite = true;
+            return metadata;
+        }
+    }
+
     /// <summary>
     /// Extension methods to be used with and by <see cref="ExecutionPathTracer"/>.
     /// </summary>
@@ -22,6 +61,10 @@ namespace Microsoft.Quantum.IQSharp.ExecutionPathTracer
         {
             sim.OnOperationStart += tracer.OnOperationStartHandler;
             sim.OnOperationEnd += tracer.OnOperationEndHandler;
+            sim.Register(
+                typeof(ApplyIfElseR<Qubit, Qubit>),
+                typeof(TracerApplyIfElse)
+            );
             return sim;
         }
 

--- a/src/Tests/ExecutionPathTracerTests.cs
+++ b/src/Tests/ExecutionPathTracerTests.cs
@@ -614,6 +614,55 @@ namespace Tests.IQSharp
             var expected = new ExecutionPath(qubits, operations);
             Assert.AreEqual(expected.ToJson(), path.ToJson());
         }
+
+        [TestMethod]
+        public void IfTest()
+        {
+            var path = GetExecutionPath("IfCirc");
+            var qubits = new QubitDeclaration[] { new QubitDeclaration(0, 1) };
+            var operations = new Operation[]
+            {
+                new Operation()
+                {
+                    Gate = "M",
+                    IsMeasurement = true,
+                    Controls = new List<Register>() { new QubitRegister(0) },
+                    Targets = new List<Register>() { new ClassicalRegister(0, 0) },
+                },
+                new Operation()
+                {
+                    Gate = "ApplyIfElseR",
+                    DisplayArgs = "(Zero, (X), (Z))",
+                    Targets = new List<Register>() { new QubitRegister(0), new QubitRegister(0) },
+                    Children = new List<List<Operation>>()
+                    {
+                        new List<Operation>()
+                        {
+                            new Operation()
+                            {
+                                Gate = "X",
+                                Targets = new List<Register>() { new QubitRegister(0) },
+                            },
+                        },
+                        new List<Operation>()
+                        {
+                            new Operation()
+                            {
+                                Gate = "Z",
+                                Targets = new List<Register>() { new QubitRegister(0) },
+                            },
+                        },
+                    },
+                },
+                new Operation()
+                {
+                    Gate = "Reset",
+                    Targets = new List<Register>() { new QubitRegister(0) },
+                },
+            };
+            var expected = new ExecutionPath(qubits, operations);
+            Assert.AreEqual(expected.ToJson(), path.ToJson());
+        }
     }
 
     [TestClass]

--- a/src/Tests/ExecutionPathTracerTests.cs
+++ b/src/Tests/ExecutionPathTracerTests.cs
@@ -633,7 +633,8 @@ namespace Tests.IQSharp
                 {
                     Gate = "ApplyIfElseR",
                     DisplayArgs = "(Zero, (X), (Z))",
-                    Targets = new List<Register>() { new QubitRegister(0), new QubitRegister(0) },
+                    Controls = new List<Register>() { new ClassicalRegister(0, 0) },
+                    Targets = new List<Register>() { new QubitRegister(0) },
                     Children = new List<List<Operation>>()
                     {
                         new List<Operation>()

--- a/src/Tests/Workspace.ExecutionPathTracer/Circuits.qs
+++ b/src/Tests/Workspace.ExecutionPathTracer/Circuits.qs
@@ -4,6 +4,7 @@
 namespace Tests.ExecutionPathTracer {
     
     open Microsoft.Quantum.Intrinsic;
+    open Microsoft.Quantum.Simulation.QuantumProcessor.Extensions;
 
     // Custom operation
     operation Foo(theta : Double, (qubit : Qubit, bar : String)) : Unit
@@ -92,6 +93,14 @@ namespace Tests.ExecutionPathTracer {
             Controlled Adjoint Bar([qs[2]], ((1.0, 2.1), (qs[0], "foo")));
             let res = M(qs[0]);
             ResetAll(qs);
+        }
+    }
+
+    operation IfCirc() : Unit {
+        using (q = Qubit()) {
+            let res = M(q);
+            ApplyIfElseR(res, (X, q), (Z, q));
+            Reset(q);
         }
     }
     


### PR DESCRIPTION
This PR is a first step at implementing classically controlled operations and is based off of work in [this PR](https://github.com/microsoft/qsharp-runtime/pull/325).  It is part of the Q# visualization tool as described in #158.

In this PR, we:

1. Use the `IsConditional` flag in the `RuntimeMetadata` class to check if the given operation is a classically-controlled operation.
2. Implement the same logic as we do for composite operations (i.e. recursively trace nested operations). In this case we would get 2 operations (one for each conditional branch). Upon exit from the recursive tracer, we add them as `Children` of the outer condition operation.
4. Override the logic for `ApplyIfElseR` with a custom `TracerApplyIfElse`.

TODO:
- [ ] Implement getting correct classical register
- [ ] Use `IsConditional` flag in visualizer (JS) to determine if the operation is a classically-controlled operation instead of checking `children`.
- [ ] Modify classically-controlled tests in visualizer (JS) to use `IsConditional` instead of `IsControlled`.

If this logic makes sense, our next steps are to:

- [ ] Override conditional logic for all other variants of `ApplyIfElse`
- [ ] Perform an IRewriteStep to convert if/else statements to `ApplyIfElse`
- [ ] Reduce `ApplyIfOne` and `ApplyIfZero` to `ApplyIfElse`.