### PR TITLE
Add colours to path visualizer

### DIFF
--- a/src/Jupyter/ConfigurationSource.cs
+++ b/src/Jupyter/ConfigurationSource.cs
@@ -96,6 +96,13 @@ namespace Microsoft.Quantum.IQSharp.Jupyter
         /// </summary>
         public int TraceVisualizationDefaultDepth =>
             GetOptionOrDefault("trace.defaultDepth", 1);
+
+        /// <summary>
+        ///     Allows for setting the default visualization style for visualizing Q# operations
+        ///     using the <c>%trace</c> command.
+        /// </summary>
+        public string TraceVisualizationStyle =>
+            GetOptionOrDefault("trace.style", "Default");
     }
 
     /// <summary>

--- a/src/Jupyter/ConfigurationSource.cs
+++ b/src/Jupyter/ConfigurationSource.cs
@@ -2,11 +2,9 @@
 // Licensed under the MIT License.
 #nullable enable
 
-using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
-using System.Linq;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
@@ -101,8 +99,8 @@ namespace Microsoft.Quantum.IQSharp.Jupyter
         ///     Allows for setting the default visualization style for visualizing Q# operations
         ///     using the <c>%trace</c> command.
         /// </summary>
-        public string TraceVisualizationStyle =>
-            GetOptionOrDefault("trace.style", "Default");
+        public TraceVisualizationStyle TraceVisualizationStyle =>
+            GetOptionOrDefault("trace.style", TraceVisualizationStyle.Default);
     }
 
     /// <summary>

--- a/src/Jupyter/Visualization/TraceVisualization.cs
+++ b/src/Jupyter/Visualization/TraceVisualization.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace Microsoft.Quantum.IQSharp.Jupyter
+{
+    /// <summary>
+    ///     Represents different styles for displaying the Q# execution path
+    ///     visualization as HTML.
+    /// </summary>
+    [JsonConverter(typeof(StringEnumConverter))]
+    public enum TraceVisualizationStyle
+    {
+        /// <summary>
+        ///     Default style with coloured gates.
+        /// </summary>
+        Default,
+        /// <summary>
+        ///     Black and white style.
+        /// </summary>
+        BlackAndWhite,
+        /// <summary> 
+        ///     Inverted black and white style (for black backgrounds).
+        /// </summary>
+        Inverted
+    }
+}

--- a/src/Kernel/Magic/ConfigMagic.cs
+++ b/src/Kernel/Magic/ConfigMagic.cs
@@ -70,6 +70,12 @@ namespace Microsoft.Quantum.IQSharp.Kernel
                     **Value:** positive integer (default `1`)
 
                     Configures the default depth used in the `%trace` command for visualizing Q# operations.
+
+                    **`trace.style`**
+
+                    **Value:** `""Default""` (default), `""BlackAndWhite""`, or `""Inverted""`
+
+                    Configures the default style used in generating the visualization of Q# operations with the `%trace` command.
                 ".Dedent(),
                 Examples = new []
                 {

--- a/src/Kernel/Magic/TraceMagic.cs
+++ b/src/Kernel/Magic/TraceMagic.cs
@@ -24,11 +24,11 @@ namespace Microsoft.Quantum.IQSharp.Kernel
         ///     given <see cref="ExecutionPath"/> (as a <see cref="JToken"/>), HTML div ID,
         ///     and the visualization style of the output circuit.
         /// </summary>
-        public ExecutionPathVisualizerContent(JToken executionPath, string id, string style)
+        public ExecutionPathVisualizerContent(JToken executionPath, string id, TraceVisualizationStyle style)
         {
             this.ExecutionPath = executionPath;
             this.Id = id;
-            this.Style = style;
+            this.Style = style.ToString();
         }
 
         /// <summary>

--- a/src/Kernel/Magic/TraceMagic.cs
+++ b/src/Kernel/Magic/TraceMagic.cs
@@ -15,19 +15,20 @@ namespace Microsoft.Quantum.IQSharp.Kernel
 {
     /// <summary>
     ///      Contains the JSON representation of the <see cref="ExecutionPath"/>
-    ///      and the ID of the HTML div that will contain the visualization of the
-    ///      execution path.
+    ///      and metadata used in the visualization of the execution path.
     /// </summary>
     public class ExecutionPathVisualizerContent : MessageContent
     {
         /// <summary>
         ///     Initializes <see cref="ExecutionPathVisualizerContent"/> with the
-        ///     given <see cref="ExecutionPath"/> (as a <see cref="JToken"/>) and HTML div ID.
+        ///     given <see cref="ExecutionPath"/> (as a <see cref="JToken"/>), HTML div ID,
+        ///     and the visualization style of the output circuit.
         /// </summary>
-        public ExecutionPathVisualizerContent(JToken executionPath, string id)
+        public ExecutionPathVisualizerContent(JToken executionPath, string id, string style)
         {
             this.ExecutionPath = executionPath;
             this.Id = id;
+            this.Style = style;
         }
 
         /// <summary>
@@ -41,6 +42,12 @@ namespace Microsoft.Quantum.IQSharp.Kernel
         /// </summary>
         [JsonProperty("id")]
         public string Id { get; }
+
+        /// <summary>
+        ///     Style for visualization.
+        /// </summary>
+        [JsonProperty("style")]
+        public string Style { get; }
     }
 
     /// <summary>
@@ -162,7 +169,11 @@ namespace Microsoft.Quantum.IQSharp.Kernel
 
             // Render empty div with unique ID as cell output
             var divId = $"execution-path-container-{Guid.NewGuid().ToString()}";
-            var content = new ExecutionPathVisualizerContent(executionPathJToken, divId);
+            var content = new ExecutionPathVisualizerContent(
+                executionPathJToken,
+                divId,
+                this.ConfigurationSource.TraceVisualizationStyle
+            );
             channel.DisplayUpdatable(new DisplayableHtmlElement($"<div id='{divId}' />"));
 
             // Send execution path to JavaScript via iopub for rendering

--- a/src/Kernel/client/ExecutionPathVisualizer/formatters/formatUtils.ts
+++ b/src/Kernel/client/ExecutionPathVisualizer/formatters/formatUtils.ts
@@ -22,21 +22,23 @@ export const group = (...svgElems: (string | string[])[]): string =>
  * @returns SVG string for control dot.
  */
 export const controlDot = (x: number, y: number, radius: number = 5): string =>
-    `<circle cx="${x}" cy="${y}" r="${radius}" stroke="black" fill="black" stroke-width="1"></circle>`;
+    `<circle class="control-dot" cx="${x}" cy="${y}" r="${radius}"></circle>`;
 
 /**
  * Generate an SVG line.
  * 
- * @param x1          x coord of starting point of line.
- * @param y1          y coord of starting point of line.
- * @param x2          x coord of ending point of line.
- * @param y2          y coord fo ending point of line.
- * @param strokeWidth Stroke width of line.
+ * @param x1        x coord of starting point of line.
+ * @param y1        y coord of starting point of line.
+ * @param x2        x coord of ending point of line.
+ * @param y2        y coord fo ending point of line.
+ * @param className Class name of element.
  * 
  * @returns SVG string for line.
  */
-export const line = (x1: number, y1: number, x2: number, y2: number, strokeWidth: number = 1): string =>
-    `<line x1="${x1}" x2="${x2}" y1="${y1}" y2="${y2}" stroke="black" stroke-width="${strokeWidth}"></line>`;
+export const line = (x1: number, y1: number, x2: number, y2: number, className?: string): string => {
+    const clsString: string = (className != null) ? ` class="${className}"` : "";
+    return `<line${clsString} x1="${x1}" x2="${x2}" y1="${y1}" y2="${y2}"></line>`;
+};
 
 /**
  * Generate the SVG representation of a unitary box that represents an arbitrary unitary operation.
@@ -49,8 +51,8 @@ export const line = (x1: number, y1: number, x2: number, y2: number, strokeWidth
  * 
  * @returns SVG string for unitary box.
  */
-export const box = (x: number, y: number, width: number, height: number, className: string = "box"): string =>
-    `<rect class="${className}" x="${x}" y="${y}" width="${width}" height="${height}" stroke="black" stroke-width="1"></rect>`;
+export const box = (x: number, y: number, width: number, height: number, className: string = "gate-unitary"): string =>
+    `<rect class="${className}" x="${x}" y="${y}" width="${width}" height="${height}"></rect>`;
 
 /**
  * Generate the SVG text element from a given text string.
@@ -63,7 +65,7 @@ export const box = (x: number, y: number, width: number, height: number, classNa
  * @returns SVG string for text.
  */
 export const text = (text: string, x: number, y: number, fs: number = labelFontSize): string =>
-    `<text font-size="${fs}" font-family="Arial" x="${x}" y="${y}" dominant-baseline="middle" text-anchor="middle" fill="black">${text}</text>`;
+    `<text font-size="${fs}" x="${x}" y="${y}">${text}</text>`;
 
 /**
  * Generate the SVG representation of the arc used in the measurement box.
@@ -76,7 +78,7 @@ export const text = (text: string, x: number, y: number, fs: number = labelFontS
  * @returns SVG string for arc.
  */
 export const arc = (x: number, y: number, rx: number, ry: number): string =>
-    `<path d="M ${x + 2 * rx} ${y} A ${rx} ${ry} 0 0 0 ${x} ${y}" stroke="black" fill="none" stroke-width="1"></path>`;
+    `<path class="arc-measure" d="M ${x + 2 * rx} ${y} A ${rx} ${ry} 0 0 0 ${x} ${y}"></path>`;
 
 /**
  * Generate a dashed SVG line.
@@ -91,7 +93,7 @@ export const arc = (x: number, y: number, rx: number, ry: number): string =>
  */
 export const dashedLine = (x1: number, y1: number, x2: number, y2: number, className?: string): string => {
     const clsString: string = (className != null) ? ` class="${className}"` : "";
-    return `<line${clsString} x1="${x1}" x2="${x2}" y1="${y1}" y2="${y2}" stroke="black" stroke-dasharray="8, 8" stroke-width="1"></line>`;
+    return `<line${clsString} x1="${x1}" x2="${x2}" y1="${y1}" y2="${y2}" stroke-dasharray="8, 8"></line>`;
 };
 
 /**
@@ -107,5 +109,5 @@ export const dashedLine = (x1: number, y1: number, x2: number, y2: number, class
  */
 export const dashedBox = (x: number, y: number, width: number, height: number, className?: string): string => {
     const clsString: string = (className != null) ? ` class="${className}"` : "";
-    return `<rect${clsString} x="${x}" y="${y}" width="${width}" height="${height}" stroke="black" fill-opacity="0" stroke-dasharray="8, 8" stroke-width="1"></rect>`;
+    return `<rect${clsString} x="${x}" y="${y}" width="${width}" height="${height}" fill-opacity="0" stroke-dasharray="8, 8"></rect>`;
 };

--- a/src/Kernel/client/ExecutionPathVisualizer/formatters/formatUtils.ts
+++ b/src/Kernel/client/ExecutionPathVisualizer/formatters/formatUtils.ts
@@ -41,15 +41,16 @@ export const line = (x1: number, y1: number, x2: number, y2: number, strokeWidth
 /**
  * Generate the SVG representation of a unitary box that represents an arbitrary unitary operation.
  * 
- * @param x      x coord of box.
- * @param y      y coord of box.
- * @param width  Width of box.
- * @param height Height of box.
+ * @param x         x coord of box.
+ * @param y         y coord of box.
+ * @param width     Width of box.
+ * @param height    Height of box.
+ * @param className Class name of element.
  * 
  * @returns SVG string for unitary box.
  */
-export const box = (x: number, y: number, width: number, height: number): string =>
-    `<rect x="${x}" y="${y}" width="${width}" height="${height}" stroke="black" fill="white" stroke-width="1"></rect>`;
+export const box = (x: number, y: number, width: number, height: number, className: string = "box"): string =>
+    `<rect class="${className}" x="${x}" y="${y}" width="${width}" height="${height}" stroke="black" stroke-width="1"></rect>`;
 
 /**
  * Generate the SVG text element from a given text string.
@@ -80,25 +81,31 @@ export const arc = (x: number, y: number, rx: number, ry: number): string =>
 /**
  * Generate a dashed SVG line.
  * 
- * @param x1 x coord of starting point of line.
- * @param y1 y coord of starting point of line.
- * @param x2 x coord of ending point of line.
- * @param y2 y coord fo ending point of line.
+ * @param x1        x coord of starting point of line.
+ * @param y1        y coord of starting point of line.
+ * @param x2        x coord of ending point of line.
+ * @param y2        y coord fo ending point of line.
+ * @param className Class name of element.
  * 
  * @returns SVG string for dashed line.
  */
-export const dashedLine = (x1: number, y1: number, x2: number, y2: number): string =>
-    `<line x1="${x1}" x2="${x2}" y1="${y1}" y2="${y2}" stroke="black" stroke-dasharray="8, 8" stroke-width="1"></line>`;
+export const dashedLine = (x1: number, y1: number, x2: number, y2: number, className?: string): string => {
+    const clsString: string = (className != null) ? ` class="${className}"` : "";
+    return `<line${clsString} x1="${x1}" x2="${x2}" y1="${y1}" y2="${y2}" stroke="black" stroke-dasharray="8, 8" stroke-width="1"></line>`;
+};
 
 /**
  * Generate the SVG representation of the dashed box used for enclosing groups of operations controlled on a classical register.
  * 
- * @param x      x coord of box.
- * @param y      y coord of box.
- * @param width  Width of box.
- * @param height Height of box.
+ * @param x         x coord of box.
+ * @param y         y coord of box.
+ * @param width     Width of box.
+ * @param height    Height of box.
+ * @param className Class name of element.
  * 
  * @returns SVG string for dashed box.
  */
-export const dashedBox = (x: number, y: number, width: number, height: number): string =>
-    `<rect x="${x}" y ="${y}" width="${width}" height="${height}" stroke="black" fill-opacity="0" stroke-dasharray="8, 8" stroke-width="1"></rect>`;
+export const dashedBox = (x: number, y: number, width: number, height: number, className?: string): string => {
+    const clsString: string = (className != null) ? ` class="${className}"` : "";
+    return `<rect${clsString} x="${x}" y="${y}" width="${width}" height="${height}" stroke="black" fill-opacity="0" stroke-dasharray="8, 8" stroke-width="1"></rect>`;
+};

--- a/src/Kernel/client/ExecutionPathVisualizer/formatters/gateFormatter.ts
+++ b/src/Kernel/client/ExecutionPathVisualizer/formatters/gateFormatter.ts
@@ -250,7 +250,7 @@ const _classicalControlled = (metadata: Metadata, padding: number = classicalBox
     let { x, controlsY, targetsY, width, children, htmlClass } = metadata;
 
     const controlY = controlsY[0];
-    if (htmlClass == null) htmlClass = 'cls-control';
+    if (htmlClass == null) htmlClass = 'classically-controlled';
 
     // Get SVG for gates controlled on 0 and make them hidden initially
     let childrenZero: string = (children != null) ? formatGates(children[0]) : '';
@@ -264,9 +264,9 @@ const _classicalControlled = (metadata: Metadata, padding: number = classicalBox
     const controlCircleX: number = x + controlBtnRadius;
     const controlCircle: string = _controlCircle(controlCircleX, controlY, htmlClass);
     const lineY1: number = controlY + controlBtnRadius, lineY2: number = controlY + classicalRegHeight / 2;
-    const vertLine: string = dashedLine(controlCircleX, lineY1, controlCircleX, lineY2, "cls-line");
+    const vertLine: string = dashedLine(controlCircleX, lineY1, controlCircleX, lineY2, "classical-line");
     x += controlBtnOffset;
-    const horLine: string = dashedLine(controlCircleX, lineY2, x, lineY2, "cls-line");
+    const horLine: string = dashedLine(controlCircleX, lineY2, x, lineY2, "classical-line");
 
     width = width - controlBtnOffset + (padding - classicalBoxPadding) * 2;
     x += classicalBoxPadding - padding;
@@ -274,10 +274,10 @@ const _classicalControlled = (metadata: Metadata, padding: number = classicalBox
     const height: number = targetsY[1] - targetsY[0] + gateHeight + padding * 2;
 
     // Draw dashed box around children gates
-    const box: string = dashedBox(x, y, width, height, "cls-container");
+    const box: string = dashedBox(x, y, width, height, "classical-container");
 
     // Display controlled operation in initial "unknown" state
-    const svg: string = group(`<g class="${htmlClass}-group cls-control-unknown">`, horLine, vertLine,
+    const svg: string = group(`<g class="${htmlClass}-group classically-controlled-unknown">`, horLine, vertLine,
         controlCircle, childrenZero, childrenOne, box, '</g>');
 
     return svg;
@@ -295,9 +295,9 @@ const _classicalControlled = (metadata: Metadata, padding: number = classicalBox
  * @returns SVG representation of control circle.
  */
 const _controlCircle = (x: number, y: number, cls: string, r: number = controlBtnRadius): string =>
-    `<g class="cls-control-btn ${cls}" onClick="toggleClassicalBtn('${cls}')">
+    `<g class="classically-controlled-btn ${cls}" onClick="toggleClassicalBtn('${cls}')">
 <circle class="${cls}" cx="${x}" cy="${y}" r="${r}" stroke="black" stroke-width="1"></circle>
-<text class="${cls} cls-control-text" font-size="${labelFontSize}" font-family="Arial" x="${x}" y="${y}" dominant-baseline="middle" text-anchor="middle" fill="black">?</text>
+<text class="${cls} classically-controlled-text" font-size="${labelFontSize}" font-family="Arial" x="${x}" y="${y}" dominant-baseline="middle" text-anchor="middle" fill="black">?</text>
 </g>`;
 
 export {

--- a/src/Kernel/client/ExecutionPathVisualizer/formatters/gateFormatter.ts
+++ b/src/Kernel/client/ExecutionPathVisualizer/formatters/gateFormatter.ts
@@ -143,7 +143,7 @@ const _unitary = (label: string, x: number, y: number[], width: number, displayA
 const _unitaryBox = (label: string, x: number, y: number, width: number,
     height: number = gateHeight, displayArgs?: string): string => {
     y -= gateHeight / 2;
-    const uBox: string = box(x - width / 2, y, width, height, "gate-unitary");
+    const uBox: string = box(x - width / 2, y, width, height);
     const labelY = y + height / 2 - ((displayArgs == null) ? 0 : 7);
     const labelText: string = text(label, x, labelY);
     const elems = [uBox, labelText];
@@ -231,7 +231,7 @@ const _controlledGate = (metadata: Metadata): string => {
  * @returns SVG representation of $\oplus$ symbol.
  */
 const _oplus = (x: number, y: number, r: number = 15): string => {
-    const circle: string = `<circle cx="${x}" cy="${y}" r="${r}" stroke="black" fill="white" stroke-width="1"></circle>`;
+    const circle: string = `<circle class="oplus" cx="${x}" cy="${y}" r="${r}"></circle>`;
     const vertLine: string = line(x, y - r, x, y + r);
     const horLine: string = line(x - r, y, x + r, y);
     const svg: string = group(circle, vertLine, horLine);

--- a/src/Kernel/client/ExecutionPathVisualizer/formatters/gateFormatter.ts
+++ b/src/Kernel/client/ExecutionPathVisualizer/formatters/gateFormatter.ts
@@ -75,7 +75,7 @@ const _measure = (x: number, qy: number, cy: number): string => {
     x -= minGateWidth / 2;
     const width: number = minGateWidth, height = gateHeight;
     // Draw measurement box
-    const mBox: string = box(x, qy - height / 2, width, height);
+    const mBox: string = box(x, qy - height / 2, width, height, "gate-measure");
     const mArc: string = arc(x + 5, qy + 2, width / 2 - 5, height / 2 - 8);
     const meter: string = line(x + width / 2, qy + 8, x + width - 8, qy - height / 2 + 8);
     const svg: string = group(mBox, mArc, meter);
@@ -94,7 +94,8 @@ const _measure = (x: number, qy: number, cy: number): string => {
  * 
  * @returns SVG representation of unitary gate.
  */
-const _unitary = (label: string, x: number, y: number[], width: number, displayArgs?: string, renderDashedLine: boolean = true): string => {
+const _unitary = (label: string, x: number, y: number[], width: number, displayArgs?: string,
+    renderDashedLine: boolean = true): string => {
     if (y.length === 0) return "";
 
     // Sort y in ascending order
@@ -139,9 +140,10 @@ const _unitary = (label: string, x: number, y: number[], width: number, displayA
  * 
  * @returns SVG representation of unitary box.
  */
-const _unitaryBox = (label: string, x: number, y: number, width: number, height: number = gateHeight, displayArgs?: string): string => {
+const _unitaryBox = (label: string, x: number, y: number, width: number,
+    height: number = gateHeight, displayArgs?: string): string => {
     y -= gateHeight / 2;
-    const uBox: string = box(x - width / 2, y, width, height);
+    const uBox: string = box(x - width / 2, y, width, height, "gate-unitary");
     const labelY = y + height / 2 - ((displayArgs == null) ? 0 : 7);
     const labelText: string = text(label, x, labelY);
     const elems = [uBox, labelText];
@@ -262,9 +264,9 @@ const _classicalControlled = (metadata: Metadata, padding: number = classicalBox
     const controlCircleX: number = x + controlBtnRadius;
     const controlCircle: string = _controlCircle(controlCircleX, controlY, htmlClass);
     const lineY1: number = controlY + controlBtnRadius, lineY2: number = controlY + classicalRegHeight / 2;
-    const vertLine: string = dashedLine(controlCircleX, lineY1, controlCircleX, lineY2);
+    const vertLine: string = dashedLine(controlCircleX, lineY1, controlCircleX, lineY2, "cls-line");
     x += controlBtnOffset;
-    const horLine: string = dashedLine(controlCircleX, lineY2, x, lineY2);
+    const horLine: string = dashedLine(controlCircleX, lineY2, x, lineY2, "cls-line");
 
     width = width - controlBtnOffset + (padding - classicalBoxPadding) * 2;
     x += classicalBoxPadding - padding;
@@ -272,7 +274,7 @@ const _classicalControlled = (metadata: Metadata, padding: number = classicalBox
     const height: number = targetsY[1] - targetsY[0] + gateHeight + padding * 2;
 
     // Draw dashed box around children gates
-    const box: string = dashedBox(x, y, width, height);
+    const box: string = dashedBox(x, y, width, height, "cls-container");
 
     // Display controlled operation in initial "unknown" state
     const svg: string = group(`<g class="${htmlClass}-group cls-control-unknown">`, horLine, vertLine,

--- a/src/Kernel/client/ExecutionPathVisualizer/formatters/registerFormatter.ts
+++ b/src/Kernel/client/ExecutionPathVisualizer/formatters/registerFormatter.ts
@@ -43,11 +43,11 @@ const formatRegisters = (registers: RegisterMap, measureGates: Metadata[], endX:
 const _classicalRegister = (startX: number, gateY: number, endX: number, wireY: number): string => {
     const wirePadding: number = 1;
     // Draw vertical lines
-    const vLine1: string = line(startX + wirePadding, gateY, startX + wirePadding, wireY - wirePadding, 0.5);
-    const vLine2: string = line(startX - wirePadding, gateY, startX - wirePadding, wireY + wirePadding, 0.5);
+    const vLine1: string = line(startX + wirePadding, gateY, startX + wirePadding, wireY - wirePadding, "register-classical");
+    const vLine2: string = line(startX - wirePadding, gateY, startX - wirePadding, wireY + wirePadding, "register-classical");
     // Draw horizontal lines
-    const hLine1: string = line(startX + wirePadding, wireY - wirePadding, endX, wireY - wirePadding, 0.5);
-    const hLine2: string = line(startX - wirePadding, wireY + wirePadding, endX, wireY + wirePadding, 0.5);
+    const hLine1: string = line(startX + wirePadding, wireY - wirePadding, endX, wireY - wirePadding, "register-classical");
+    const hLine2: string = line(startX - wirePadding, wireY + wirePadding, endX, wireY + wirePadding, "register-classical");
     const svg: string = [vLine1, vLine2, hLine1, hLine2].join('\n');
     return svg;
 };

--- a/src/Kernel/client/ExecutionPathVisualizer/index.ts
+++ b/src/Kernel/client/ExecutionPathVisualizer/index.ts
@@ -5,102 +5,17 @@ import { processOperations } from "./process";
 import { ExecutionPath } from "./executionPath";
 import { Metadata } from "./metadata";
 import { GateType } from "./constants";
-
-const script = `
-<script type="text/JavaScript">
-    function toggleClassicalBtn(cls) {
-        const textSvg = document.querySelector(\`.\${cls} text\`);
-        const group = document.querySelector(\`.\${cls}-group\`);
-        const currValue = textSvg.childNodes[0].nodeValue;
-        const zeroGates = document.querySelector(\`.\${cls}-zero\`);
-        const oneGates = document.querySelector(\`.\${cls}-one\`);
-        switch (currValue) {
-            case '?':
-                textSvg.childNodes[0].nodeValue = '1';
-                group.classList.remove('cls-control-unknown');
-                group.classList.add('cls-control-one');
-                break;
-            case '1':
-                textSvg.childNodes[0].nodeValue = '0';
-                group.classList.remove('cls-control-one');
-                group.classList.add('cls-control-zero');
-                oneGates.classList.toggle('hidden');
-                zeroGates.classList.toggle('hidden');
-                break;
-            case '0':
-                textSvg.childNodes[0].nodeValue = '?';
-                group.classList.remove('cls-control-zero');
-                group.classList.add('cls-control-unknown');
-                zeroGates.classList.toggle('hidden');
-                oneGates.classList.toggle('hidden');
-                break;
-        }
-    }
-</script>
-`;
-
-const style = `
-<style>
-    .hidden {
-        display: none;
-    }
-    .cls-control-unknown {
-        opacity: 0.25;
-    }
-    <!-- Gate outline -->
-    .cls-control-one rect,
-    .cls-control-one line,
-    .cls-control-one circle {
-        stroke: #4059bd;
-        stroke-width: 1.3;
-    }
-    .cls-control-zero rect,
-    .cls-control-zero line,
-    .cls-control-zero circle {
-        stroke: #c40000;
-        stroke-width: 1.3;
-    }
-    <!-- Gate label -->
-    .cls-control-one text {
-        fill: #4059bd;
-    }
-    .cls-control-zero text {
-        fill: #c40000;
-    }
-    <!-- Control button -->
-    .cls-control-btn {
-        cursor: pointer;
-    }
-    .cls-control-unknown .cls-control-btn {
-        fill: #e5e5e5;
-    }
-    .cls-control-one .cls-control-btn {
-        fill: #4059bd;
-    }
-    .cls-control-zero .cls-control-btn {
-        fill: #c40000;
-    }
-    <!-- Control button text -->
-    .cls-control-unknown .cls-control-text {
-        fill: black;
-        stroke: none;
-    }
-    .cls-control-one .cls-control-text,
-    .cls-control-zero .cls-control-text {
-        fill: white;
-        stroke: none;
-    }
-</style>
-`;
+import { StyleConfig, script, style } from "./styles";
 
 /**
  * Converts JSON representing an execution path of a Q# program given by the simulator and returns its HTML visualization.
  * 
- * @param json JSON received from simulator.
+ * @param json            JSON received from simulator.
+ * @param userStyleConfig Custom CSS style config for visualization.
  * 
  * @returns HTML representation of circuit.
  */
-export const executionPathToHtml = (json: ExecutionPath): string => {
+export const executionPathToHtml = (json: ExecutionPath, userStyleConfig?: StyleConfig): string => {
     const { qubits, operations } = json;
     const { qubitWires, registers, svgHeight } = formatInputs(qubits);
     const { metadataList, svgWidth } = processOperations(operations, registers);
@@ -110,7 +25,7 @@ export const executionPathToHtml = (json: ExecutionPath): string => {
     return `<html>
     <svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="${svgWidth}" height="${svgHeight}">
         ${script}
-        ${style}
+        ${style(userStyleConfig)}
         ${qubitWires}
         ${formattedRegs}
         ${formattedGates}

--- a/src/Kernel/client/ExecutionPathVisualizer/index.ts
+++ b/src/Kernel/client/ExecutionPathVisualizer/index.ts
@@ -22,20 +22,20 @@ const script: string = `
         switch (currValue) {
             case '?':
                 textSvg.childNodes[0].nodeValue = '1';
-                group.classList.remove('cls-control-unknown');
-                group.classList.add('cls-control-one');
+                group.classList.remove('classically-controlled-unknown');
+                group.classList.add('classically-controlled-one');
                 break;
             case '1':
                 textSvg.childNodes[0].nodeValue = '0';
-                group.classList.remove('cls-control-one');
-                group.classList.add('cls-control-zero');
+                group.classList.remove('classically-controlled-one');
+                group.classList.add('classically-controlled-zero');
                 oneGates.classList.toggle('hidden');
                 zeroGates.classList.toggle('hidden');
                 break;
             case '0':
                 textSvg.childNodes[0].nodeValue = '?';
-                group.classList.remove('cls-control-zero');
-                group.classList.add('cls-control-unknown');
+                group.classList.remove('classically-controlled-zero');
+                group.classList.add('classically-controlled-unknown');
                 zeroGates.classList.toggle('hidden');
                 oneGates.classList.toggle('hidden');
                 break;

--- a/src/Kernel/client/ExecutionPathVisualizer/index.ts
+++ b/src/Kernel/client/ExecutionPathVisualizer/index.ts
@@ -5,7 +5,44 @@ import { processOperations } from "./process";
 import { ExecutionPath } from "./executionPath";
 import { Metadata } from "./metadata";
 import { GateType } from "./constants";
-import { StyleConfig, script, style } from "./styles";
+import { StyleConfig, style } from "./styles";
+
+/**
+ * Custom JavaScript code to be injected into visualization HTML string.
+ * Handles interactive elements, such as classically-controlled operations.
+ */
+const script: string = `
+<script type="text/JavaScript">
+    function toggleClassicalBtn(cls) {
+        const textSvg = document.querySelector(\`.\${cls} text\`);
+        const group = document.querySelector(\`.\${cls}-group\`);
+        const currValue = textSvg.childNodes[0].nodeValue;
+        const zeroGates = document.querySelector(\`.\${cls}-zero\`);
+        const oneGates = document.querySelector(\`.\${cls}-one\`);
+        switch (currValue) {
+            case '?':
+                textSvg.childNodes[0].nodeValue = '1';
+                group.classList.remove('cls-control-unknown');
+                group.classList.add('cls-control-one');
+                break;
+            case '1':
+                textSvg.childNodes[0].nodeValue = '0';
+                group.classList.remove('cls-control-one');
+                group.classList.add('cls-control-zero');
+                oneGates.classList.toggle('hidden');
+                zeroGates.classList.toggle('hidden');
+                break;
+            case '0':
+                textSvg.childNodes[0].nodeValue = '?';
+                group.classList.remove('cls-control-zero');
+                group.classList.add('cls-control-unknown');
+                zeroGates.classList.toggle('hidden');
+                oneGates.classList.toggle('hidden');
+                break;
+        }
+    }
+</script>
+`;
 
 /**
  * Converts JSON representing an execution path of a Q# program given by the simulator and returns its HTML visualization.

--- a/src/Kernel/client/ExecutionPathVisualizer/process.ts
+++ b/src/Kernel/client/ExecutionPathVisualizer/process.ts
@@ -54,7 +54,7 @@ const processOperations = (operations: Operation[], registers: RegisterMap)
 
             // Add HTML class attribute if classically controlled
             if (metadata.type === GateType.ClassicalControlled) {
-                _addClass(metadata, `cls-control-${cls++}`);
+                _addClass(metadata, `classically-controlled-${cls++}`);
             }
 
             // Expand column size, if needed

--- a/src/Kernel/client/ExecutionPathVisualizer/styles.ts
+++ b/src/Kernel/client/ExecutionPathVisualizer/styles.ts
@@ -2,8 +2,16 @@
  * Provides configuration for CSS styles of visualization.
  */
 export interface StyleConfig {
+    /** Line stroke style. */
+    lineStroke?: string;
+    /** Line width. */
+    lineWidth?: number;
+    /** Text colour. */
+    textColour?: string;
     /** Single qubit unitary fill colour. */
     unitary?: string;
+    /** Oplus circle fill colour. */
+    oplus?: string;
     /** Measurement gate fill colour. */
     measure?: string;
     /** Measurement unknown primary colour. */
@@ -14,33 +22,90 @@ export interface StyleConfig {
     classicalOne?: string;
 }
 
-const defaultStyleConfig: StyleConfig = {
+const defaultStyle: StyleConfig = {
+    lineStroke: "#000000",
+    lineWidth: 1,
+    textColour: "#000000",
     unitary: "#D9F1FA",
+    oplus: "#FFFFFF",
     measure: "#FFDE86",
     classicalUnknown: "#E5E5E5",
     classicalZero: "#C40000",
     classicalOne: "#4059BD",
 };
 
+const blackAndWhiteStyle: StyleConfig = {
+    lineStroke: "#000000",
+    lineWidth: 1,
+    textColour: "#000000",
+    unitary: "#FFFFFF",
+    oplus: "#FFFFFF",
+    measure: "#FFFFFF",
+    classicalUnknown: "#FFFFFF",
+    classicalZero: "#FFFFFF",
+    classicalOne: "#FFFFFF",
+};
+
+const invertedStyle: StyleConfig = {
+    lineStroke: "#FFFFFF",
+    lineWidth: 1,
+    textColour: "#FFFFFF",
+    unitary: "#000000",
+    oplus: "#000000",
+    measure: "#000000",
+    classicalUnknown: "#000000",
+    classicalZero: "#000000",
+    classicalOne: "#000000",
+};
+
+export const STYLES = {
+    DEFAULT: defaultStyle,
+    BLACK_AND_WHITE: blackAndWhiteStyle,
+    INVERTED: invertedStyle,
+};
+
 /**
  * CSS style script to be injected into visualization HTML string.
  * 
- * @param userConfig Custom style configuration.
+ * @param customStyle Custom style configuration.
  * 
  * @returns String containing CSS style script.
  */
-export const style = (userConfig: StyleConfig = {}) => {
-    const config = { ...defaultStyleConfig, ...userConfig };
+export const style = (customStyle: StyleConfig = {}) => {
+    const styleConfig = { ...defaultStyle, ...customStyle };
     return `
 <style>
-    .box {
-        fill: white;
+    line,
+    circle,
+    rect {
+        stroke: ${styleConfig.lineStroke};
+        stroke-width: ${styleConfig.lineWidth};
+    }
+    text {
+        color: ${styleConfig.textColour};
+        dominant-baseline: middle;
+        text-anchor: middle;
+        font-family: Arial;
+    }
+    .control-dot {
+        fill: ${styleConfig.lineStroke};
+    }
+    .oplus {
+        fill: ${styleConfig.oplus};
     }
     .gate-unitary {
-        fill: ${config.unitary};
+        fill: ${styleConfig.unitary};
     }
     .gate-measure {
-        fill: ${config.measure};
+        fill: ${styleConfig.measure};
+    }
+    .arc-measure {
+        stroke: ${styleConfig.lineStroke};
+        fill: none;
+        stroke-width: ${styleConfig.lineWidth};
+    }
+    .register-classical {
+        stroke-width: ${styleConfig.lineWidth / 2};
     }
     <!-- Classically controlled gates -->
     .hidden {
@@ -52,74 +117,37 @@ export const style = (userConfig: StyleConfig = {}) => {
     <!-- Gate outline -->
     .cls-control-one .cls-container,
     .cls-control-one .cls-line {
-        stroke: ${config.classicalOne};
-        stroke-width: 1.3;
+        stroke: ${styleConfig.classicalOne};
+        stroke-width: ${styleConfig.lineWidth + 0.3};
     }
     .cls-control-zero .cls-container,
     .cls-control-zero .cls-line {
-        stroke: ${config.classicalZero};
-        stroke-width: 1.3;
+        stroke: ${styleConfig.classicalZero};
+        stroke-width: ${styleConfig.lineWidth + 0.3};
     }
     <!-- Control button -->
     .cls-control-btn {
         cursor: pointer;
     }
     .cls-control-unknown .cls-control-btn {
-        fill: ${config.classicalUnknown};
+        fill: ${styleConfig.classicalUnknown};
     }
     .cls-control-one .cls-control-btn {
-        fill: ${config.classicalOne};
+        fill: ${styleConfig.classicalOne};
     }
     .cls-control-zero .cls-control-btn {
-        fill: ${config.classicalZero};
+        fill: ${styleConfig.classicalZero};
     }
     <!-- Control button text -->
     .cls-control-unknown .cls-control-text {
-        fill: black;
+        fill: ${styleConfig.textColour};
         stroke: none;
     }
     .cls-control-one .cls-control-text,
     .cls-control-zero .cls-control-text {
-        fill: white;
+        color: white;
         stroke: none;
     }
 </style>
 `
 };
-
-/**
- * Custom JavaScript code to be injected into visualization HTML string.
- * Handles interactive elements, such as classically-controlled operations.
- */
-export const script = `
-<script type="text/JavaScript">
-    function toggleClassicalBtn(cls) {
-        const textSvg = document.querySelector(\`.\${cls} text\`);
-        const group = document.querySelector(\`.\${cls}-group\`);
-        const currValue = textSvg.childNodes[0].nodeValue;
-        const zeroGates = document.querySelector(\`.\${cls}-zero\`);
-        const oneGates = document.querySelector(\`.\${cls}-one\`);
-        switch (currValue) {
-            case '?':
-                textSvg.childNodes[0].nodeValue = '1';
-                group.classList.remove('cls-control-unknown');
-                group.classList.add('cls-control-one');
-                break;
-            case '1':
-                textSvg.childNodes[0].nodeValue = '0';
-                group.classList.remove('cls-control-one');
-                group.classList.add('cls-control-zero');
-                oneGates.classList.toggle('hidden');
-                zeroGates.classList.toggle('hidden');
-                break;
-            case '0':
-                textSvg.childNodes[0].nodeValue = '?';
-                group.classList.remove('cls-control-zero');
-                group.classList.add('cls-control-unknown');
-                zeroGates.classList.toggle('hidden');
-                oneGates.classList.toggle('hidden');
-                break;
-        }
-    }
-</script>
-`;

--- a/src/Kernel/client/ExecutionPathVisualizer/styles.ts
+++ b/src/Kernel/client/ExecutionPathVisualizer/styles.ts
@@ -61,13 +61,13 @@ const invertedStyle: StyleConfig = {
 /**
  * Set of default styles.
  */
-export const STYLES = {
+export const STYLES: { [name: string]: StyleConfig } = {
     /** Default style with coloured gates. */
-    DEFAULT: defaultStyle,
+    "Default": defaultStyle,
     /** Black and white style. */
-    BLACK_AND_WHITE: blackAndWhiteStyle,
+    "BlackAndWhite": blackAndWhiteStyle,
     /** Inverted black and white style (for black backgrounds). */
-    INVERTED: invertedStyle,
+    "Inverted": invertedStyle,
 };
 
 /**

--- a/src/Kernel/client/ExecutionPathVisualizer/styles.ts
+++ b/src/Kernel/client/ExecutionPathVisualizer/styles.ts
@@ -1,0 +1,125 @@
+/**
+ * Provides configuration for CSS styles of visualization.
+ */
+export interface StyleConfig {
+    /** Single qubit unitary fill colour. */
+    unitary?: string;
+    /** Measurement gate fill colour. */
+    measure?: string;
+    /** Measurement unknown primary colour. */
+    classicalUnknown?: string;
+    /** Measurement zero primary colour. */
+    classicalZero?: string;
+    /** Measurement one primary colour. */
+    classicalOne?: string;
+}
+
+const defaultStyleConfig: StyleConfig = {
+    unitary: "#D9F1FA",
+    measure: "#FFDE86",
+    classicalUnknown: "#E5E5E5",
+    classicalZero: "#C40000",
+    classicalOne: "#4059BD",
+};
+
+/**
+ * CSS style script to be injected into visualization HTML string.
+ * 
+ * @param userConfig Custom style configuration.
+ * 
+ * @returns String containing CSS style script.
+ */
+export const style = (userConfig: StyleConfig = {}) => {
+    const config = { ...defaultStyleConfig, ...userConfig };
+    return `
+<style>
+    .box {
+        fill: white;
+    }
+    .gate-unitary {
+        fill: ${config.unitary};
+    }
+    .gate-measure {
+        fill: ${config.measure};
+    }
+    <!-- Classically controlled gates -->
+    .hidden {
+        display: none;
+    }
+    .cls-control-unknown {
+        opacity: 0.25;
+    }
+    <!-- Gate outline -->
+    .cls-control-one .cls-container,
+    .cls-control-one .cls-line {
+        stroke: ${config.classicalOne};
+        stroke-width: 1.3;
+    }
+    .cls-control-zero .cls-container,
+    .cls-control-zero .cls-line {
+        stroke: ${config.classicalZero};
+        stroke-width: 1.3;
+    }
+    <!-- Control button -->
+    .cls-control-btn {
+        cursor: pointer;
+    }
+    .cls-control-unknown .cls-control-btn {
+        fill: ${config.classicalUnknown};
+    }
+    .cls-control-one .cls-control-btn {
+        fill: ${config.classicalOne};
+    }
+    .cls-control-zero .cls-control-btn {
+        fill: ${config.classicalZero};
+    }
+    <!-- Control button text -->
+    .cls-control-unknown .cls-control-text {
+        fill: black;
+        stroke: none;
+    }
+    .cls-control-one .cls-control-text,
+    .cls-control-zero .cls-control-text {
+        fill: white;
+        stroke: none;
+    }
+</style>
+`
+};
+
+/**
+ * Custom JavaScript code to be injected into visualization HTML string.
+ * Handles interactive elements, such as classically-controlled operations.
+ */
+export const script = `
+<script type="text/JavaScript">
+    function toggleClassicalBtn(cls) {
+        const textSvg = document.querySelector(\`.\${cls} text\`);
+        const group = document.querySelector(\`.\${cls}-group\`);
+        const currValue = textSvg.childNodes[0].nodeValue;
+        const zeroGates = document.querySelector(\`.\${cls}-zero\`);
+        const oneGates = document.querySelector(\`.\${cls}-one\`);
+        switch (currValue) {
+            case '?':
+                textSvg.childNodes[0].nodeValue = '1';
+                group.classList.remove('cls-control-unknown');
+                group.classList.add('cls-control-one');
+                break;
+            case '1':
+                textSvg.childNodes[0].nodeValue = '0';
+                group.classList.remove('cls-control-one');
+                group.classList.add('cls-control-zero');
+                oneGates.classList.toggle('hidden');
+                zeroGates.classList.toggle('hidden');
+                break;
+            case '0':
+                textSvg.childNodes[0].nodeValue = '?';
+                group.classList.remove('cls-control-zero');
+                group.classList.add('cls-control-unknown');
+                zeroGates.classList.toggle('hidden');
+                oneGates.classList.toggle('hidden');
+                break;
+        }
+    }
+</script>
+`;

--- a/src/Kernel/client/ExecutionPathVisualizer/styles.ts
+++ b/src/Kernel/client/ExecutionPathVisualizer/styles.ts
@@ -58,9 +58,15 @@ const invertedStyle: StyleConfig = {
     classicalOne: "#000000",
 };
 
+/**
+ * Set of default styles.
+ */
 export const STYLES = {
+    /** Default style with coloured gates. */
     DEFAULT: defaultStyle,
+    /** Black and white style. */
     BLACK_AND_WHITE: blackAndWhiteStyle,
+    /** Inverted black and white style (for black backgrounds). */
     INVERTED: invertedStyle,
 };
 
@@ -111,40 +117,40 @@ export const style = (customStyle: StyleConfig = {}) => {
     .hidden {
         display: none;
     }
-    .cls-control-unknown {
+    .classically-controlled-unknown {
         opacity: 0.25;
     }
     <!-- Gate outline -->
-    .cls-control-one .cls-container,
-    .cls-control-one .cls-line {
+    .classically-controlled-one .classical-container,
+    .classically-controlled-one .classical-line {
         stroke: ${styleConfig.classicalOne};
         stroke-width: ${styleConfig.lineWidth + 0.3};
     }
-    .cls-control-zero .cls-container,
-    .cls-control-zero .cls-line {
+    .classically-controlled-zero .classical-container,
+    .classically-controlled-zero .classical-line {
         stroke: ${styleConfig.classicalZero};
         stroke-width: ${styleConfig.lineWidth + 0.3};
     }
     <!-- Control button -->
-    .cls-control-btn {
+    .classically-controlled-btn {
         cursor: pointer;
     }
-    .cls-control-unknown .cls-control-btn {
+    .classically-controlled-unknown .classically-controlled-btn {
         fill: ${styleConfig.classicalUnknown};
     }
-    .cls-control-one .cls-control-btn {
+    .classically-controlled-one .classically-controlled-btn {
         fill: ${styleConfig.classicalOne};
     }
-    .cls-control-zero .cls-control-btn {
+    .classically-controlled-zero .classically-controlled-btn {
         fill: ${styleConfig.classicalZero};
     }
     <!-- Control button text -->
-    .cls-control-unknown .cls-control-text {
+    .classically-controlled-unknown .classically-controlled-text {
         fill: ${styleConfig.textColour};
         stroke: none;
     }
-    .cls-control-one .cls-control-text,
-    .cls-control-zero .cls-control-text {
+    .classically-controlled-one .classically-controlled-text,
+    .classically-controlled-zero .classically-controlled-text {
         color: white;
         stroke: none;
     }

--- a/src/Kernel/client/__tests__/ExecutionPathVisualizerTests/__snapshots__/gateFormatter.test.ts.snap
+++ b/src/Kernel/client/__tests__/ExecutionPathVisualizerTests/__snapshots__/gateFormatter.test.ts.snap
@@ -2,61 +2,61 @@
 
 exports[`Testing _classicalControlled No htmlClass 1`] = `
 "<g>
-<g class=\\"cls-control-group cls-control-unknown\\">
-<line class=\\"cls-line\\" x1=\\"95\\" x2=\\"120\\" y1=\\"180\\" y2=\\"180\\" stroke-dasharray=\\"8, 8\\"></line>
-<line class=\\"cls-line\\" x1=\\"95\\" x2=\\"95\\" y1=\\"175\\" y2=\\"180\\" stroke-dasharray=\\"8, 8\\"></line>
-<g class=\\"cls-control-btn cls-control\\" onClick=\\"toggleClassicalBtn('cls-control')\\">
-<circle class=\\"cls-control\\" cx=\\"95\\" cy=\\"160\\" r=\\"15\\" stroke=\\"black\\" stroke-width=\\"1\\"></circle>
-<text class=\\"cls-control cls-control-text\\" font-size=\\"14\\" font-family=\\"Arial\\" x=\\"95\\" y=\\"160\\" dominant-baseline=\\"middle\\" text-anchor=\\"middle\\" fill=\\"black\\">?</text>
+<g class=\\"classically-controlled-group classically-controlled-unknown\\">
+<line class=\\"classical-line\\" x1=\\"95\\" x2=\\"120\\" y1=\\"180\\" y2=\\"180\\" stroke-dasharray=\\"8, 8\\"></line>
+<line class=\\"classical-line\\" x1=\\"95\\" x2=\\"95\\" y1=\\"175\\" y2=\\"180\\" stroke-dasharray=\\"8, 8\\"></line>
+<g class=\\"classically-controlled-btn classically-controlled\\" onClick=\\"toggleClassicalBtn('classically-controlled')\\">
+<circle class=\\"classically-controlled\\" cx=\\"95\\" cy=\\"160\\" r=\\"15\\" stroke=\\"black\\" stroke-width=\\"1\\"></circle>
+<text class=\\"classically-controlled classically-controlled-text\\" font-size=\\"14\\" font-family=\\"Arial\\" x=\\"95\\" y=\\"160\\" dominant-baseline=\\"middle\\" text-anchor=\\"middle\\" fill=\\"black\\">?</text>
 </g>
-<g class=\\"cls-control-zero hidden\\">
+<g class=\\"classically-controlled-zero hidden\\">
 </g>
-<g class=\\"cls-control-one\\">
+<g class=\\"classically-controlled-one\\">
 <g>
 <rect class=\\"gate-unitary\\" x=\\"90\\" y=\\"20\\" width=\\"40\\" height=\\"40\\"></rect>
 <text font-size=\\"14\\" x=\\"110\\" y=\\"40\\">X</text>
 </g></g>
-<rect class=\\"cls-container\\" x=\\"120\\" y=\\"5\\" width=\\"80\\" height=\\"130\\" fill-opacity=\\"0\\" stroke-dasharray=\\"8, 8\\"></rect>
+<rect class=\\"classical-container\\" x=\\"120\\" y=\\"5\\" width=\\"80\\" height=\\"130\\" fill-opacity=\\"0\\" stroke-dasharray=\\"8, 8\\"></rect>
 </g>
 </g>"
 `;
 
 exports[`Testing _classicalControlled change padding 1`] = `
 "<g>
-<g class=\\"cls-control-1-group cls-control-unknown\\">
-<line class=\\"cls-line\\" x1=\\"95\\" x2=\\"120\\" y1=\\"180\\" y2=\\"180\\" stroke-dasharray=\\"8, 8\\"></line>
-<line class=\\"cls-line\\" x1=\\"95\\" x2=\\"95\\" y1=\\"175\\" y2=\\"180\\" stroke-dasharray=\\"8, 8\\"></line>
-<g class=\\"cls-control-btn cls-control-1\\" onClick=\\"toggleClassicalBtn('cls-control-1')\\">
-<circle class=\\"cls-control-1\\" cx=\\"95\\" cy=\\"160\\" r=\\"15\\" stroke=\\"black\\" stroke-width=\\"1\\"></circle>
-<text class=\\"cls-control-1 cls-control-text\\" font-size=\\"14\\" font-family=\\"Arial\\" x=\\"95\\" y=\\"160\\" dominant-baseline=\\"middle\\" text-anchor=\\"middle\\" fill=\\"black\\">?</text>
+<g class=\\"classically-controlled-1-group classically-controlled-unknown\\">
+<line class=\\"classical-line\\" x1=\\"95\\" x2=\\"120\\" y1=\\"180\\" y2=\\"180\\" stroke-dasharray=\\"8, 8\\"></line>
+<line class=\\"classical-line\\" x1=\\"95\\" x2=\\"95\\" y1=\\"175\\" y2=\\"180\\" stroke-dasharray=\\"8, 8\\"></line>
+<g class=\\"classically-controlled-btn classically-controlled-1\\" onClick=\\"toggleClassicalBtn('classically-controlled-1')\\">
+<circle class=\\"classically-controlled-1\\" cx=\\"95\\" cy=\\"160\\" r=\\"15\\" stroke=\\"black\\" stroke-width=\\"1\\"></circle>
+<text class=\\"classically-controlled-1 classically-controlled-text\\" font-size=\\"14\\" font-family=\\"Arial\\" x=\\"95\\" y=\\"160\\" dominant-baseline=\\"middle\\" text-anchor=\\"middle\\" fill=\\"black\\">?</text>
 </g>
-<g class=\\"cls-control-1-zero hidden\\">
+<g class=\\"classically-controlled-1-zero hidden\\">
 </g>
-<g class=\\"cls-control-1-one\\">
+<g class=\\"classically-controlled-1-one\\">
 <g>
 <rect class=\\"gate-unitary\\" x=\\"90\\" y=\\"20\\" width=\\"40\\" height=\\"40\\"></rect>
 <text font-size=\\"14\\" x=\\"110\\" y=\\"40\\">X</text>
 </g></g>
-<rect class=\\"cls-container\\" x=\\"115\\" y=\\"0\\" width=\\"90\\" height=\\"140\\" fill-opacity=\\"0\\" stroke-dasharray=\\"8, 8\\"></rect>
+<rect class=\\"classical-container\\" x=\\"115\\" y=\\"0\\" width=\\"90\\" height=\\"140\\" fill-opacity=\\"0\\" stroke-dasharray=\\"8, 8\\"></rect>
 </g>
 </g>"
 `;
 
 exports[`Testing _classicalControlled multiple 'zero'/'one' children 1`] = `
 "<g>
-<g class=\\"cls-control-1-group cls-control-unknown\\">
-<line class=\\"cls-line\\" x1=\\"95\\" x2=\\"120\\" y1=\\"180\\" y2=\\"180\\" stroke-dasharray=\\"8, 8\\"></line>
-<line class=\\"cls-line\\" x1=\\"95\\" x2=\\"95\\" y1=\\"175\\" y2=\\"180\\" stroke-dasharray=\\"8, 8\\"></line>
-<g class=\\"cls-control-btn cls-control-1\\" onClick=\\"toggleClassicalBtn('cls-control-1')\\">
-<circle class=\\"cls-control-1\\" cx=\\"95\\" cy=\\"160\\" r=\\"15\\" stroke=\\"black\\" stroke-width=\\"1\\"></circle>
-<text class=\\"cls-control-1 cls-control-text\\" font-size=\\"14\\" font-family=\\"Arial\\" x=\\"95\\" y=\\"160\\" dominant-baseline=\\"middle\\" text-anchor=\\"middle\\" fill=\\"black\\">?</text>
+<g class=\\"classically-controlled-1-group classically-controlled-unknown\\">
+<line class=\\"classical-line\\" x1=\\"95\\" x2=\\"120\\" y1=\\"180\\" y2=\\"180\\" stroke-dasharray=\\"8, 8\\"></line>
+<line class=\\"classical-line\\" x1=\\"95\\" x2=\\"95\\" y1=\\"175\\" y2=\\"180\\" stroke-dasharray=\\"8, 8\\"></line>
+<g class=\\"classically-controlled-btn classically-controlled-1\\" onClick=\\"toggleClassicalBtn('classically-controlled-1')\\">
+<circle class=\\"classically-controlled-1\\" cx=\\"95\\" cy=\\"160\\" r=\\"15\\" stroke=\\"black\\" stroke-width=\\"1\\"></circle>
+<text class=\\"classically-controlled-1 classically-controlled-text\\" font-size=\\"14\\" font-family=\\"Arial\\" x=\\"95\\" y=\\"160\\" dominant-baseline=\\"middle\\" text-anchor=\\"middle\\" fill=\\"black\\">?</text>
 </g>
-<g class=\\"cls-control-1-zero hidden\\">
+<g class=\\"classically-controlled-1-zero hidden\\">
 <g>
 <rect class=\\"gate-unitary\\" x=\\"90\\" y=\\"20\\" width=\\"40\\" height=\\"40\\"></rect>
 <text font-size=\\"14\\" x=\\"110\\" y=\\"40\\">X</text>
 </g></g>
-<g class=\\"cls-control-1-one\\">
+<g class=\\"classically-controlled-1-one\\">
 <g>
 <rect class=\\"gate-unitary\\" x=\\"90\\" y=\\"20\\" width=\\"40\\" height=\\"40\\"></rect>
 <text font-size=\\"14\\" x=\\"110\\" y=\\"40\\">X</text>
@@ -70,38 +70,38 @@ exports[`Testing _classicalControlled multiple 'zero'/'one' children 1`] = `
 <line x1=\\"155\\" x2=\\"185\\" y1=\\"40\\" y2=\\"40\\"></line>
 </g>
 </g></g>
-<rect class=\\"cls-container\\" x=\\"120\\" y=\\"5\\" width=\\"80\\" height=\\"130\\" fill-opacity=\\"0\\" stroke-dasharray=\\"8, 8\\"></rect>
+<rect class=\\"classical-container\\" x=\\"120\\" y=\\"5\\" width=\\"80\\" height=\\"130\\" fill-opacity=\\"0\\" stroke-dasharray=\\"8, 8\\"></rect>
 </g>
 </g>"
 `;
 
 exports[`Testing _classicalControlled nested children 1`] = `
 "<g>
-<g class=\\"cls-control-1-group cls-control-unknown\\">
-<line class=\\"cls-line\\" x1=\\"95\\" x2=\\"120\\" y1=\\"180\\" y2=\\"180\\" stroke-dasharray=\\"8, 8\\"></line>
-<line class=\\"cls-line\\" x1=\\"95\\" x2=\\"95\\" y1=\\"175\\" y2=\\"180\\" stroke-dasharray=\\"8, 8\\"></line>
-<g class=\\"cls-control-btn cls-control-1\\" onClick=\\"toggleClassicalBtn('cls-control-1')\\">
-<circle class=\\"cls-control-1\\" cx=\\"95\\" cy=\\"160\\" r=\\"15\\" stroke=\\"black\\" stroke-width=\\"1\\"></circle>
-<text class=\\"cls-control-1 cls-control-text\\" font-size=\\"14\\" font-family=\\"Arial\\" x=\\"95\\" y=\\"160\\" dominant-baseline=\\"middle\\" text-anchor=\\"middle\\" fill=\\"black\\">?</text>
+<g class=\\"classically-controlled-1-group classically-controlled-unknown\\">
+<line class=\\"classical-line\\" x1=\\"95\\" x2=\\"120\\" y1=\\"180\\" y2=\\"180\\" stroke-dasharray=\\"8, 8\\"></line>
+<line class=\\"classical-line\\" x1=\\"95\\" x2=\\"95\\" y1=\\"175\\" y2=\\"180\\" stroke-dasharray=\\"8, 8\\"></line>
+<g class=\\"classically-controlled-btn classically-controlled-1\\" onClick=\\"toggleClassicalBtn('classically-controlled-1')\\">
+<circle class=\\"classically-controlled-1\\" cx=\\"95\\" cy=\\"160\\" r=\\"15\\" stroke=\\"black\\" stroke-width=\\"1\\"></circle>
+<text class=\\"classically-controlled-1 classically-controlled-text\\" font-size=\\"14\\" font-family=\\"Arial\\" x=\\"95\\" y=\\"160\\" dominant-baseline=\\"middle\\" text-anchor=\\"middle\\" fill=\\"black\\">?</text>
 </g>
-<g class=\\"cls-control-1-zero hidden\\">
+<g class=\\"classically-controlled-1-zero hidden\\">
 </g>
-<g class=\\"cls-control-1-one\\">
+<g class=\\"classically-controlled-1-one\\">
 <g>
 <rect class=\\"gate-unitary\\" x=\\"90\\" y=\\"20\\" width=\\"40\\" height=\\"40\\"></rect>
 <text font-size=\\"14\\" x=\\"110\\" y=\\"40\\">X</text>
 </g>
 <g>
-<g class=\\"cls-control-1-group cls-control-unknown\\">
-<line class=\\"cls-line\\" x1=\\"165\\" x2=\\"190\\" y1=\\"240\\" y2=\\"240\\" stroke-dasharray=\\"8, 8\\"></line>
-<line class=\\"cls-line\\" x1=\\"165\\" x2=\\"165\\" y1=\\"235\\" y2=\\"240\\" stroke-dasharray=\\"8, 8\\"></line>
-<g class=\\"cls-control-btn cls-control-1\\" onClick=\\"toggleClassicalBtn('cls-control-1')\\">
-<circle class=\\"cls-control-1\\" cx=\\"165\\" cy=\\"220\\" r=\\"15\\" stroke=\\"black\\" stroke-width=\\"1\\"></circle>
-<text class=\\"cls-control-1 cls-control-text\\" font-size=\\"14\\" font-family=\\"Arial\\" x=\\"165\\" y=\\"220\\" dominant-baseline=\\"middle\\" text-anchor=\\"middle\\" fill=\\"black\\">?</text>
+<g class=\\"classically-controlled-1-group classically-controlled-unknown\\">
+<line class=\\"classical-line\\" x1=\\"165\\" x2=\\"190\\" y1=\\"240\\" y2=\\"240\\" stroke-dasharray=\\"8, 8\\"></line>
+<line class=\\"classical-line\\" x1=\\"165\\" x2=\\"165\\" y1=\\"235\\" y2=\\"240\\" stroke-dasharray=\\"8, 8\\"></line>
+<g class=\\"classically-controlled-btn classically-controlled-1\\" onClick=\\"toggleClassicalBtn('classically-controlled-1')\\">
+<circle class=\\"classically-controlled-1\\" cx=\\"165\\" cy=\\"220\\" r=\\"15\\" stroke=\\"black\\" stroke-width=\\"1\\"></circle>
+<text class=\\"classically-controlled-1 classically-controlled-text\\" font-size=\\"14\\" font-family=\\"Arial\\" x=\\"165\\" y=\\"220\\" dominant-baseline=\\"middle\\" text-anchor=\\"middle\\" fill=\\"black\\">?</text>
 </g>
-<g class=\\"cls-control-1-zero hidden\\">
+<g class=\\"classically-controlled-1-zero hidden\\">
 </g>
-<g class=\\"cls-control-1-one\\">
+<g class=\\"classically-controlled-1-one\\">
 <g>
 <line x1=\\"180\\" x2=\\"180\\" y1=\\"40\\" y2=\\"100\\"></line>
 <circle class=\\"control-dot\\" cx=\\"180\\" cy=\\"100\\" r=\\"5\\"></circle>
@@ -111,52 +111,52 @@ exports[`Testing _classicalControlled nested children 1`] = `
 <line x1=\\"165\\" x2=\\"195\\" y1=\\"40\\" y2=\\"40\\"></line>
 </g>
 </g></g>
-<rect class=\\"cls-container\\" x=\\"190\\" y=\\"5\\" width=\\"20\\" height=\\"130\\" fill-opacity=\\"0\\" stroke-dasharray=\\"8, 8\\"></rect>
+<rect class=\\"classical-container\\" x=\\"190\\" y=\\"5\\" width=\\"20\\" height=\\"130\\" fill-opacity=\\"0\\" stroke-dasharray=\\"8, 8\\"></rect>
 </g>
 </g></g>
-<rect class=\\"cls-container\\" x=\\"120\\" y=\\"5\\" width=\\"100\\" height=\\"130\\" fill-opacity=\\"0\\" stroke-dasharray=\\"8, 8\\"></rect>
+<rect class=\\"classical-container\\" x=\\"120\\" y=\\"5\\" width=\\"100\\" height=\\"130\\" fill-opacity=\\"0\\" stroke-dasharray=\\"8, 8\\"></rect>
 </g>
 </g>"
 `;
 
 exports[`Testing _classicalControlled one 'one' child 1`] = `
 "<g>
-<g class=\\"cls-control-1-group cls-control-unknown\\">
-<line class=\\"cls-line\\" x1=\\"95\\" x2=\\"120\\" y1=\\"180\\" y2=\\"180\\" stroke-dasharray=\\"8, 8\\"></line>
-<line class=\\"cls-line\\" x1=\\"95\\" x2=\\"95\\" y1=\\"175\\" y2=\\"180\\" stroke-dasharray=\\"8, 8\\"></line>
-<g class=\\"cls-control-btn cls-control-1\\" onClick=\\"toggleClassicalBtn('cls-control-1')\\">
-<circle class=\\"cls-control-1\\" cx=\\"95\\" cy=\\"160\\" r=\\"15\\" stroke=\\"black\\" stroke-width=\\"1\\"></circle>
-<text class=\\"cls-control-1 cls-control-text\\" font-size=\\"14\\" font-family=\\"Arial\\" x=\\"95\\" y=\\"160\\" dominant-baseline=\\"middle\\" text-anchor=\\"middle\\" fill=\\"black\\">?</text>
+<g class=\\"classically-controlled-1-group classically-controlled-unknown\\">
+<line class=\\"classical-line\\" x1=\\"95\\" x2=\\"120\\" y1=\\"180\\" y2=\\"180\\" stroke-dasharray=\\"8, 8\\"></line>
+<line class=\\"classical-line\\" x1=\\"95\\" x2=\\"95\\" y1=\\"175\\" y2=\\"180\\" stroke-dasharray=\\"8, 8\\"></line>
+<g class=\\"classically-controlled-btn classically-controlled-1\\" onClick=\\"toggleClassicalBtn('classically-controlled-1')\\">
+<circle class=\\"classically-controlled-1\\" cx=\\"95\\" cy=\\"160\\" r=\\"15\\" stroke=\\"black\\" stroke-width=\\"1\\"></circle>
+<text class=\\"classically-controlled-1 classically-controlled-text\\" font-size=\\"14\\" font-family=\\"Arial\\" x=\\"95\\" y=\\"160\\" dominant-baseline=\\"middle\\" text-anchor=\\"middle\\" fill=\\"black\\">?</text>
 </g>
-<g class=\\"cls-control-1-zero hidden\\">
+<g class=\\"classically-controlled-1-zero hidden\\">
 </g>
-<g class=\\"cls-control-1-one\\">
+<g class=\\"classically-controlled-1-one\\">
 <g>
 <rect class=\\"gate-unitary\\" x=\\"90\\" y=\\"20\\" width=\\"40\\" height=\\"40\\"></rect>
 <text font-size=\\"14\\" x=\\"110\\" y=\\"40\\">X</text>
 </g></g>
-<rect class=\\"cls-container\\" x=\\"120\\" y=\\"5\\" width=\\"20\\" height=\\"130\\" fill-opacity=\\"0\\" stroke-dasharray=\\"8, 8\\"></rect>
+<rect class=\\"classical-container\\" x=\\"120\\" y=\\"5\\" width=\\"20\\" height=\\"130\\" fill-opacity=\\"0\\" stroke-dasharray=\\"8, 8\\"></rect>
 </g>
 </g>"
 `;
 
 exports[`Testing _classicalControlled one 'zero' child 1`] = `
 "<g>
-<g class=\\"cls-control-1-group cls-control-unknown\\">
-<line class=\\"cls-line\\" x1=\\"95\\" x2=\\"120\\" y1=\\"180\\" y2=\\"180\\" stroke-dasharray=\\"8, 8\\"></line>
-<line class=\\"cls-line\\" x1=\\"95\\" x2=\\"95\\" y1=\\"175\\" y2=\\"180\\" stroke-dasharray=\\"8, 8\\"></line>
-<g class=\\"cls-control-btn cls-control-1\\" onClick=\\"toggleClassicalBtn('cls-control-1')\\">
-<circle class=\\"cls-control-1\\" cx=\\"95\\" cy=\\"160\\" r=\\"15\\" stroke=\\"black\\" stroke-width=\\"1\\"></circle>
-<text class=\\"cls-control-1 cls-control-text\\" font-size=\\"14\\" font-family=\\"Arial\\" x=\\"95\\" y=\\"160\\" dominant-baseline=\\"middle\\" text-anchor=\\"middle\\" fill=\\"black\\">?</text>
+<g class=\\"classically-controlled-1-group classically-controlled-unknown\\">
+<line class=\\"classical-line\\" x1=\\"95\\" x2=\\"120\\" y1=\\"180\\" y2=\\"180\\" stroke-dasharray=\\"8, 8\\"></line>
+<line class=\\"classical-line\\" x1=\\"95\\" x2=\\"95\\" y1=\\"175\\" y2=\\"180\\" stroke-dasharray=\\"8, 8\\"></line>
+<g class=\\"classically-controlled-btn classically-controlled-1\\" onClick=\\"toggleClassicalBtn('classically-controlled-1')\\">
+<circle class=\\"classically-controlled-1\\" cx=\\"95\\" cy=\\"160\\" r=\\"15\\" stroke=\\"black\\" stroke-width=\\"1\\"></circle>
+<text class=\\"classically-controlled-1 classically-controlled-text\\" font-size=\\"14\\" font-family=\\"Arial\\" x=\\"95\\" y=\\"160\\" dominant-baseline=\\"middle\\" text-anchor=\\"middle\\" fill=\\"black\\">?</text>
 </g>
-<g class=\\"cls-control-1-zero hidden\\">
+<g class=\\"classically-controlled-1-zero hidden\\">
 <g>
 <rect class=\\"gate-unitary\\" x=\\"90\\" y=\\"20\\" width=\\"40\\" height=\\"40\\"></rect>
 <text font-size=\\"14\\" x=\\"110\\" y=\\"40\\">X</text>
 </g></g>
-<g class=\\"cls-control-1-one\\">
+<g class=\\"classically-controlled-1-one\\">
 </g>
-<rect class=\\"cls-container\\" x=\\"120\\" y=\\"5\\" width=\\"20\\" height=\\"130\\" fill-opacity=\\"0\\" stroke-dasharray=\\"8, 8\\"></rect>
+<rect class=\\"classical-container\\" x=\\"120\\" y=\\"5\\" width=\\"20\\" height=\\"130\\" fill-opacity=\\"0\\" stroke-dasharray=\\"8, 8\\"></rect>
 </g>
 </g>"
 `;
@@ -383,18 +383,18 @@ exports[`Testing _formatGate CNOT gate 1`] = `
 
 exports[`Testing _formatGate classically controlled gate 1`] = `
 "<g>
-<g class=\\"cls-control-group cls-control-unknown\\">
-<line class=\\"cls-line\\" x1=\\"95\\" x2=\\"120\\" y1=\\"180\\" y2=\\"180\\" stroke-dasharray=\\"8, 8\\"></line>
-<line class=\\"cls-line\\" x1=\\"95\\" x2=\\"95\\" y1=\\"175\\" y2=\\"180\\" stroke-dasharray=\\"8, 8\\"></line>
-<g class=\\"cls-control-btn cls-control\\" onClick=\\"toggleClassicalBtn('cls-control')\\">
-<circle class=\\"cls-control\\" cx=\\"95\\" cy=\\"160\\" r=\\"15\\" stroke=\\"black\\" stroke-width=\\"1\\"></circle>
-<text class=\\"cls-control cls-control-text\\" font-size=\\"14\\" font-family=\\"Arial\\" x=\\"95\\" y=\\"160\\" dominant-baseline=\\"middle\\" text-anchor=\\"middle\\" fill=\\"black\\">?</text>
+<g class=\\"classically-controlled-group classically-controlled-unknown\\">
+<line class=\\"classical-line\\" x1=\\"95\\" x2=\\"120\\" y1=\\"180\\" y2=\\"180\\" stroke-dasharray=\\"8, 8\\"></line>
+<line class=\\"classical-line\\" x1=\\"95\\" x2=\\"95\\" y1=\\"175\\" y2=\\"180\\" stroke-dasharray=\\"8, 8\\"></line>
+<g class=\\"classically-controlled-btn classically-controlled\\" onClick=\\"toggleClassicalBtn('classically-controlled')\\">
+<circle class=\\"classically-controlled\\" cx=\\"95\\" cy=\\"160\\" r=\\"15\\" stroke=\\"black\\" stroke-width=\\"1\\"></circle>
+<text class=\\"classically-controlled classically-controlled-text\\" font-size=\\"14\\" font-family=\\"Arial\\" x=\\"95\\" y=\\"160\\" dominant-baseline=\\"middle\\" text-anchor=\\"middle\\" fill=\\"black\\">?</text>
 </g>
-<g class=\\"cls-control-zero hidden\\">
+<g class=\\"classically-controlled-zero hidden\\">
 </g>
-<g class=\\"cls-control-one\\">
+<g class=\\"classically-controlled-one\\">
 </g>
-<rect class=\\"cls-container\\" x=\\"120\\" y=\\"5\\" width=\\"0\\" height=\\"130\\" fill-opacity=\\"0\\" stroke-dasharray=\\"8, 8\\"></rect>
+<rect class=\\"classical-container\\" x=\\"120\\" y=\\"5\\" width=\\"0\\" height=\\"130\\" fill-opacity=\\"0\\" stroke-dasharray=\\"8, 8\\"></rect>
 </g>
 </g>"
 `;

--- a/src/Kernel/client/__tests__/ExecutionPathVisualizerTests/__snapshots__/gateFormatter.test.ts.snap
+++ b/src/Kernel/client/__tests__/ExecutionPathVisualizerTests/__snapshots__/gateFormatter.test.ts.snap
@@ -3,8 +3,8 @@
 exports[`Testing _classicalControlled No htmlClass 1`] = `
 "<g>
 <g class=\\"cls-control-group cls-control-unknown\\">
-<line class=\\"cls-line\\" x1=\\"95\\" x2=\\"120\\" y1=\\"180\\" y2=\\"180\\" stroke=\\"black\\" stroke-dasharray=\\"8, 8\\" stroke-width=\\"1\\"></line>
-<line class=\\"cls-line\\" x1=\\"95\\" x2=\\"95\\" y1=\\"175\\" y2=\\"180\\" stroke=\\"black\\" stroke-dasharray=\\"8, 8\\" stroke-width=\\"1\\"></line>
+<line class=\\"cls-line\\" x1=\\"95\\" x2=\\"120\\" y1=\\"180\\" y2=\\"180\\" stroke-dasharray=\\"8, 8\\"></line>
+<line class=\\"cls-line\\" x1=\\"95\\" x2=\\"95\\" y1=\\"175\\" y2=\\"180\\" stroke-dasharray=\\"8, 8\\"></line>
 <g class=\\"cls-control-btn cls-control\\" onClick=\\"toggleClassicalBtn('cls-control')\\">
 <circle class=\\"cls-control\\" cx=\\"95\\" cy=\\"160\\" r=\\"15\\" stroke=\\"black\\" stroke-width=\\"1\\"></circle>
 <text class=\\"cls-control cls-control-text\\" font-size=\\"14\\" font-family=\\"Arial\\" x=\\"95\\" y=\\"160\\" dominant-baseline=\\"middle\\" text-anchor=\\"middle\\" fill=\\"black\\">?</text>
@@ -13,10 +13,10 @@ exports[`Testing _classicalControlled No htmlClass 1`] = `
 </g>
 <g class=\\"cls-control-one\\">
 <g>
-<rect class=\\"gate-unitary\\" x=\\"90\\" y=\\"20\\" width=\\"40\\" height=\\"40\\" stroke=\\"black\\" stroke-width=\\"1\\"></rect>
-<text font-size=\\"14\\" font-family=\\"Arial\\" x=\\"110\\" y=\\"40\\" dominant-baseline=\\"middle\\" text-anchor=\\"middle\\" fill=\\"black\\">X</text>
+<rect class=\\"gate-unitary\\" x=\\"90\\" y=\\"20\\" width=\\"40\\" height=\\"40\\"></rect>
+<text font-size=\\"14\\" x=\\"110\\" y=\\"40\\">X</text>
 </g></g>
-<rect class=\\"cls-container\\" x=\\"120\\" y=\\"5\\" width=\\"80\\" height=\\"130\\" stroke=\\"black\\" fill-opacity=\\"0\\" stroke-dasharray=\\"8, 8\\" stroke-width=\\"1\\"></rect>
+<rect class=\\"cls-container\\" x=\\"120\\" y=\\"5\\" width=\\"80\\" height=\\"130\\" fill-opacity=\\"0\\" stroke-dasharray=\\"8, 8\\"></rect>
 </g>
 </g>"
 `;
@@ -24,8 +24,8 @@ exports[`Testing _classicalControlled No htmlClass 1`] = `
 exports[`Testing _classicalControlled change padding 1`] = `
 "<g>
 <g class=\\"cls-control-1-group cls-control-unknown\\">
-<line class=\\"cls-line\\" x1=\\"95\\" x2=\\"120\\" y1=\\"180\\" y2=\\"180\\" stroke=\\"black\\" stroke-dasharray=\\"8, 8\\" stroke-width=\\"1\\"></line>
-<line class=\\"cls-line\\" x1=\\"95\\" x2=\\"95\\" y1=\\"175\\" y2=\\"180\\" stroke=\\"black\\" stroke-dasharray=\\"8, 8\\" stroke-width=\\"1\\"></line>
+<line class=\\"cls-line\\" x1=\\"95\\" x2=\\"120\\" y1=\\"180\\" y2=\\"180\\" stroke-dasharray=\\"8, 8\\"></line>
+<line class=\\"cls-line\\" x1=\\"95\\" x2=\\"95\\" y1=\\"175\\" y2=\\"180\\" stroke-dasharray=\\"8, 8\\"></line>
 <g class=\\"cls-control-btn cls-control-1\\" onClick=\\"toggleClassicalBtn('cls-control-1')\\">
 <circle class=\\"cls-control-1\\" cx=\\"95\\" cy=\\"160\\" r=\\"15\\" stroke=\\"black\\" stroke-width=\\"1\\"></circle>
 <text class=\\"cls-control-1 cls-control-text\\" font-size=\\"14\\" font-family=\\"Arial\\" x=\\"95\\" y=\\"160\\" dominant-baseline=\\"middle\\" text-anchor=\\"middle\\" fill=\\"black\\">?</text>
@@ -34,10 +34,10 @@ exports[`Testing _classicalControlled change padding 1`] = `
 </g>
 <g class=\\"cls-control-1-one\\">
 <g>
-<rect class=\\"gate-unitary\\" x=\\"90\\" y=\\"20\\" width=\\"40\\" height=\\"40\\" stroke=\\"black\\" stroke-width=\\"1\\"></rect>
-<text font-size=\\"14\\" font-family=\\"Arial\\" x=\\"110\\" y=\\"40\\" dominant-baseline=\\"middle\\" text-anchor=\\"middle\\" fill=\\"black\\">X</text>
+<rect class=\\"gate-unitary\\" x=\\"90\\" y=\\"20\\" width=\\"40\\" height=\\"40\\"></rect>
+<text font-size=\\"14\\" x=\\"110\\" y=\\"40\\">X</text>
 </g></g>
-<rect class=\\"cls-container\\" x=\\"115\\" y=\\"0\\" width=\\"90\\" height=\\"140\\" stroke=\\"black\\" fill-opacity=\\"0\\" stroke-dasharray=\\"8, 8\\" stroke-width=\\"1\\"></rect>
+<rect class=\\"cls-container\\" x=\\"115\\" y=\\"0\\" width=\\"90\\" height=\\"140\\" fill-opacity=\\"0\\" stroke-dasharray=\\"8, 8\\"></rect>
 </g>
 </g>"
 `;
@@ -45,32 +45,32 @@ exports[`Testing _classicalControlled change padding 1`] = `
 exports[`Testing _classicalControlled multiple 'zero'/'one' children 1`] = `
 "<g>
 <g class=\\"cls-control-1-group cls-control-unknown\\">
-<line class=\\"cls-line\\" x1=\\"95\\" x2=\\"120\\" y1=\\"180\\" y2=\\"180\\" stroke=\\"black\\" stroke-dasharray=\\"8, 8\\" stroke-width=\\"1\\"></line>
-<line class=\\"cls-line\\" x1=\\"95\\" x2=\\"95\\" y1=\\"175\\" y2=\\"180\\" stroke=\\"black\\" stroke-dasharray=\\"8, 8\\" stroke-width=\\"1\\"></line>
+<line class=\\"cls-line\\" x1=\\"95\\" x2=\\"120\\" y1=\\"180\\" y2=\\"180\\" stroke-dasharray=\\"8, 8\\"></line>
+<line class=\\"cls-line\\" x1=\\"95\\" x2=\\"95\\" y1=\\"175\\" y2=\\"180\\" stroke-dasharray=\\"8, 8\\"></line>
 <g class=\\"cls-control-btn cls-control-1\\" onClick=\\"toggleClassicalBtn('cls-control-1')\\">
 <circle class=\\"cls-control-1\\" cx=\\"95\\" cy=\\"160\\" r=\\"15\\" stroke=\\"black\\" stroke-width=\\"1\\"></circle>
 <text class=\\"cls-control-1 cls-control-text\\" font-size=\\"14\\" font-family=\\"Arial\\" x=\\"95\\" y=\\"160\\" dominant-baseline=\\"middle\\" text-anchor=\\"middle\\" fill=\\"black\\">?</text>
 </g>
 <g class=\\"cls-control-1-zero hidden\\">
 <g>
-<rect class=\\"gate-unitary\\" x=\\"90\\" y=\\"20\\" width=\\"40\\" height=\\"40\\" stroke=\\"black\\" stroke-width=\\"1\\"></rect>
-<text font-size=\\"14\\" font-family=\\"Arial\\" x=\\"110\\" y=\\"40\\" dominant-baseline=\\"middle\\" text-anchor=\\"middle\\" fill=\\"black\\">X</text>
+<rect class=\\"gate-unitary\\" x=\\"90\\" y=\\"20\\" width=\\"40\\" height=\\"40\\"></rect>
+<text font-size=\\"14\\" x=\\"110\\" y=\\"40\\">X</text>
 </g></g>
 <g class=\\"cls-control-1-one\\">
 <g>
-<rect class=\\"gate-unitary\\" x=\\"90\\" y=\\"20\\" width=\\"40\\" height=\\"40\\" stroke=\\"black\\" stroke-width=\\"1\\"></rect>
-<text font-size=\\"14\\" font-family=\\"Arial\\" x=\\"110\\" y=\\"40\\" dominant-baseline=\\"middle\\" text-anchor=\\"middle\\" fill=\\"black\\">X</text>
+<rect class=\\"gate-unitary\\" x=\\"90\\" y=\\"20\\" width=\\"40\\" height=\\"40\\"></rect>
+<text font-size=\\"14\\" x=\\"110\\" y=\\"40\\">X</text>
 </g>
 <g>
-<line x1=\\"170\\" x2=\\"170\\" y1=\\"40\\" y2=\\"100\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
-<circle cx=\\"170\\" cy=\\"100\\" r=\\"5\\" stroke=\\"black\\" fill=\\"black\\" stroke-width=\\"1\\"></circle>
+<line x1=\\"170\\" x2=\\"170\\" y1=\\"40\\" y2=\\"100\\"></line>
+<circle class=\\"control-dot\\" cx=\\"170\\" cy=\\"100\\" r=\\"5\\"></circle>
 <g>
-<circle cx=\\"170\\" cy=\\"40\\" r=\\"15\\" stroke=\\"black\\" fill=\\"white\\" stroke-width=\\"1\\"></circle>
-<line x1=\\"170\\" x2=\\"170\\" y1=\\"25\\" y2=\\"55\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
-<line x1=\\"155\\" x2=\\"185\\" y1=\\"40\\" y2=\\"40\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
+<circle class=\\"oplus\\" cx=\\"170\\" cy=\\"40\\" r=\\"15\\"></circle>
+<line x1=\\"170\\" x2=\\"170\\" y1=\\"25\\" y2=\\"55\\"></line>
+<line x1=\\"155\\" x2=\\"185\\" y1=\\"40\\" y2=\\"40\\"></line>
 </g>
 </g></g>
-<rect class=\\"cls-container\\" x=\\"120\\" y=\\"5\\" width=\\"80\\" height=\\"130\\" stroke=\\"black\\" fill-opacity=\\"0\\" stroke-dasharray=\\"8, 8\\" stroke-width=\\"1\\"></rect>
+<rect class=\\"cls-container\\" x=\\"120\\" y=\\"5\\" width=\\"80\\" height=\\"130\\" fill-opacity=\\"0\\" stroke-dasharray=\\"8, 8\\"></rect>
 </g>
 </g>"
 `;
@@ -78,8 +78,8 @@ exports[`Testing _classicalControlled multiple 'zero'/'one' children 1`] = `
 exports[`Testing _classicalControlled nested children 1`] = `
 "<g>
 <g class=\\"cls-control-1-group cls-control-unknown\\">
-<line class=\\"cls-line\\" x1=\\"95\\" x2=\\"120\\" y1=\\"180\\" y2=\\"180\\" stroke=\\"black\\" stroke-dasharray=\\"8, 8\\" stroke-width=\\"1\\"></line>
-<line class=\\"cls-line\\" x1=\\"95\\" x2=\\"95\\" y1=\\"175\\" y2=\\"180\\" stroke=\\"black\\" stroke-dasharray=\\"8, 8\\" stroke-width=\\"1\\"></line>
+<line class=\\"cls-line\\" x1=\\"95\\" x2=\\"120\\" y1=\\"180\\" y2=\\"180\\" stroke-dasharray=\\"8, 8\\"></line>
+<line class=\\"cls-line\\" x1=\\"95\\" x2=\\"95\\" y1=\\"175\\" y2=\\"180\\" stroke-dasharray=\\"8, 8\\"></line>
 <g class=\\"cls-control-btn cls-control-1\\" onClick=\\"toggleClassicalBtn('cls-control-1')\\">
 <circle class=\\"cls-control-1\\" cx=\\"95\\" cy=\\"160\\" r=\\"15\\" stroke=\\"black\\" stroke-width=\\"1\\"></circle>
 <text class=\\"cls-control-1 cls-control-text\\" font-size=\\"14\\" font-family=\\"Arial\\" x=\\"95\\" y=\\"160\\" dominant-baseline=\\"middle\\" text-anchor=\\"middle\\" fill=\\"black\\">?</text>
@@ -88,13 +88,13 @@ exports[`Testing _classicalControlled nested children 1`] = `
 </g>
 <g class=\\"cls-control-1-one\\">
 <g>
-<rect class=\\"gate-unitary\\" x=\\"90\\" y=\\"20\\" width=\\"40\\" height=\\"40\\" stroke=\\"black\\" stroke-width=\\"1\\"></rect>
-<text font-size=\\"14\\" font-family=\\"Arial\\" x=\\"110\\" y=\\"40\\" dominant-baseline=\\"middle\\" text-anchor=\\"middle\\" fill=\\"black\\">X</text>
+<rect class=\\"gate-unitary\\" x=\\"90\\" y=\\"20\\" width=\\"40\\" height=\\"40\\"></rect>
+<text font-size=\\"14\\" x=\\"110\\" y=\\"40\\">X</text>
 </g>
 <g>
 <g class=\\"cls-control-1-group cls-control-unknown\\">
-<line class=\\"cls-line\\" x1=\\"165\\" x2=\\"190\\" y1=\\"240\\" y2=\\"240\\" stroke=\\"black\\" stroke-dasharray=\\"8, 8\\" stroke-width=\\"1\\"></line>
-<line class=\\"cls-line\\" x1=\\"165\\" x2=\\"165\\" y1=\\"235\\" y2=\\"240\\" stroke=\\"black\\" stroke-dasharray=\\"8, 8\\" stroke-width=\\"1\\"></line>
+<line class=\\"cls-line\\" x1=\\"165\\" x2=\\"190\\" y1=\\"240\\" y2=\\"240\\" stroke-dasharray=\\"8, 8\\"></line>
+<line class=\\"cls-line\\" x1=\\"165\\" x2=\\"165\\" y1=\\"235\\" y2=\\"240\\" stroke-dasharray=\\"8, 8\\"></line>
 <g class=\\"cls-control-btn cls-control-1\\" onClick=\\"toggleClassicalBtn('cls-control-1')\\">
 <circle class=\\"cls-control-1\\" cx=\\"165\\" cy=\\"220\\" r=\\"15\\" stroke=\\"black\\" stroke-width=\\"1\\"></circle>
 <text class=\\"cls-control-1 cls-control-text\\" font-size=\\"14\\" font-family=\\"Arial\\" x=\\"165\\" y=\\"220\\" dominant-baseline=\\"middle\\" text-anchor=\\"middle\\" fill=\\"black\\">?</text>
@@ -103,18 +103,18 @@ exports[`Testing _classicalControlled nested children 1`] = `
 </g>
 <g class=\\"cls-control-1-one\\">
 <g>
-<line x1=\\"180\\" x2=\\"180\\" y1=\\"40\\" y2=\\"100\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
-<circle cx=\\"180\\" cy=\\"100\\" r=\\"5\\" stroke=\\"black\\" fill=\\"black\\" stroke-width=\\"1\\"></circle>
+<line x1=\\"180\\" x2=\\"180\\" y1=\\"40\\" y2=\\"100\\"></line>
+<circle class=\\"control-dot\\" cx=\\"180\\" cy=\\"100\\" r=\\"5\\"></circle>
 <g>
-<circle cx=\\"180\\" cy=\\"40\\" r=\\"15\\" stroke=\\"black\\" fill=\\"white\\" stroke-width=\\"1\\"></circle>
-<line x1=\\"180\\" x2=\\"180\\" y1=\\"25\\" y2=\\"55\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
-<line x1=\\"165\\" x2=\\"195\\" y1=\\"40\\" y2=\\"40\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
+<circle class=\\"oplus\\" cx=\\"180\\" cy=\\"40\\" r=\\"15\\"></circle>
+<line x1=\\"180\\" x2=\\"180\\" y1=\\"25\\" y2=\\"55\\"></line>
+<line x1=\\"165\\" x2=\\"195\\" y1=\\"40\\" y2=\\"40\\"></line>
 </g>
 </g></g>
-<rect class=\\"cls-container\\" x=\\"190\\" y=\\"5\\" width=\\"20\\" height=\\"130\\" stroke=\\"black\\" fill-opacity=\\"0\\" stroke-dasharray=\\"8, 8\\" stroke-width=\\"1\\"></rect>
+<rect class=\\"cls-container\\" x=\\"190\\" y=\\"5\\" width=\\"20\\" height=\\"130\\" fill-opacity=\\"0\\" stroke-dasharray=\\"8, 8\\"></rect>
 </g>
 </g></g>
-<rect class=\\"cls-container\\" x=\\"120\\" y=\\"5\\" width=\\"100\\" height=\\"130\\" stroke=\\"black\\" fill-opacity=\\"0\\" stroke-dasharray=\\"8, 8\\" stroke-width=\\"1\\"></rect>
+<rect class=\\"cls-container\\" x=\\"120\\" y=\\"5\\" width=\\"100\\" height=\\"130\\" fill-opacity=\\"0\\" stroke-dasharray=\\"8, 8\\"></rect>
 </g>
 </g>"
 `;
@@ -122,8 +122,8 @@ exports[`Testing _classicalControlled nested children 1`] = `
 exports[`Testing _classicalControlled one 'one' child 1`] = `
 "<g>
 <g class=\\"cls-control-1-group cls-control-unknown\\">
-<line class=\\"cls-line\\" x1=\\"95\\" x2=\\"120\\" y1=\\"180\\" y2=\\"180\\" stroke=\\"black\\" stroke-dasharray=\\"8, 8\\" stroke-width=\\"1\\"></line>
-<line class=\\"cls-line\\" x1=\\"95\\" x2=\\"95\\" y1=\\"175\\" y2=\\"180\\" stroke=\\"black\\" stroke-dasharray=\\"8, 8\\" stroke-width=\\"1\\"></line>
+<line class=\\"cls-line\\" x1=\\"95\\" x2=\\"120\\" y1=\\"180\\" y2=\\"180\\" stroke-dasharray=\\"8, 8\\"></line>
+<line class=\\"cls-line\\" x1=\\"95\\" x2=\\"95\\" y1=\\"175\\" y2=\\"180\\" stroke-dasharray=\\"8, 8\\"></line>
 <g class=\\"cls-control-btn cls-control-1\\" onClick=\\"toggleClassicalBtn('cls-control-1')\\">
 <circle class=\\"cls-control-1\\" cx=\\"95\\" cy=\\"160\\" r=\\"15\\" stroke=\\"black\\" stroke-width=\\"1\\"></circle>
 <text class=\\"cls-control-1 cls-control-text\\" font-size=\\"14\\" font-family=\\"Arial\\" x=\\"95\\" y=\\"160\\" dominant-baseline=\\"middle\\" text-anchor=\\"middle\\" fill=\\"black\\">?</text>
@@ -132,10 +132,10 @@ exports[`Testing _classicalControlled one 'one' child 1`] = `
 </g>
 <g class=\\"cls-control-1-one\\">
 <g>
-<rect class=\\"gate-unitary\\" x=\\"90\\" y=\\"20\\" width=\\"40\\" height=\\"40\\" stroke=\\"black\\" stroke-width=\\"1\\"></rect>
-<text font-size=\\"14\\" font-family=\\"Arial\\" x=\\"110\\" y=\\"40\\" dominant-baseline=\\"middle\\" text-anchor=\\"middle\\" fill=\\"black\\">X</text>
+<rect class=\\"gate-unitary\\" x=\\"90\\" y=\\"20\\" width=\\"40\\" height=\\"40\\"></rect>
+<text font-size=\\"14\\" x=\\"110\\" y=\\"40\\">X</text>
 </g></g>
-<rect class=\\"cls-container\\" x=\\"120\\" y=\\"5\\" width=\\"20\\" height=\\"130\\" stroke=\\"black\\" fill-opacity=\\"0\\" stroke-dasharray=\\"8, 8\\" stroke-width=\\"1\\"></rect>
+<rect class=\\"cls-container\\" x=\\"120\\" y=\\"5\\" width=\\"20\\" height=\\"130\\" fill-opacity=\\"0\\" stroke-dasharray=\\"8, 8\\"></rect>
 </g>
 </g>"
 `;
@@ -143,240 +143,240 @@ exports[`Testing _classicalControlled one 'one' child 1`] = `
 exports[`Testing _classicalControlled one 'zero' child 1`] = `
 "<g>
 <g class=\\"cls-control-1-group cls-control-unknown\\">
-<line class=\\"cls-line\\" x1=\\"95\\" x2=\\"120\\" y1=\\"180\\" y2=\\"180\\" stroke=\\"black\\" stroke-dasharray=\\"8, 8\\" stroke-width=\\"1\\"></line>
-<line class=\\"cls-line\\" x1=\\"95\\" x2=\\"95\\" y1=\\"175\\" y2=\\"180\\" stroke=\\"black\\" stroke-dasharray=\\"8, 8\\" stroke-width=\\"1\\"></line>
+<line class=\\"cls-line\\" x1=\\"95\\" x2=\\"120\\" y1=\\"180\\" y2=\\"180\\" stroke-dasharray=\\"8, 8\\"></line>
+<line class=\\"cls-line\\" x1=\\"95\\" x2=\\"95\\" y1=\\"175\\" y2=\\"180\\" stroke-dasharray=\\"8, 8\\"></line>
 <g class=\\"cls-control-btn cls-control-1\\" onClick=\\"toggleClassicalBtn('cls-control-1')\\">
 <circle class=\\"cls-control-1\\" cx=\\"95\\" cy=\\"160\\" r=\\"15\\" stroke=\\"black\\" stroke-width=\\"1\\"></circle>
 <text class=\\"cls-control-1 cls-control-text\\" font-size=\\"14\\" font-family=\\"Arial\\" x=\\"95\\" y=\\"160\\" dominant-baseline=\\"middle\\" text-anchor=\\"middle\\" fill=\\"black\\">?</text>
 </g>
 <g class=\\"cls-control-1-zero hidden\\">
 <g>
-<rect class=\\"gate-unitary\\" x=\\"90\\" y=\\"20\\" width=\\"40\\" height=\\"40\\" stroke=\\"black\\" stroke-width=\\"1\\"></rect>
-<text font-size=\\"14\\" font-family=\\"Arial\\" x=\\"110\\" y=\\"40\\" dominant-baseline=\\"middle\\" text-anchor=\\"middle\\" fill=\\"black\\">X</text>
+<rect class=\\"gate-unitary\\" x=\\"90\\" y=\\"20\\" width=\\"40\\" height=\\"40\\"></rect>
+<text font-size=\\"14\\" x=\\"110\\" y=\\"40\\">X</text>
 </g></g>
 <g class=\\"cls-control-1-one\\">
 </g>
-<rect class=\\"cls-container\\" x=\\"120\\" y=\\"5\\" width=\\"20\\" height=\\"130\\" stroke=\\"black\\" fill-opacity=\\"0\\" stroke-dasharray=\\"8, 8\\" stroke-width=\\"1\\"></rect>
+<rect class=\\"cls-container\\" x=\\"120\\" y=\\"5\\" width=\\"20\\" height=\\"130\\" fill-opacity=\\"0\\" stroke-dasharray=\\"8, 8\\"></rect>
 </g>
 </g>"
 `;
 
 exports[`Testing _controlledGate CNOT gate 1`] = `
 "<g>
-<line x1=\\"80\\" x2=\\"80\\" y1=\\"40\\" y2=\\"100\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
-<circle cx=\\"80\\" cy=\\"40\\" r=\\"5\\" stroke=\\"black\\" fill=\\"black\\" stroke-width=\\"1\\"></circle>
+<line x1=\\"80\\" x2=\\"80\\" y1=\\"40\\" y2=\\"100\\"></line>
+<circle class=\\"control-dot\\" cx=\\"80\\" cy=\\"40\\" r=\\"5\\"></circle>
 <g>
-<circle cx=\\"80\\" cy=\\"100\\" r=\\"15\\" stroke=\\"black\\" fill=\\"white\\" stroke-width=\\"1\\"></circle>
-<line x1=\\"80\\" x2=\\"80\\" y1=\\"85\\" y2=\\"115\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
-<line x1=\\"65\\" x2=\\"95\\" y1=\\"100\\" y2=\\"100\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
+<circle class=\\"oplus\\" cx=\\"80\\" cy=\\"100\\" r=\\"15\\"></circle>
+<line x1=\\"80\\" x2=\\"80\\" y1=\\"85\\" y2=\\"115\\"></line>
+<line x1=\\"65\\" x2=\\"95\\" y1=\\"100\\" y2=\\"100\\"></line>
 </g>
 </g>"
 `;
 
 exports[`Testing _controlledGate CNOT gate 2`] = `
 "<g>
-<line x1=\\"80\\" x2=\\"80\\" y1=\\"40\\" y2=\\"100\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
-<circle cx=\\"80\\" cy=\\"100\\" r=\\"5\\" stroke=\\"black\\" fill=\\"black\\" stroke-width=\\"1\\"></circle>
+<line x1=\\"80\\" x2=\\"80\\" y1=\\"40\\" y2=\\"100\\"></line>
+<circle class=\\"control-dot\\" cx=\\"80\\" cy=\\"100\\" r=\\"5\\"></circle>
 <g>
-<circle cx=\\"80\\" cy=\\"40\\" r=\\"15\\" stroke=\\"black\\" fill=\\"white\\" stroke-width=\\"1\\"></circle>
-<line x1=\\"80\\" x2=\\"80\\" y1=\\"25\\" y2=\\"55\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
-<line x1=\\"65\\" x2=\\"95\\" y1=\\"40\\" y2=\\"40\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
+<circle class=\\"oplus\\" cx=\\"80\\" cy=\\"40\\" r=\\"15\\"></circle>
+<line x1=\\"80\\" x2=\\"80\\" y1=\\"25\\" y2=\\"55\\"></line>
+<line x1=\\"65\\" x2=\\"95\\" y1=\\"40\\" y2=\\"40\\"></line>
 </g>
 </g>"
 `;
 
 exports[`Testing _controlledGate Controlled U gate with 1 control + 1 target 1`] = `
 "<g>
-<line x1=\\"80\\" x2=\\"80\\" y1=\\"40\\" y2=\\"100\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
-<circle cx=\\"80\\" cy=\\"40\\" r=\\"5\\" stroke=\\"black\\" fill=\\"black\\" stroke-width=\\"1\\"></circle>
+<line x1=\\"80\\" x2=\\"80\\" y1=\\"40\\" y2=\\"100\\"></line>
+<circle class=\\"control-dot\\" cx=\\"80\\" cy=\\"40\\" r=\\"5\\"></circle>
 <g>
-<rect class=\\"gate-unitary\\" x=\\"57.5\\" y=\\"80\\" width=\\"45\\" height=\\"40\\" stroke=\\"black\\" stroke-width=\\"1\\"></rect>
-<text font-size=\\"14\\" font-family=\\"Arial\\" x=\\"80\\" y=\\"100\\" dominant-baseline=\\"middle\\" text-anchor=\\"middle\\" fill=\\"black\\">Foo</text>
+<rect class=\\"gate-unitary\\" x=\\"57.5\\" y=\\"80\\" width=\\"45\\" height=\\"40\\"></rect>
+<text font-size=\\"14\\" x=\\"80\\" y=\\"100\\">Foo</text>
 </g>
 </g>"
 `;
 
 exports[`Testing _controlledGate Controlled U gate with 1 control + 1 target 2`] = `
 "<g>
-<line x1=\\"80\\" x2=\\"80\\" y1=\\"40\\" y2=\\"100\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
-<circle cx=\\"80\\" cy=\\"100\\" r=\\"5\\" stroke=\\"black\\" fill=\\"black\\" stroke-width=\\"1\\"></circle>
+<line x1=\\"80\\" x2=\\"80\\" y1=\\"40\\" y2=\\"100\\"></line>
+<circle class=\\"control-dot\\" cx=\\"80\\" cy=\\"100\\" r=\\"5\\"></circle>
 <g>
-<rect class=\\"gate-unitary\\" x=\\"57.5\\" y=\\"20\\" width=\\"45\\" height=\\"40\\" stroke=\\"black\\" stroke-width=\\"1\\"></rect>
-<text font-size=\\"14\\" font-family=\\"Arial\\" x=\\"80\\" y=\\"40\\" dominant-baseline=\\"middle\\" text-anchor=\\"middle\\" fill=\\"black\\">Foo</text>
+<rect class=\\"gate-unitary\\" x=\\"57.5\\" y=\\"20\\" width=\\"45\\" height=\\"40\\"></rect>
+<text font-size=\\"14\\" x=\\"80\\" y=\\"40\\">Foo</text>
 </g>
 </g>"
 `;
 
 exports[`Testing _controlledGate Controlled U gate with 1 control + 2 targets 1`] = `
 "<g>
-<line x1=\\"80\\" x2=\\"80\\" y1=\\"40\\" y2=\\"160\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
-<circle cx=\\"80\\" cy=\\"160\\" r=\\"5\\" stroke=\\"black\\" fill=\\"black\\" stroke-width=\\"1\\"></circle>
+<line x1=\\"80\\" x2=\\"80\\" y1=\\"40\\" y2=\\"160\\"></line>
+<circle class=\\"control-dot\\" cx=\\"80\\" cy=\\"160\\" r=\\"5\\"></circle>
 <g>
-<rect class=\\"gate-unitary\\" x=\\"57.5\\" y=\\"20\\" width=\\"45\\" height=\\"100\\" stroke=\\"black\\" stroke-width=\\"1\\"></rect>
-<text font-size=\\"14\\" font-family=\\"Arial\\" x=\\"80\\" y=\\"70\\" dominant-baseline=\\"middle\\" text-anchor=\\"middle\\" fill=\\"black\\">Foo</text>
+<rect class=\\"gate-unitary\\" x=\\"57.5\\" y=\\"20\\" width=\\"45\\" height=\\"100\\"></rect>
+<text font-size=\\"14\\" x=\\"80\\" y=\\"70\\">Foo</text>
 </g>
 </g>"
 `;
 
 exports[`Testing _controlledGate Controlled U gate with 1 control + 2 targets 2`] = `
 "<g>
-<line x1=\\"80\\" x2=\\"80\\" y1=\\"40\\" y2=\\"160\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
-<circle cx=\\"80\\" cy=\\"40\\" r=\\"5\\" stroke=\\"black\\" fill=\\"black\\" stroke-width=\\"1\\"></circle>
+<line x1=\\"80\\" x2=\\"80\\" y1=\\"40\\" y2=\\"160\\"></line>
+<circle class=\\"control-dot\\" cx=\\"80\\" cy=\\"40\\" r=\\"5\\"></circle>
 <g>
-<rect class=\\"gate-unitary\\" x=\\"57.5\\" y=\\"80\\" width=\\"45\\" height=\\"100\\" stroke=\\"black\\" stroke-width=\\"1\\"></rect>
-<text font-size=\\"14\\" font-family=\\"Arial\\" x=\\"80\\" y=\\"130\\" dominant-baseline=\\"middle\\" text-anchor=\\"middle\\" fill=\\"black\\">Foo</text>
+<rect class=\\"gate-unitary\\" x=\\"57.5\\" y=\\"80\\" width=\\"45\\" height=\\"100\\"></rect>
+<text font-size=\\"14\\" x=\\"80\\" y=\\"130\\">Foo</text>
 </g>
 </g>"
 `;
 
 exports[`Testing _controlledGate Controlled U gate with 1 control + 2 targets 3`] = `
 "<g>
-<line x1=\\"80\\" x2=\\"80\\" y1=\\"40\\" y2=\\"160\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
-<circle cx=\\"80\\" cy=\\"100\\" r=\\"5\\" stroke=\\"black\\" fill=\\"black\\" stroke-width=\\"1\\"></circle>
+<line x1=\\"80\\" x2=\\"80\\" y1=\\"40\\" y2=\\"160\\"></line>
+<circle class=\\"control-dot\\" cx=\\"80\\" cy=\\"100\\" r=\\"5\\"></circle>
 <g>
-<rect class=\\"gate-unitary\\" x=\\"57.5\\" y=\\"20\\" width=\\"45\\" height=\\"40\\" stroke=\\"black\\" stroke-width=\\"1\\"></rect>
-<text font-size=\\"14\\" font-family=\\"Arial\\" x=\\"80\\" y=\\"40\\" dominant-baseline=\\"middle\\" text-anchor=\\"middle\\" fill=\\"black\\">Foo</text>
+<rect class=\\"gate-unitary\\" x=\\"57.5\\" y=\\"20\\" width=\\"45\\" height=\\"40\\"></rect>
+<text font-size=\\"14\\" x=\\"80\\" y=\\"40\\">Foo</text>
 </g>
 <g>
-<rect class=\\"gate-unitary\\" x=\\"57.5\\" y=\\"140\\" width=\\"45\\" height=\\"40\\" stroke=\\"black\\" stroke-width=\\"1\\"></rect>
-<text font-size=\\"14\\" font-family=\\"Arial\\" x=\\"80\\" y=\\"160\\" dominant-baseline=\\"middle\\" text-anchor=\\"middle\\" fill=\\"black\\">Foo</text>
+<rect class=\\"gate-unitary\\" x=\\"57.5\\" y=\\"140\\" width=\\"45\\" height=\\"40\\"></rect>
+<text font-size=\\"14\\" x=\\"80\\" y=\\"160\\">Foo</text>
 </g>
 </g>"
 `;
 
 exports[`Testing _controlledGate Controlled U gate with 2 controls + 2 targets 1`] = `
 "<g>
-<line x1=\\"80\\" x2=\\"80\\" y1=\\"40\\" y2=\\"220\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
-<circle cx=\\"80\\" cy=\\"160\\" r=\\"5\\" stroke=\\"black\\" fill=\\"black\\" stroke-width=\\"1\\"></circle>
-<circle cx=\\"80\\" cy=\\"220\\" r=\\"5\\" stroke=\\"black\\" fill=\\"black\\" stroke-width=\\"1\\"></circle>
+<line x1=\\"80\\" x2=\\"80\\" y1=\\"40\\" y2=\\"220\\"></line>
+<circle class=\\"control-dot\\" cx=\\"80\\" cy=\\"160\\" r=\\"5\\"></circle>
+<circle class=\\"control-dot\\" cx=\\"80\\" cy=\\"220\\" r=\\"5\\"></circle>
 <g>
-<rect class=\\"gate-unitary\\" x=\\"57.5\\" y=\\"20\\" width=\\"45\\" height=\\"100\\" stroke=\\"black\\" stroke-width=\\"1\\"></rect>
-<text font-size=\\"14\\" font-family=\\"Arial\\" x=\\"80\\" y=\\"70\\" dominant-baseline=\\"middle\\" text-anchor=\\"middle\\" fill=\\"black\\">Foo</text>
+<rect class=\\"gate-unitary\\" x=\\"57.5\\" y=\\"20\\" width=\\"45\\" height=\\"100\\"></rect>
+<text font-size=\\"14\\" x=\\"80\\" y=\\"70\\">Foo</text>
 </g>
 </g>"
 `;
 
 exports[`Testing _controlledGate Controlled U gate with 2 controls + 2 targets 2`] = `
 "<g>
-<line x1=\\"80\\" x2=\\"80\\" y1=\\"40\\" y2=\\"220\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
-<circle cx=\\"80\\" cy=\\"40\\" r=\\"5\\" stroke=\\"black\\" fill=\\"black\\" stroke-width=\\"1\\"></circle>
-<circle cx=\\"80\\" cy=\\"100\\" r=\\"5\\" stroke=\\"black\\" fill=\\"black\\" stroke-width=\\"1\\"></circle>
+<line x1=\\"80\\" x2=\\"80\\" y1=\\"40\\" y2=\\"220\\"></line>
+<circle class=\\"control-dot\\" cx=\\"80\\" cy=\\"40\\" r=\\"5\\"></circle>
+<circle class=\\"control-dot\\" cx=\\"80\\" cy=\\"100\\" r=\\"5\\"></circle>
 <g>
-<rect class=\\"gate-unitary\\" x=\\"57.5\\" y=\\"140\\" width=\\"45\\" height=\\"100\\" stroke=\\"black\\" stroke-width=\\"1\\"></rect>
-<text font-size=\\"14\\" font-family=\\"Arial\\" x=\\"80\\" y=\\"190\\" dominant-baseline=\\"middle\\" text-anchor=\\"middle\\" fill=\\"black\\">Foo</text>
+<rect class=\\"gate-unitary\\" x=\\"57.5\\" y=\\"140\\" width=\\"45\\" height=\\"100\\"></rect>
+<text font-size=\\"14\\" x=\\"80\\" y=\\"190\\">Foo</text>
 </g>
 </g>"
 `;
 
 exports[`Testing _controlledGate Controlled U gate with 2 controls + 2 targets 3`] = `
 "<g>
-<line x1=\\"80\\" x2=\\"80\\" y1=\\"40\\" y2=\\"220\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
-<circle cx=\\"80\\" cy=\\"100\\" r=\\"5\\" stroke=\\"black\\" fill=\\"black\\" stroke-width=\\"1\\"></circle>
-<circle cx=\\"80\\" cy=\\"160\\" r=\\"5\\" stroke=\\"black\\" fill=\\"black\\" stroke-width=\\"1\\"></circle>
+<line x1=\\"80\\" x2=\\"80\\" y1=\\"40\\" y2=\\"220\\"></line>
+<circle class=\\"control-dot\\" cx=\\"80\\" cy=\\"100\\" r=\\"5\\"></circle>
+<circle class=\\"control-dot\\" cx=\\"80\\" cy=\\"160\\" r=\\"5\\"></circle>
 <g>
-<rect class=\\"gate-unitary\\" x=\\"57.5\\" y=\\"20\\" width=\\"45\\" height=\\"40\\" stroke=\\"black\\" stroke-width=\\"1\\"></rect>
-<text font-size=\\"14\\" font-family=\\"Arial\\" x=\\"80\\" y=\\"40\\" dominant-baseline=\\"middle\\" text-anchor=\\"middle\\" fill=\\"black\\">Foo</text>
+<rect class=\\"gate-unitary\\" x=\\"57.5\\" y=\\"20\\" width=\\"45\\" height=\\"40\\"></rect>
+<text font-size=\\"14\\" x=\\"80\\" y=\\"40\\">Foo</text>
 </g>
 <g>
-<rect class=\\"gate-unitary\\" x=\\"57.5\\" y=\\"200\\" width=\\"45\\" height=\\"40\\" stroke=\\"black\\" stroke-width=\\"1\\"></rect>
-<text font-size=\\"14\\" font-family=\\"Arial\\" x=\\"80\\" y=\\"220\\" dominant-baseline=\\"middle\\" text-anchor=\\"middle\\" fill=\\"black\\">Foo</text>
+<rect class=\\"gate-unitary\\" x=\\"57.5\\" y=\\"200\\" width=\\"45\\" height=\\"40\\"></rect>
+<text font-size=\\"14\\" x=\\"80\\" y=\\"220\\">Foo</text>
 </g>
 </g>"
 `;
 
 exports[`Testing _controlledGate Controlled U gate with 2 controls + 2 targets 4`] = `
 "<g>
-<line x1=\\"80\\" x2=\\"80\\" y1=\\"40\\" y2=\\"220\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
-<circle cx=\\"80\\" cy=\\"100\\" r=\\"5\\" stroke=\\"black\\" fill=\\"black\\" stroke-width=\\"1\\"></circle>
-<circle cx=\\"80\\" cy=\\"220\\" r=\\"5\\" stroke=\\"black\\" fill=\\"black\\" stroke-width=\\"1\\"></circle>
+<line x1=\\"80\\" x2=\\"80\\" y1=\\"40\\" y2=\\"220\\"></line>
+<circle class=\\"control-dot\\" cx=\\"80\\" cy=\\"100\\" r=\\"5\\"></circle>
+<circle class=\\"control-dot\\" cx=\\"80\\" cy=\\"220\\" r=\\"5\\"></circle>
 <g>
-<rect class=\\"gate-unitary\\" x=\\"57.5\\" y=\\"20\\" width=\\"45\\" height=\\"40\\" stroke=\\"black\\" stroke-width=\\"1\\"></rect>
-<text font-size=\\"14\\" font-family=\\"Arial\\" x=\\"80\\" y=\\"40\\" dominant-baseline=\\"middle\\" text-anchor=\\"middle\\" fill=\\"black\\">Foo</text>
+<rect class=\\"gate-unitary\\" x=\\"57.5\\" y=\\"20\\" width=\\"45\\" height=\\"40\\"></rect>
+<text font-size=\\"14\\" x=\\"80\\" y=\\"40\\">Foo</text>
 </g>
 <g>
-<rect class=\\"gate-unitary\\" x=\\"57.5\\" y=\\"140\\" width=\\"45\\" height=\\"40\\" stroke=\\"black\\" stroke-width=\\"1\\"></rect>
-<text font-size=\\"14\\" font-family=\\"Arial\\" x=\\"80\\" y=\\"160\\" dominant-baseline=\\"middle\\" text-anchor=\\"middle\\" fill=\\"black\\">Foo</text>
+<rect class=\\"gate-unitary\\" x=\\"57.5\\" y=\\"140\\" width=\\"45\\" height=\\"40\\"></rect>
+<text font-size=\\"14\\" x=\\"80\\" y=\\"160\\">Foo</text>
 </g>
 </g>"
 `;
 
 exports[`Testing _controlledGate Controlled U gate with multiple controls + 1 target 1`] = `
 "<g>
-<line x1=\\"80\\" x2=\\"80\\" y1=\\"40\\" y2=\\"160\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
-<circle cx=\\"80\\" cy=\\"40\\" r=\\"5\\" stroke=\\"black\\" fill=\\"black\\" stroke-width=\\"1\\"></circle>
-<circle cx=\\"80\\" cy=\\"100\\" r=\\"5\\" stroke=\\"black\\" fill=\\"black\\" stroke-width=\\"1\\"></circle>
+<line x1=\\"80\\" x2=\\"80\\" y1=\\"40\\" y2=\\"160\\"></line>
+<circle class=\\"control-dot\\" cx=\\"80\\" cy=\\"40\\" r=\\"5\\"></circle>
+<circle class=\\"control-dot\\" cx=\\"80\\" cy=\\"100\\" r=\\"5\\"></circle>
 <g>
-<rect class=\\"gate-unitary\\" x=\\"57.5\\" y=\\"140\\" width=\\"45\\" height=\\"40\\" stroke=\\"black\\" stroke-width=\\"1\\"></rect>
-<text font-size=\\"14\\" font-family=\\"Arial\\" x=\\"80\\" y=\\"160\\" dominant-baseline=\\"middle\\" text-anchor=\\"middle\\" fill=\\"black\\">Foo</text>
+<rect class=\\"gate-unitary\\" x=\\"57.5\\" y=\\"140\\" width=\\"45\\" height=\\"40\\"></rect>
+<text font-size=\\"14\\" x=\\"80\\" y=\\"160\\">Foo</text>
 </g>
 </g>"
 `;
 
 exports[`Testing _controlledGate Controlled U gate with multiple controls + 1 target 2`] = `
 "<g>
-<line x1=\\"80\\" x2=\\"80\\" y1=\\"40\\" y2=\\"160\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
-<circle cx=\\"80\\" cy=\\"100\\" r=\\"5\\" stroke=\\"black\\" fill=\\"black\\" stroke-width=\\"1\\"></circle>
-<circle cx=\\"80\\" cy=\\"160\\" r=\\"5\\" stroke=\\"black\\" fill=\\"black\\" stroke-width=\\"1\\"></circle>
+<line x1=\\"80\\" x2=\\"80\\" y1=\\"40\\" y2=\\"160\\"></line>
+<circle class=\\"control-dot\\" cx=\\"80\\" cy=\\"100\\" r=\\"5\\"></circle>
+<circle class=\\"control-dot\\" cx=\\"80\\" cy=\\"160\\" r=\\"5\\"></circle>
 <g>
-<rect class=\\"gate-unitary\\" x=\\"57.5\\" y=\\"20\\" width=\\"45\\" height=\\"40\\" stroke=\\"black\\" stroke-width=\\"1\\"></rect>
-<text font-size=\\"14\\" font-family=\\"Arial\\" x=\\"80\\" y=\\"40\\" dominant-baseline=\\"middle\\" text-anchor=\\"middle\\" fill=\\"black\\">Foo</text>
+<rect class=\\"gate-unitary\\" x=\\"57.5\\" y=\\"20\\" width=\\"45\\" height=\\"40\\"></rect>
+<text font-size=\\"14\\" x=\\"80\\" y=\\"40\\">Foo</text>
 </g>
 </g>"
 `;
 
 exports[`Testing _controlledGate Controlled U gate with multiple controls + 1 target 3`] = `
 "<g>
-<line x1=\\"80\\" x2=\\"80\\" y1=\\"40\\" y2=\\"160\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
-<circle cx=\\"80\\" cy=\\"40\\" r=\\"5\\" stroke=\\"black\\" fill=\\"black\\" stroke-width=\\"1\\"></circle>
-<circle cx=\\"80\\" cy=\\"160\\" r=\\"5\\" stroke=\\"black\\" fill=\\"black\\" stroke-width=\\"1\\"></circle>
+<line x1=\\"80\\" x2=\\"80\\" y1=\\"40\\" y2=\\"160\\"></line>
+<circle class=\\"control-dot\\" cx=\\"80\\" cy=\\"40\\" r=\\"5\\"></circle>
+<circle class=\\"control-dot\\" cx=\\"80\\" cy=\\"160\\" r=\\"5\\"></circle>
 <g>
-<rect class=\\"gate-unitary\\" x=\\"57.5\\" y=\\"80\\" width=\\"45\\" height=\\"40\\" stroke=\\"black\\" stroke-width=\\"1\\"></rect>
-<text font-size=\\"14\\" font-family=\\"Arial\\" x=\\"80\\" y=\\"100\\" dominant-baseline=\\"middle\\" text-anchor=\\"middle\\" fill=\\"black\\">Foo</text>
+<rect class=\\"gate-unitary\\" x=\\"57.5\\" y=\\"80\\" width=\\"45\\" height=\\"40\\"></rect>
+<text font-size=\\"14\\" x=\\"80\\" y=\\"100\\">Foo</text>
 </g>
 </g>"
 `;
 
 exports[`Testing _controlledGate SWAP gate 1`] = `
 "<g>
-<line x1=\\"80\\" x2=\\"80\\" y1=\\"40\\" y2=\\"160\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
-<circle cx=\\"80\\" cy=\\"40\\" r=\\"5\\" stroke=\\"black\\" fill=\\"black\\" stroke-width=\\"1\\"></circle>
-<line x1=\\"72\\" x2=\\"88\\" y1=\\"92\\" y2=\\"108\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
-<line x1=\\"72\\" x2=\\"88\\" y1=\\"108\\" y2=\\"92\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
-<line x1=\\"72\\" x2=\\"88\\" y1=\\"152\\" y2=\\"168\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
-<line x1=\\"72\\" x2=\\"88\\" y1=\\"168\\" y2=\\"152\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
+<line x1=\\"80\\" x2=\\"80\\" y1=\\"40\\" y2=\\"160\\"></line>
+<circle class=\\"control-dot\\" cx=\\"80\\" cy=\\"40\\" r=\\"5\\"></circle>
+<line x1=\\"72\\" x2=\\"88\\" y1=\\"92\\" y2=\\"108\\"></line>
+<line x1=\\"72\\" x2=\\"88\\" y1=\\"108\\" y2=\\"92\\"></line>
+<line x1=\\"72\\" x2=\\"88\\" y1=\\"152\\" y2=\\"168\\"></line>
+<line x1=\\"72\\" x2=\\"88\\" y1=\\"168\\" y2=\\"152\\"></line>
 </g>"
 `;
 
 exports[`Testing _controlledGate SWAP gate 2`] = `
 "<g>
-<line x1=\\"80\\" x2=\\"80\\" y1=\\"40\\" y2=\\"160\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
-<circle cx=\\"80\\" cy=\\"160\\" r=\\"5\\" stroke=\\"black\\" fill=\\"black\\" stroke-width=\\"1\\"></circle>
-<line x1=\\"72\\" x2=\\"88\\" y1=\\"32\\" y2=\\"48\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
-<line x1=\\"72\\" x2=\\"88\\" y1=\\"48\\" y2=\\"32\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
-<line x1=\\"72\\" x2=\\"88\\" y1=\\"92\\" y2=\\"108\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
-<line x1=\\"72\\" x2=\\"88\\" y1=\\"108\\" y2=\\"92\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
+<line x1=\\"80\\" x2=\\"80\\" y1=\\"40\\" y2=\\"160\\"></line>
+<circle class=\\"control-dot\\" cx=\\"80\\" cy=\\"160\\" r=\\"5\\"></circle>
+<line x1=\\"72\\" x2=\\"88\\" y1=\\"32\\" y2=\\"48\\"></line>
+<line x1=\\"72\\" x2=\\"88\\" y1=\\"48\\" y2=\\"32\\"></line>
+<line x1=\\"72\\" x2=\\"88\\" y1=\\"92\\" y2=\\"108\\"></line>
+<line x1=\\"72\\" x2=\\"88\\" y1=\\"108\\" y2=\\"92\\"></line>
 </g>"
 `;
 
 exports[`Testing _controlledGate SWAP gate 3`] = `
 "<g>
-<line x1=\\"80\\" x2=\\"80\\" y1=\\"40\\" y2=\\"160\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
-<circle cx=\\"80\\" cy=\\"100\\" r=\\"5\\" stroke=\\"black\\" fill=\\"black\\" stroke-width=\\"1\\"></circle>
-<line x1=\\"72\\" x2=\\"88\\" y1=\\"32\\" y2=\\"48\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
-<line x1=\\"72\\" x2=\\"88\\" y1=\\"48\\" y2=\\"32\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
-<line x1=\\"72\\" x2=\\"88\\" y1=\\"152\\" y2=\\"168\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
-<line x1=\\"72\\" x2=\\"88\\" y1=\\"168\\" y2=\\"152\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
+<line x1=\\"80\\" x2=\\"80\\" y1=\\"40\\" y2=\\"160\\"></line>
+<circle class=\\"control-dot\\" cx=\\"80\\" cy=\\"100\\" r=\\"5\\"></circle>
+<line x1=\\"72\\" x2=\\"88\\" y1=\\"32\\" y2=\\"48\\"></line>
+<line x1=\\"72\\" x2=\\"88\\" y1=\\"48\\" y2=\\"32\\"></line>
+<line x1=\\"72\\" x2=\\"88\\" y1=\\"152\\" y2=\\"168\\"></line>
+<line x1=\\"72\\" x2=\\"88\\" y1=\\"168\\" y2=\\"152\\"></line>
 </g>"
 `;
 
 exports[`Testing _formatGate CNOT gate 1`] = `
 "<g>
-<line x1=\\"80\\" x2=\\"80\\" y1=\\"40\\" y2=\\"100\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
-<circle cx=\\"80\\" cy=\\"40\\" r=\\"5\\" stroke=\\"black\\" fill=\\"black\\" stroke-width=\\"1\\"></circle>
+<line x1=\\"80\\" x2=\\"80\\" y1=\\"40\\" y2=\\"100\\"></line>
+<circle class=\\"control-dot\\" cx=\\"80\\" cy=\\"40\\" r=\\"5\\"></circle>
 <g>
-<circle cx=\\"80\\" cy=\\"100\\" r=\\"15\\" stroke=\\"black\\" fill=\\"white\\" stroke-width=\\"1\\"></circle>
-<line x1=\\"80\\" x2=\\"80\\" y1=\\"85\\" y2=\\"115\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
-<line x1=\\"65\\" x2=\\"95\\" y1=\\"100\\" y2=\\"100\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
+<circle class=\\"oplus\\" cx=\\"80\\" cy=\\"100\\" r=\\"15\\"></circle>
+<line x1=\\"80\\" x2=\\"80\\" y1=\\"85\\" y2=\\"115\\"></line>
+<line x1=\\"65\\" x2=\\"95\\" y1=\\"100\\" y2=\\"100\\"></line>
 </g>
 </g>"
 `;
@@ -384,8 +384,8 @@ exports[`Testing _formatGate CNOT gate 1`] = `
 exports[`Testing _formatGate classically controlled gate 1`] = `
 "<g>
 <g class=\\"cls-control-group cls-control-unknown\\">
-<line class=\\"cls-line\\" x1=\\"95\\" x2=\\"120\\" y1=\\"180\\" y2=\\"180\\" stroke=\\"black\\" stroke-dasharray=\\"8, 8\\" stroke-width=\\"1\\"></line>
-<line class=\\"cls-line\\" x1=\\"95\\" x2=\\"95\\" y1=\\"175\\" y2=\\"180\\" stroke=\\"black\\" stroke-dasharray=\\"8, 8\\" stroke-width=\\"1\\"></line>
+<line class=\\"cls-line\\" x1=\\"95\\" x2=\\"120\\" y1=\\"180\\" y2=\\"180\\" stroke-dasharray=\\"8, 8\\"></line>
+<line class=\\"cls-line\\" x1=\\"95\\" x2=\\"95\\" y1=\\"175\\" y2=\\"180\\" stroke-dasharray=\\"8, 8\\"></line>
 <g class=\\"cls-control-btn cls-control\\" onClick=\\"toggleClassicalBtn('cls-control')\\">
 <circle class=\\"cls-control\\" cx=\\"95\\" cy=\\"160\\" r=\\"15\\" stroke=\\"black\\" stroke-width=\\"1\\"></circle>
 <text class=\\"cls-control cls-control-text\\" font-size=\\"14\\" font-family=\\"Arial\\" x=\\"95\\" y=\\"160\\" dominant-baseline=\\"middle\\" text-anchor=\\"middle\\" fill=\\"black\\">?</text>
@@ -394,272 +394,272 @@ exports[`Testing _formatGate classically controlled gate 1`] = `
 </g>
 <g class=\\"cls-control-one\\">
 </g>
-<rect class=\\"cls-container\\" x=\\"120\\" y=\\"5\\" width=\\"0\\" height=\\"130\\" stroke=\\"black\\" fill-opacity=\\"0\\" stroke-dasharray=\\"8, 8\\" stroke-width=\\"1\\"></rect>
+<rect class=\\"cls-container\\" x=\\"120\\" y=\\"5\\" width=\\"0\\" height=\\"130\\" fill-opacity=\\"0\\" stroke-dasharray=\\"8, 8\\"></rect>
 </g>
 </g>"
 `;
 
 exports[`Testing _formatGate controlled swap gate 1`] = `
 "<g>
-<line x1=\\"80\\" x2=\\"80\\" y1=\\"40\\" y2=\\"160\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
-<circle cx=\\"80\\" cy=\\"40\\" r=\\"5\\" stroke=\\"black\\" fill=\\"black\\" stroke-width=\\"1\\"></circle>
-<line x1=\\"72\\" x2=\\"88\\" y1=\\"92\\" y2=\\"108\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
-<line x1=\\"72\\" x2=\\"88\\" y1=\\"108\\" y2=\\"92\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
-<line x1=\\"72\\" x2=\\"88\\" y1=\\"152\\" y2=\\"168\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
-<line x1=\\"72\\" x2=\\"88\\" y1=\\"168\\" y2=\\"152\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
+<line x1=\\"80\\" x2=\\"80\\" y1=\\"40\\" y2=\\"160\\"></line>
+<circle class=\\"control-dot\\" cx=\\"80\\" cy=\\"40\\" r=\\"5\\"></circle>
+<line x1=\\"72\\" x2=\\"88\\" y1=\\"92\\" y2=\\"108\\"></line>
+<line x1=\\"72\\" x2=\\"88\\" y1=\\"108\\" y2=\\"92\\"></line>
+<line x1=\\"72\\" x2=\\"88\\" y1=\\"152\\" y2=\\"168\\"></line>
+<line x1=\\"72\\" x2=\\"88\\" y1=\\"168\\" y2=\\"152\\"></line>
 </g>"
 `;
 
 exports[`Testing _formatGate controlled unitary gate 1`] = `
 "<g>
-<line x1=\\"80\\" x2=\\"80\\" y1=\\"40\\" y2=\\"100\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
-<circle cx=\\"80\\" cy=\\"40\\" r=\\"5\\" stroke=\\"black\\" fill=\\"black\\" stroke-width=\\"1\\"></circle>
+<line x1=\\"80\\" x2=\\"80\\" y1=\\"40\\" y2=\\"100\\"></line>
+<circle class=\\"control-dot\\" cx=\\"80\\" cy=\\"40\\" r=\\"5\\"></circle>
 <g>
-<rect class=\\"gate-unitary\\" x=\\"60\\" y=\\"80\\" width=\\"40\\" height=\\"40\\" stroke=\\"black\\" stroke-width=\\"1\\"></rect>
-<text font-size=\\"14\\" font-family=\\"Arial\\" x=\\"80\\" y=\\"100\\" dominant-baseline=\\"middle\\" text-anchor=\\"middle\\" fill=\\"black\\">U</text>
+<rect class=\\"gate-unitary\\" x=\\"60\\" y=\\"80\\" width=\\"40\\" height=\\"40\\"></rect>
+<text font-size=\\"14\\" x=\\"80\\" y=\\"100\\">U</text>
 </g>
 </g>"
 `;
 
 exports[`Testing _formatGate controlled unitary gate with arguments 1`] = `
 "<g>
-<line x1=\\"80\\" x2=\\"80\\" y1=\\"40\\" y2=\\"100\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
-<circle cx=\\"80\\" cy=\\"40\\" r=\\"5\\" stroke=\\"black\\" fill=\\"black\\" stroke-width=\\"1\\"></circle>
+<line x1=\\"80\\" x2=\\"80\\" y1=\\"40\\" y2=\\"100\\"></line>
+<circle class=\\"control-dot\\" cx=\\"80\\" cy=\\"40\\" r=\\"5\\"></circle>
 <g>
-<rect class=\\"gate-unitary\\" x=\\"41.5\\" y=\\"80\\" width=\\"77\\" height=\\"40\\" stroke=\\"black\\" stroke-width=\\"1\\"></rect>
-<text font-size=\\"14\\" font-family=\\"Arial\\" x=\\"80\\" y=\\"93\\" dominant-baseline=\\"middle\\" text-anchor=\\"middle\\" fill=\\"black\\">U</text>
-<text font-size=\\"12\\" font-family=\\"Arial\\" x=\\"80\\" y=\\"108\\" dominant-baseline=\\"middle\\" text-anchor=\\"middle\\" fill=\\"black\\">('foo', 'bar')</text>
+<rect class=\\"gate-unitary\\" x=\\"41.5\\" y=\\"80\\" width=\\"77\\" height=\\"40\\"></rect>
+<text font-size=\\"14\\" x=\\"80\\" y=\\"93\\">U</text>
+<text font-size=\\"12\\" x=\\"80\\" y=\\"108\\">('foo', 'bar')</text>
 </g>
 </g>"
 `;
 
 exports[`Testing _formatGate measure gate 1`] = `
 "<g>
-<rect class=\\"gate-measure\\" x=\\"60\\" y=\\"20\\" width=\\"40\\" height=\\"40\\" stroke=\\"black\\" stroke-width=\\"1\\"></rect>
-<path d=\\"M 95 42 A 15 12 0 0 0 65 42\\" stroke=\\"black\\" fill=\\"none\\" stroke-width=\\"1\\"></path>
-<line x1=\\"80\\" x2=\\"92\\" y1=\\"48\\" y2=\\"28\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
+<rect class=\\"gate-measure\\" x=\\"60\\" y=\\"20\\" width=\\"40\\" height=\\"40\\"></rect>
+<path class=\\"arc-measure\\" d=\\"M 95 42 A 15 12 0 0 0 65 42\\"></path>
+<line x1=\\"80\\" x2=\\"92\\" y1=\\"48\\" y2=\\"28\\"></line>
 </g>"
 `;
 
 exports[`Testing _formatGate multi-qubit unitary gate 1`] = `
 "<g>
-<rect class=\\"gate-unitary\\" x=\\"60\\" y=\\"20\\" width=\\"40\\" height=\\"100\\" stroke=\\"black\\" stroke-width=\\"1\\"></rect>
-<text font-size=\\"14\\" font-family=\\"Arial\\" x=\\"80\\" y=\\"70\\" dominant-baseline=\\"middle\\" text-anchor=\\"middle\\" fill=\\"black\\">U</text>
+<rect class=\\"gate-unitary\\" x=\\"60\\" y=\\"20\\" width=\\"40\\" height=\\"100\\"></rect>
+<text font-size=\\"14\\" x=\\"80\\" y=\\"70\\">U</text>
 </g>"
 `;
 
 exports[`Testing _formatGate multi-qubit unitary gate with arguments 1`] = `
 "<g>
-<line x1=\\"80\\" x2=\\"80\\" y1=\\"40\\" y2=\\"100\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
+<line x1=\\"80\\" x2=\\"80\\" y1=\\"40\\" y2=\\"100\\"></line>
 <g>
-<rect class=\\"gate-unitary\\" x=\\"41.5\\" y=\\"20\\" width=\\"77\\" height=\\"100\\" stroke=\\"black\\" stroke-width=\\"1\\"></rect>
-<text font-size=\\"14\\" font-family=\\"Arial\\" x=\\"80\\" y=\\"63\\" dominant-baseline=\\"middle\\" text-anchor=\\"middle\\" fill=\\"black\\">U</text>
-<text font-size=\\"12\\" font-family=\\"Arial\\" x=\\"80\\" y=\\"78\\" dominant-baseline=\\"middle\\" text-anchor=\\"middle\\" fill=\\"black\\">('foo', 'bar')</text>
+<rect class=\\"gate-unitary\\" x=\\"41.5\\" y=\\"20\\" width=\\"77\\" height=\\"100\\"></rect>
+<text font-size=\\"14\\" x=\\"80\\" y=\\"63\\">U</text>
+<text font-size=\\"12\\" x=\\"80\\" y=\\"78\\">('foo', 'bar')</text>
 </g>
 </g>"
 `;
 
 exports[`Testing _formatGate single-qubit unitary gate 1`] = `
 "<g>
-<rect class=\\"gate-unitary\\" x=\\"60\\" y=\\"20\\" width=\\"40\\" height=\\"40\\" stroke=\\"black\\" stroke-width=\\"1\\"></rect>
-<text font-size=\\"14\\" font-family=\\"Arial\\" x=\\"80\\" y=\\"40\\" dominant-baseline=\\"middle\\" text-anchor=\\"middle\\" fill=\\"black\\">H</text>
+<rect class=\\"gate-unitary\\" x=\\"60\\" y=\\"20\\" width=\\"40\\" height=\\"40\\"></rect>
+<text font-size=\\"14\\" x=\\"80\\" y=\\"40\\">H</text>
 </g>"
 `;
 
 exports[`Testing _formatGate single-qubit unitary gate with arguments 1`] = `
 "<g>
-<rect class=\\"gate-unitary\\" x=\\"54\\" y=\\"20\\" width=\\"52\\" height=\\"40\\" stroke=\\"black\\" stroke-width=\\"1\\"></rect>
-<text font-size=\\"14\\" font-family=\\"Arial\\" x=\\"80\\" y=\\"33\\" dominant-baseline=\\"middle\\" text-anchor=\\"middle\\" fill=\\"black\\">Ry</text>
-<text font-size=\\"12\\" font-family=\\"Arial\\" x=\\"80\\" y=\\"48\\" dominant-baseline=\\"middle\\" text-anchor=\\"middle\\" fill=\\"black\\">(0.25)</text>
+<rect class=\\"gate-unitary\\" x=\\"54\\" y=\\"20\\" width=\\"52\\" height=\\"40\\"></rect>
+<text font-size=\\"14\\" x=\\"80\\" y=\\"33\\">Ry</text>
+<text font-size=\\"12\\" x=\\"80\\" y=\\"48\\">(0.25)</text>
 </g>"
 `;
 
 exports[`Testing _formatGate swap gate 1`] = `
 "<g>
-<line x1=\\"72\\" x2=\\"88\\" y1=\\"32\\" y2=\\"48\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
-<line x1=\\"72\\" x2=\\"88\\" y1=\\"48\\" y2=\\"32\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
-<line x1=\\"72\\" x2=\\"88\\" y1=\\"92\\" y2=\\"108\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
-<line x1=\\"72\\" x2=\\"88\\" y1=\\"108\\" y2=\\"92\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
-<line x1=\\"80\\" x2=\\"80\\" y1=\\"40\\" y2=\\"100\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
+<line x1=\\"72\\" x2=\\"88\\" y1=\\"32\\" y2=\\"48\\"></line>
+<line x1=\\"72\\" x2=\\"88\\" y1=\\"48\\" y2=\\"32\\"></line>
+<line x1=\\"72\\" x2=\\"88\\" y1=\\"92\\" y2=\\"108\\"></line>
+<line x1=\\"72\\" x2=\\"88\\" y1=\\"108\\" y2=\\"92\\"></line>
+<line x1=\\"80\\" x2=\\"80\\" y1=\\"40\\" y2=\\"100\\"></line>
 </g>"
 `;
 
 exports[`Testing _measure 1 qubit + 1 classical registers 1`] = `
 "<g>
-<rect class=\\"gate-measure\\" x=\\"60\\" y=\\"20\\" width=\\"40\\" height=\\"40\\" stroke=\\"black\\" stroke-width=\\"1\\"></rect>
-<path d=\\"M 95 42 A 15 12 0 0 0 65 42\\" stroke=\\"black\\" fill=\\"none\\" stroke-width=\\"1\\"></path>
-<line x1=\\"80\\" x2=\\"92\\" y1=\\"48\\" y2=\\"28\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
+<rect class=\\"gate-measure\\" x=\\"60\\" y=\\"20\\" width=\\"40\\" height=\\"40\\"></rect>
+<path class=\\"arc-measure\\" d=\\"M 95 42 A 15 12 0 0 0 65 42\\"></path>
+<line x1=\\"80\\" x2=\\"92\\" y1=\\"48\\" y2=\\"28\\"></line>
 </g>"
 `;
 
 exports[`Testing _measure 2 qubit + 1 classical registers 1`] = `
 "<g>
-<rect class=\\"gate-measure\\" x=\\"60\\" y=\\"20\\" width=\\"40\\" height=\\"40\\" stroke=\\"black\\" stroke-width=\\"1\\"></rect>
-<path d=\\"M 95 42 A 15 12 0 0 0 65 42\\" stroke=\\"black\\" fill=\\"none\\" stroke-width=\\"1\\"></path>
-<line x1=\\"80\\" x2=\\"92\\" y1=\\"48\\" y2=\\"28\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
+<rect class=\\"gate-measure\\" x=\\"60\\" y=\\"20\\" width=\\"40\\" height=\\"40\\"></rect>
+<path class=\\"arc-measure\\" d=\\"M 95 42 A 15 12 0 0 0 65 42\\"></path>
+<line x1=\\"80\\" x2=\\"92\\" y1=\\"48\\" y2=\\"28\\"></line>
 </g>"
 `;
 
 exports[`Testing _measure 2 qubit + 2 classical registers 1`] = `
 "<g>
-<rect class=\\"gate-measure\\" x=\\"60\\" y=\\"20\\" width=\\"40\\" height=\\"40\\" stroke=\\"black\\" stroke-width=\\"1\\"></rect>
-<path d=\\"M 95 42 A 15 12 0 0 0 65 42\\" stroke=\\"black\\" fill=\\"none\\" stroke-width=\\"1\\"></path>
-<line x1=\\"80\\" x2=\\"92\\" y1=\\"48\\" y2=\\"28\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
+<rect class=\\"gate-measure\\" x=\\"60\\" y=\\"20\\" width=\\"40\\" height=\\"40\\"></rect>
+<path class=\\"arc-measure\\" d=\\"M 95 42 A 15 12 0 0 0 65 42\\"></path>
+<line x1=\\"80\\" x2=\\"92\\" y1=\\"48\\" y2=\\"28\\"></line>
 </g>"
 `;
 
 exports[`Testing _measure 2 qubit + 2 classical registers 2`] = `
 "<g>
-<rect class=\\"gate-measure\\" x=\\"60\\" y=\\"80\\" width=\\"40\\" height=\\"40\\" stroke=\\"black\\" stroke-width=\\"1\\"></rect>
-<path d=\\"M 95 102 A 15 12 0 0 0 65 102\\" stroke=\\"black\\" fill=\\"none\\" stroke-width=\\"1\\"></path>
-<line x1=\\"80\\" x2=\\"92\\" y1=\\"108\\" y2=\\"88\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
+<rect class=\\"gate-measure\\" x=\\"60\\" y=\\"80\\" width=\\"40\\" height=\\"40\\"></rect>
+<path class=\\"arc-measure\\" d=\\"M 95 102 A 15 12 0 0 0 65 102\\"></path>
+<line x1=\\"80\\" x2=\\"92\\" y1=\\"108\\" y2=\\"88\\"></line>
 </g>"
 `;
 
 exports[`Testing _swap Adjacent swap 1`] = `
 "<g>
-<line x1=\\"72\\" x2=\\"88\\" y1=\\"32\\" y2=\\"48\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
-<line x1=\\"72\\" x2=\\"88\\" y1=\\"48\\" y2=\\"32\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
-<line x1=\\"72\\" x2=\\"88\\" y1=\\"92\\" y2=\\"108\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
-<line x1=\\"72\\" x2=\\"88\\" y1=\\"108\\" y2=\\"92\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
-<line x1=\\"80\\" x2=\\"80\\" y1=\\"40\\" y2=\\"100\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
+<line x1=\\"72\\" x2=\\"88\\" y1=\\"32\\" y2=\\"48\\"></line>
+<line x1=\\"72\\" x2=\\"88\\" y1=\\"48\\" y2=\\"32\\"></line>
+<line x1=\\"72\\" x2=\\"88\\" y1=\\"92\\" y2=\\"108\\"></line>
+<line x1=\\"72\\" x2=\\"88\\" y1=\\"108\\" y2=\\"92\\"></line>
+<line x1=\\"80\\" x2=\\"80\\" y1=\\"40\\" y2=\\"100\\"></line>
 </g>"
 `;
 
 exports[`Testing _swap Adjacent swap 2`] = `
 "<g>
-<line x1=\\"72\\" x2=\\"88\\" y1=\\"92\\" y2=\\"108\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
-<line x1=\\"72\\" x2=\\"88\\" y1=\\"108\\" y2=\\"92\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
-<line x1=\\"72\\" x2=\\"88\\" y1=\\"32\\" y2=\\"48\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
-<line x1=\\"72\\" x2=\\"88\\" y1=\\"48\\" y2=\\"32\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
-<line x1=\\"80\\" x2=\\"80\\" y1=\\"100\\" y2=\\"40\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
+<line x1=\\"72\\" x2=\\"88\\" y1=\\"92\\" y2=\\"108\\"></line>
+<line x1=\\"72\\" x2=\\"88\\" y1=\\"108\\" y2=\\"92\\"></line>
+<line x1=\\"72\\" x2=\\"88\\" y1=\\"32\\" y2=\\"48\\"></line>
+<line x1=\\"72\\" x2=\\"88\\" y1=\\"48\\" y2=\\"32\\"></line>
+<line x1=\\"80\\" x2=\\"80\\" y1=\\"100\\" y2=\\"40\\"></line>
 </g>"
 `;
 
 exports[`Testing _swap Non-adjacent swap 1`] = `
 "<g>
-<line x1=\\"72\\" x2=\\"88\\" y1=\\"32\\" y2=\\"48\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
-<line x1=\\"72\\" x2=\\"88\\" y1=\\"48\\" y2=\\"32\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
-<line x1=\\"72\\" x2=\\"88\\" y1=\\"152\\" y2=\\"168\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
-<line x1=\\"72\\" x2=\\"88\\" y1=\\"168\\" y2=\\"152\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
-<line x1=\\"80\\" x2=\\"80\\" y1=\\"40\\" y2=\\"160\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
+<line x1=\\"72\\" x2=\\"88\\" y1=\\"32\\" y2=\\"48\\"></line>
+<line x1=\\"72\\" x2=\\"88\\" y1=\\"48\\" y2=\\"32\\"></line>
+<line x1=\\"72\\" x2=\\"88\\" y1=\\"152\\" y2=\\"168\\"></line>
+<line x1=\\"72\\" x2=\\"88\\" y1=\\"168\\" y2=\\"152\\"></line>
+<line x1=\\"80\\" x2=\\"80\\" y1=\\"40\\" y2=\\"160\\"></line>
 </g>"
 `;
 
 exports[`Testing _swap Non-adjacent swap 2`] = `
 "<g>
-<line x1=\\"72\\" x2=\\"88\\" y1=\\"152\\" y2=\\"168\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
-<line x1=\\"72\\" x2=\\"88\\" y1=\\"168\\" y2=\\"152\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
-<line x1=\\"72\\" x2=\\"88\\" y1=\\"32\\" y2=\\"48\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
-<line x1=\\"72\\" x2=\\"88\\" y1=\\"48\\" y2=\\"32\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
-<line x1=\\"80\\" x2=\\"80\\" y1=\\"160\\" y2=\\"40\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
+<line x1=\\"72\\" x2=\\"88\\" y1=\\"152\\" y2=\\"168\\"></line>
+<line x1=\\"72\\" x2=\\"88\\" y1=\\"168\\" y2=\\"152\\"></line>
+<line x1=\\"72\\" x2=\\"88\\" y1=\\"32\\" y2=\\"48\\"></line>
+<line x1=\\"72\\" x2=\\"88\\" y1=\\"48\\" y2=\\"32\\"></line>
+<line x1=\\"80\\" x2=\\"80\\" y1=\\"160\\" y2=\\"40\\"></line>
 </g>"
 `;
 
 exports[`Testing _unitary Multiqubit unitary on consecutive registers 1`] = `
 "<g>
-<rect class=\\"gate-unitary\\" x=\\"60\\" y=\\"20\\" width=\\"40\\" height=\\"100\\" stroke=\\"black\\" stroke-width=\\"1\\"></rect>
-<text font-size=\\"14\\" font-family=\\"Arial\\" x=\\"80\\" y=\\"70\\" dominant-baseline=\\"middle\\" text-anchor=\\"middle\\" fill=\\"black\\">ZZ</text>
+<rect class=\\"gate-unitary\\" x=\\"60\\" y=\\"20\\" width=\\"40\\" height=\\"100\\"></rect>
+<text font-size=\\"14\\" x=\\"80\\" y=\\"70\\">ZZ</text>
 </g>"
 `;
 
 exports[`Testing _unitary Multiqubit unitary on consecutive registers 2`] = `
 "<g>
-<rect class=\\"gate-unitary\\" x=\\"60\\" y=\\"20\\" width=\\"40\\" height=\\"160\\" stroke=\\"black\\" stroke-width=\\"1\\"></rect>
-<text font-size=\\"14\\" font-family=\\"Arial\\" x=\\"80\\" y=\\"100\\" dominant-baseline=\\"middle\\" text-anchor=\\"middle\\" fill=\\"black\\">ZZZ</text>
+<rect class=\\"gate-unitary\\" x=\\"60\\" y=\\"20\\" width=\\"40\\" height=\\"160\\"></rect>
+<text font-size=\\"14\\" x=\\"80\\" y=\\"100\\">ZZZ</text>
 </g>"
 `;
 
 exports[`Testing _unitary Multiqubit unitary on non-consecutive registers 1`] = `
-"<line x1=\\"80\\" x2=\\"80\\" y1=\\"40\\" y2=\\"160\\" stroke=\\"black\\" stroke-dasharray=\\"8, 8\\" stroke-width=\\"1\\"></line>
+"<line x1=\\"80\\" x2=\\"80\\" y1=\\"40\\" y2=\\"160\\" stroke-dasharray=\\"8, 8\\"></line>
 <g>
-<rect class=\\"gate-unitary\\" x=\\"60\\" y=\\"20\\" width=\\"40\\" height=\\"40\\" stroke=\\"black\\" stroke-width=\\"1\\"></rect>
-<text font-size=\\"14\\" font-family=\\"Arial\\" x=\\"80\\" y=\\"40\\" dominant-baseline=\\"middle\\" text-anchor=\\"middle\\" fill=\\"black\\">ZZ</text>
+<rect class=\\"gate-unitary\\" x=\\"60\\" y=\\"20\\" width=\\"40\\" height=\\"40\\"></rect>
+<text font-size=\\"14\\" x=\\"80\\" y=\\"40\\">ZZ</text>
 </g>
 <g>
-<rect class=\\"gate-unitary\\" x=\\"60\\" y=\\"140\\" width=\\"40\\" height=\\"40\\" stroke=\\"black\\" stroke-width=\\"1\\"></rect>
-<text font-size=\\"14\\" font-family=\\"Arial\\" x=\\"80\\" y=\\"160\\" dominant-baseline=\\"middle\\" text-anchor=\\"middle\\" fill=\\"black\\">ZZ</text>
+<rect class=\\"gate-unitary\\" x=\\"60\\" y=\\"140\\" width=\\"40\\" height=\\"40\\"></rect>
+<text font-size=\\"14\\" x=\\"80\\" y=\\"160\\">ZZ</text>
 </g>"
 `;
 
 exports[`Testing _unitary Multiqubit unitary on non-consecutive registers 2`] = `
-"<line x1=\\"80\\" x2=\\"80\\" y1=\\"40\\" y2=\\"220\\" stroke=\\"black\\" stroke-dasharray=\\"8, 8\\" stroke-width=\\"1\\"></line>
+"<line x1=\\"80\\" x2=\\"80\\" y1=\\"40\\" y2=\\"220\\" stroke-dasharray=\\"8, 8\\"></line>
 <g>
-<rect class=\\"gate-unitary\\" x=\\"60\\" y=\\"20\\" width=\\"40\\" height=\\"40\\" stroke=\\"black\\" stroke-width=\\"1\\"></rect>
-<text font-size=\\"14\\" font-family=\\"Arial\\" x=\\"80\\" y=\\"40\\" dominant-baseline=\\"middle\\" text-anchor=\\"middle\\" fill=\\"black\\">ZZZ</text>
+<rect class=\\"gate-unitary\\" x=\\"60\\" y=\\"20\\" width=\\"40\\" height=\\"40\\"></rect>
+<text font-size=\\"14\\" x=\\"80\\" y=\\"40\\">ZZZ</text>
 </g>
 <g>
-<rect class=\\"gate-unitary\\" x=\\"60\\" y=\\"140\\" width=\\"40\\" height=\\"100\\" stroke=\\"black\\" stroke-width=\\"1\\"></rect>
-<text font-size=\\"14\\" font-family=\\"Arial\\" x=\\"80\\" y=\\"190\\" dominant-baseline=\\"middle\\" text-anchor=\\"middle\\" fill=\\"black\\">ZZZ</text>
+<rect class=\\"gate-unitary\\" x=\\"60\\" y=\\"140\\" width=\\"40\\" height=\\"100\\"></rect>
+<text font-size=\\"14\\" x=\\"80\\" y=\\"190\\">ZZZ</text>
 </g>"
 `;
 
 exports[`Testing _unitary Multiqubit unitary on non-consecutive registers 3`] = `
 "<g>
-<rect class=\\"gate-unitary\\" x=\\"60\\" y=\\"20\\" width=\\"40\\" height=\\"40\\" stroke=\\"black\\" stroke-width=\\"1\\"></rect>
-<text font-size=\\"14\\" font-family=\\"Arial\\" x=\\"80\\" y=\\"40\\" dominant-baseline=\\"middle\\" text-anchor=\\"middle\\" fill=\\"black\\">ZZ</text>
+<rect class=\\"gate-unitary\\" x=\\"60\\" y=\\"20\\" width=\\"40\\" height=\\"40\\"></rect>
+<text font-size=\\"14\\" x=\\"80\\" y=\\"40\\">ZZ</text>
 </g>
 <g>
-<rect class=\\"gate-unitary\\" x=\\"60\\" y=\\"140\\" width=\\"40\\" height=\\"40\\" stroke=\\"black\\" stroke-width=\\"1\\"></rect>
-<text font-size=\\"14\\" font-family=\\"Arial\\" x=\\"80\\" y=\\"160\\" dominant-baseline=\\"middle\\" text-anchor=\\"middle\\" fill=\\"black\\">ZZ</text>
+<rect class=\\"gate-unitary\\" x=\\"60\\" y=\\"140\\" width=\\"40\\" height=\\"40\\"></rect>
+<text font-size=\\"14\\" x=\\"80\\" y=\\"160\\">ZZ</text>
 </g>"
 `;
 
 exports[`Testing _unitary Multiqubit unitary on non-consecutive registers 4`] = `
 "<g>
-<rect class=\\"gate-unitary\\" x=\\"60\\" y=\\"20\\" width=\\"40\\" height=\\"40\\" stroke=\\"black\\" stroke-width=\\"1\\"></rect>
-<text font-size=\\"14\\" font-family=\\"Arial\\" x=\\"80\\" y=\\"40\\" dominant-baseline=\\"middle\\" text-anchor=\\"middle\\" fill=\\"black\\">ZZZ</text>
+<rect class=\\"gate-unitary\\" x=\\"60\\" y=\\"20\\" width=\\"40\\" height=\\"40\\"></rect>
+<text font-size=\\"14\\" x=\\"80\\" y=\\"40\\">ZZZ</text>
 </g>
 <g>
-<rect class=\\"gate-unitary\\" x=\\"60\\" y=\\"140\\" width=\\"40\\" height=\\"100\\" stroke=\\"black\\" stroke-width=\\"1\\"></rect>
-<text font-size=\\"14\\" font-family=\\"Arial\\" x=\\"80\\" y=\\"190\\" dominant-baseline=\\"middle\\" text-anchor=\\"middle\\" fill=\\"black\\">ZZZ</text>
+<rect class=\\"gate-unitary\\" x=\\"60\\" y=\\"140\\" width=\\"40\\" height=\\"100\\"></rect>
+<text font-size=\\"14\\" x=\\"80\\" y=\\"190\\">ZZZ</text>
 </g>"
 `;
 
 exports[`Testing _unitary Single qubit unitary 1`] = `
 "<g>
-<rect class=\\"gate-unitary\\" x=\\"60\\" y=\\"20\\" width=\\"40\\" height=\\"40\\" stroke=\\"black\\" stroke-width=\\"1\\"></rect>
-<text font-size=\\"14\\" font-family=\\"Arial\\" x=\\"80\\" y=\\"40\\" dominant-baseline=\\"middle\\" text-anchor=\\"middle\\" fill=\\"black\\">H</text>
+<rect class=\\"gate-unitary\\" x=\\"60\\" y=\\"20\\" width=\\"40\\" height=\\"40\\"></rect>
+<text font-size=\\"14\\" x=\\"80\\" y=\\"40\\">H</text>
 </g>"
 `;
 
 exports[`Testing formatGates Multiple gates 1`] = `
 "<g>
-<line x1=\\"80\\" x2=\\"80\\" y1=\\"40\\" y2=\\"100\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
-<circle cx=\\"80\\" cy=\\"100\\" r=\\"5\\" stroke=\\"black\\" fill=\\"black\\" stroke-width=\\"1\\"></circle>
+<line x1=\\"80\\" x2=\\"80\\" y1=\\"40\\" y2=\\"100\\"></line>
+<circle class=\\"control-dot\\" cx=\\"80\\" cy=\\"100\\" r=\\"5\\"></circle>
 <g>
-<circle cx=\\"80\\" cy=\\"40\\" r=\\"15\\" stroke=\\"black\\" fill=\\"white\\" stroke-width=\\"1\\"></circle>
-<line x1=\\"80\\" x2=\\"80\\" y1=\\"25\\" y2=\\"55\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
-<line x1=\\"65\\" x2=\\"95\\" y1=\\"40\\" y2=\\"40\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
+<circle class=\\"oplus\\" cx=\\"80\\" cy=\\"40\\" r=\\"15\\"></circle>
+<line x1=\\"80\\" x2=\\"80\\" y1=\\"25\\" y2=\\"55\\"></line>
+<line x1=\\"65\\" x2=\\"95\\" y1=\\"40\\" y2=\\"40\\"></line>
 </g>
 </g>
 <g>
-<line x1=\\"80\\" x2=\\"80\\" y1=\\"100\\" y2=\\"160\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
-<circle cx=\\"80\\" cy=\\"100\\" r=\\"5\\" stroke=\\"black\\" fill=\\"black\\" stroke-width=\\"1\\"></circle>
+<line x1=\\"80\\" x2=\\"80\\" y1=\\"100\\" y2=\\"160\\"></line>
+<circle class=\\"control-dot\\" cx=\\"80\\" cy=\\"100\\" r=\\"5\\"></circle>
 <g>
-<rect class=\\"gate-unitary\\" x=\\"60\\" y=\\"140\\" width=\\"40\\" height=\\"40\\" stroke=\\"black\\" stroke-width=\\"1\\"></rect>
-<text font-size=\\"14\\" font-family=\\"Arial\\" x=\\"80\\" y=\\"160\\" dominant-baseline=\\"middle\\" text-anchor=\\"middle\\" fill=\\"black\\">X</text>
+<rect class=\\"gate-unitary\\" x=\\"60\\" y=\\"140\\" width=\\"40\\" height=\\"40\\"></rect>
+<text font-size=\\"14\\" x=\\"80\\" y=\\"160\\">X</text>
 </g>
 </g>
 <g>
-<rect class=\\"gate-unitary\\" x=\\"60\\" y=\\"140\\" width=\\"40\\" height=\\"40\\" stroke=\\"black\\" stroke-width=\\"1\\"></rect>
-<text font-size=\\"14\\" font-family=\\"Arial\\" x=\\"80\\" y=\\"160\\" dominant-baseline=\\"middle\\" text-anchor=\\"middle\\" fill=\\"black\\">X</text>
+<rect class=\\"gate-unitary\\" x=\\"60\\" y=\\"140\\" width=\\"40\\" height=\\"40\\"></rect>
+<text font-size=\\"14\\" x=\\"80\\" y=\\"160\\">X</text>
 </g>
 <g>
-<rect class=\\"gate-measure\\" x=\\"60\\" y=\\"20\\" width=\\"40\\" height=\\"40\\" stroke=\\"black\\" stroke-width=\\"1\\"></rect>
-<path d=\\"M 95 42 A 15 12 0 0 0 65 42\\" stroke=\\"black\\" fill=\\"none\\" stroke-width=\\"1\\"></path>
-<line x1=\\"80\\" x2=\\"92\\" y1=\\"48\\" y2=\\"28\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
+<rect class=\\"gate-measure\\" x=\\"60\\" y=\\"20\\" width=\\"40\\" height=\\"40\\"></rect>
+<path class=\\"arc-measure\\" d=\\"M 95 42 A 15 12 0 0 0 65 42\\"></path>
+<line x1=\\"80\\" x2=\\"92\\" y1=\\"48\\" y2=\\"28\\"></line>
 </g>"
 `;
 
 exports[`Testing formatGates Single gate 1`] = `
 "<g>
-<line x1=\\"80\\" x2=\\"80\\" y1=\\"40\\" y2=\\"100\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
-<circle cx=\\"80\\" cy=\\"40\\" r=\\"5\\" stroke=\\"black\\" fill=\\"black\\" stroke-width=\\"1\\"></circle>
+<line x1=\\"80\\" x2=\\"80\\" y1=\\"40\\" y2=\\"100\\"></line>
+<circle class=\\"control-dot\\" cx=\\"80\\" cy=\\"40\\" r=\\"5\\"></circle>
 <g>
-<circle cx=\\"80\\" cy=\\"100\\" r=\\"15\\" stroke=\\"black\\" fill=\\"white\\" stroke-width=\\"1\\"></circle>
-<line x1=\\"80\\" x2=\\"80\\" y1=\\"85\\" y2=\\"115\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
-<line x1=\\"65\\" x2=\\"95\\" y1=\\"100\\" y2=\\"100\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
+<circle class=\\"oplus\\" cx=\\"80\\" cy=\\"100\\" r=\\"15\\"></circle>
+<line x1=\\"80\\" x2=\\"80\\" y1=\\"85\\" y2=\\"115\\"></line>
+<line x1=\\"65\\" x2=\\"95\\" y1=\\"100\\" y2=\\"100\\"></line>
 </g>
 </g>"
 `;

--- a/src/Kernel/client/__tests__/ExecutionPathVisualizerTests/__snapshots__/gateFormatter.test.ts.snap
+++ b/src/Kernel/client/__tests__/ExecutionPathVisualizerTests/__snapshots__/gateFormatter.test.ts.snap
@@ -3,8 +3,8 @@
 exports[`Testing _classicalControlled No htmlClass 1`] = `
 "<g>
 <g class=\\"cls-control-group cls-control-unknown\\">
-<line x1=\\"95\\" x2=\\"120\\" y1=\\"180\\" y2=\\"180\\" stroke=\\"black\\" stroke-dasharray=\\"8, 8\\" stroke-width=\\"1\\"></line>
-<line x1=\\"95\\" x2=\\"95\\" y1=\\"175\\" y2=\\"180\\" stroke=\\"black\\" stroke-dasharray=\\"8, 8\\" stroke-width=\\"1\\"></line>
+<line class=\\"cls-line\\" x1=\\"95\\" x2=\\"120\\" y1=\\"180\\" y2=\\"180\\" stroke=\\"black\\" stroke-dasharray=\\"8, 8\\" stroke-width=\\"1\\"></line>
+<line class=\\"cls-line\\" x1=\\"95\\" x2=\\"95\\" y1=\\"175\\" y2=\\"180\\" stroke=\\"black\\" stroke-dasharray=\\"8, 8\\" stroke-width=\\"1\\"></line>
 <g class=\\"cls-control-btn cls-control\\" onClick=\\"toggleClassicalBtn('cls-control')\\">
 <circle class=\\"cls-control\\" cx=\\"95\\" cy=\\"160\\" r=\\"15\\" stroke=\\"black\\" stroke-width=\\"1\\"></circle>
 <text class=\\"cls-control cls-control-text\\" font-size=\\"14\\" font-family=\\"Arial\\" x=\\"95\\" y=\\"160\\" dominant-baseline=\\"middle\\" text-anchor=\\"middle\\" fill=\\"black\\">?</text>
@@ -13,10 +13,10 @@ exports[`Testing _classicalControlled No htmlClass 1`] = `
 </g>
 <g class=\\"cls-control-one\\">
 <g>
-<rect x=\\"90\\" y=\\"20\\" width=\\"40\\" height=\\"40\\" stroke=\\"black\\" fill=\\"white\\" stroke-width=\\"1\\"></rect>
+<rect class=\\"gate-unitary\\" x=\\"90\\" y=\\"20\\" width=\\"40\\" height=\\"40\\" stroke=\\"black\\" stroke-width=\\"1\\"></rect>
 <text font-size=\\"14\\" font-family=\\"Arial\\" x=\\"110\\" y=\\"40\\" dominant-baseline=\\"middle\\" text-anchor=\\"middle\\" fill=\\"black\\">X</text>
 </g></g>
-<rect x=\\"120\\" y =\\"5\\" width=\\"80\\" height=\\"130\\" stroke=\\"black\\" fill-opacity=\\"0\\" stroke-dasharray=\\"8, 8\\" stroke-width=\\"1\\"></rect>
+<rect class=\\"cls-container\\" x=\\"120\\" y=\\"5\\" width=\\"80\\" height=\\"130\\" stroke=\\"black\\" fill-opacity=\\"0\\" stroke-dasharray=\\"8, 8\\" stroke-width=\\"1\\"></rect>
 </g>
 </g>"
 `;
@@ -24,8 +24,8 @@ exports[`Testing _classicalControlled No htmlClass 1`] = `
 exports[`Testing _classicalControlled change padding 1`] = `
 "<g>
 <g class=\\"cls-control-1-group cls-control-unknown\\">
-<line x1=\\"95\\" x2=\\"120\\" y1=\\"180\\" y2=\\"180\\" stroke=\\"black\\" stroke-dasharray=\\"8, 8\\" stroke-width=\\"1\\"></line>
-<line x1=\\"95\\" x2=\\"95\\" y1=\\"175\\" y2=\\"180\\" stroke=\\"black\\" stroke-dasharray=\\"8, 8\\" stroke-width=\\"1\\"></line>
+<line class=\\"cls-line\\" x1=\\"95\\" x2=\\"120\\" y1=\\"180\\" y2=\\"180\\" stroke=\\"black\\" stroke-dasharray=\\"8, 8\\" stroke-width=\\"1\\"></line>
+<line class=\\"cls-line\\" x1=\\"95\\" x2=\\"95\\" y1=\\"175\\" y2=\\"180\\" stroke=\\"black\\" stroke-dasharray=\\"8, 8\\" stroke-width=\\"1\\"></line>
 <g class=\\"cls-control-btn cls-control-1\\" onClick=\\"toggleClassicalBtn('cls-control-1')\\">
 <circle class=\\"cls-control-1\\" cx=\\"95\\" cy=\\"160\\" r=\\"15\\" stroke=\\"black\\" stroke-width=\\"1\\"></circle>
 <text class=\\"cls-control-1 cls-control-text\\" font-size=\\"14\\" font-family=\\"Arial\\" x=\\"95\\" y=\\"160\\" dominant-baseline=\\"middle\\" text-anchor=\\"middle\\" fill=\\"black\\">?</text>
@@ -34,10 +34,10 @@ exports[`Testing _classicalControlled change padding 1`] = `
 </g>
 <g class=\\"cls-control-1-one\\">
 <g>
-<rect x=\\"90\\" y=\\"20\\" width=\\"40\\" height=\\"40\\" stroke=\\"black\\" fill=\\"white\\" stroke-width=\\"1\\"></rect>
+<rect class=\\"gate-unitary\\" x=\\"90\\" y=\\"20\\" width=\\"40\\" height=\\"40\\" stroke=\\"black\\" stroke-width=\\"1\\"></rect>
 <text font-size=\\"14\\" font-family=\\"Arial\\" x=\\"110\\" y=\\"40\\" dominant-baseline=\\"middle\\" text-anchor=\\"middle\\" fill=\\"black\\">X</text>
 </g></g>
-<rect x=\\"115\\" y =\\"0\\" width=\\"90\\" height=\\"140\\" stroke=\\"black\\" fill-opacity=\\"0\\" stroke-dasharray=\\"8, 8\\" stroke-width=\\"1\\"></rect>
+<rect class=\\"cls-container\\" x=\\"115\\" y=\\"0\\" width=\\"90\\" height=\\"140\\" stroke=\\"black\\" fill-opacity=\\"0\\" stroke-dasharray=\\"8, 8\\" stroke-width=\\"1\\"></rect>
 </g>
 </g>"
 `;
@@ -45,20 +45,20 @@ exports[`Testing _classicalControlled change padding 1`] = `
 exports[`Testing _classicalControlled multiple 'zero'/'one' children 1`] = `
 "<g>
 <g class=\\"cls-control-1-group cls-control-unknown\\">
-<line x1=\\"95\\" x2=\\"120\\" y1=\\"180\\" y2=\\"180\\" stroke=\\"black\\" stroke-dasharray=\\"8, 8\\" stroke-width=\\"1\\"></line>
-<line x1=\\"95\\" x2=\\"95\\" y1=\\"175\\" y2=\\"180\\" stroke=\\"black\\" stroke-dasharray=\\"8, 8\\" stroke-width=\\"1\\"></line>
+<line class=\\"cls-line\\" x1=\\"95\\" x2=\\"120\\" y1=\\"180\\" y2=\\"180\\" stroke=\\"black\\" stroke-dasharray=\\"8, 8\\" stroke-width=\\"1\\"></line>
+<line class=\\"cls-line\\" x1=\\"95\\" x2=\\"95\\" y1=\\"175\\" y2=\\"180\\" stroke=\\"black\\" stroke-dasharray=\\"8, 8\\" stroke-width=\\"1\\"></line>
 <g class=\\"cls-control-btn cls-control-1\\" onClick=\\"toggleClassicalBtn('cls-control-1')\\">
 <circle class=\\"cls-control-1\\" cx=\\"95\\" cy=\\"160\\" r=\\"15\\" stroke=\\"black\\" stroke-width=\\"1\\"></circle>
 <text class=\\"cls-control-1 cls-control-text\\" font-size=\\"14\\" font-family=\\"Arial\\" x=\\"95\\" y=\\"160\\" dominant-baseline=\\"middle\\" text-anchor=\\"middle\\" fill=\\"black\\">?</text>
 </g>
 <g class=\\"cls-control-1-zero hidden\\">
 <g>
-<rect x=\\"90\\" y=\\"20\\" width=\\"40\\" height=\\"40\\" stroke=\\"black\\" fill=\\"white\\" stroke-width=\\"1\\"></rect>
+<rect class=\\"gate-unitary\\" x=\\"90\\" y=\\"20\\" width=\\"40\\" height=\\"40\\" stroke=\\"black\\" stroke-width=\\"1\\"></rect>
 <text font-size=\\"14\\" font-family=\\"Arial\\" x=\\"110\\" y=\\"40\\" dominant-baseline=\\"middle\\" text-anchor=\\"middle\\" fill=\\"black\\">X</text>
 </g></g>
 <g class=\\"cls-control-1-one\\">
 <g>
-<rect x=\\"90\\" y=\\"20\\" width=\\"40\\" height=\\"40\\" stroke=\\"black\\" fill=\\"white\\" stroke-width=\\"1\\"></rect>
+<rect class=\\"gate-unitary\\" x=\\"90\\" y=\\"20\\" width=\\"40\\" height=\\"40\\" stroke=\\"black\\" stroke-width=\\"1\\"></rect>
 <text font-size=\\"14\\" font-family=\\"Arial\\" x=\\"110\\" y=\\"40\\" dominant-baseline=\\"middle\\" text-anchor=\\"middle\\" fill=\\"black\\">X</text>
 </g>
 <g>
@@ -70,7 +70,7 @@ exports[`Testing _classicalControlled multiple 'zero'/'one' children 1`] = `
 <line x1=\\"155\\" x2=\\"185\\" y1=\\"40\\" y2=\\"40\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
 </g>
 </g></g>
-<rect x=\\"120\\" y =\\"5\\" width=\\"80\\" height=\\"130\\" stroke=\\"black\\" fill-opacity=\\"0\\" stroke-dasharray=\\"8, 8\\" stroke-width=\\"1\\"></rect>
+<rect class=\\"cls-container\\" x=\\"120\\" y=\\"5\\" width=\\"80\\" height=\\"130\\" stroke=\\"black\\" fill-opacity=\\"0\\" stroke-dasharray=\\"8, 8\\" stroke-width=\\"1\\"></rect>
 </g>
 </g>"
 `;
@@ -78,8 +78,8 @@ exports[`Testing _classicalControlled multiple 'zero'/'one' children 1`] = `
 exports[`Testing _classicalControlled nested children 1`] = `
 "<g>
 <g class=\\"cls-control-1-group cls-control-unknown\\">
-<line x1=\\"95\\" x2=\\"120\\" y1=\\"180\\" y2=\\"180\\" stroke=\\"black\\" stroke-dasharray=\\"8, 8\\" stroke-width=\\"1\\"></line>
-<line x1=\\"95\\" x2=\\"95\\" y1=\\"175\\" y2=\\"180\\" stroke=\\"black\\" stroke-dasharray=\\"8, 8\\" stroke-width=\\"1\\"></line>
+<line class=\\"cls-line\\" x1=\\"95\\" x2=\\"120\\" y1=\\"180\\" y2=\\"180\\" stroke=\\"black\\" stroke-dasharray=\\"8, 8\\" stroke-width=\\"1\\"></line>
+<line class=\\"cls-line\\" x1=\\"95\\" x2=\\"95\\" y1=\\"175\\" y2=\\"180\\" stroke=\\"black\\" stroke-dasharray=\\"8, 8\\" stroke-width=\\"1\\"></line>
 <g class=\\"cls-control-btn cls-control-1\\" onClick=\\"toggleClassicalBtn('cls-control-1')\\">
 <circle class=\\"cls-control-1\\" cx=\\"95\\" cy=\\"160\\" r=\\"15\\" stroke=\\"black\\" stroke-width=\\"1\\"></circle>
 <text class=\\"cls-control-1 cls-control-text\\" font-size=\\"14\\" font-family=\\"Arial\\" x=\\"95\\" y=\\"160\\" dominant-baseline=\\"middle\\" text-anchor=\\"middle\\" fill=\\"black\\">?</text>
@@ -88,13 +88,13 @@ exports[`Testing _classicalControlled nested children 1`] = `
 </g>
 <g class=\\"cls-control-1-one\\">
 <g>
-<rect x=\\"90\\" y=\\"20\\" width=\\"40\\" height=\\"40\\" stroke=\\"black\\" fill=\\"white\\" stroke-width=\\"1\\"></rect>
+<rect class=\\"gate-unitary\\" x=\\"90\\" y=\\"20\\" width=\\"40\\" height=\\"40\\" stroke=\\"black\\" stroke-width=\\"1\\"></rect>
 <text font-size=\\"14\\" font-family=\\"Arial\\" x=\\"110\\" y=\\"40\\" dominant-baseline=\\"middle\\" text-anchor=\\"middle\\" fill=\\"black\\">X</text>
 </g>
 <g>
 <g class=\\"cls-control-1-group cls-control-unknown\\">
-<line x1=\\"165\\" x2=\\"190\\" y1=\\"240\\" y2=\\"240\\" stroke=\\"black\\" stroke-dasharray=\\"8, 8\\" stroke-width=\\"1\\"></line>
-<line x1=\\"165\\" x2=\\"165\\" y1=\\"235\\" y2=\\"240\\" stroke=\\"black\\" stroke-dasharray=\\"8, 8\\" stroke-width=\\"1\\"></line>
+<line class=\\"cls-line\\" x1=\\"165\\" x2=\\"190\\" y1=\\"240\\" y2=\\"240\\" stroke=\\"black\\" stroke-dasharray=\\"8, 8\\" stroke-width=\\"1\\"></line>
+<line class=\\"cls-line\\" x1=\\"165\\" x2=\\"165\\" y1=\\"235\\" y2=\\"240\\" stroke=\\"black\\" stroke-dasharray=\\"8, 8\\" stroke-width=\\"1\\"></line>
 <g class=\\"cls-control-btn cls-control-1\\" onClick=\\"toggleClassicalBtn('cls-control-1')\\">
 <circle class=\\"cls-control-1\\" cx=\\"165\\" cy=\\"220\\" r=\\"15\\" stroke=\\"black\\" stroke-width=\\"1\\"></circle>
 <text class=\\"cls-control-1 cls-control-text\\" font-size=\\"14\\" font-family=\\"Arial\\" x=\\"165\\" y=\\"220\\" dominant-baseline=\\"middle\\" text-anchor=\\"middle\\" fill=\\"black\\">?</text>
@@ -111,10 +111,10 @@ exports[`Testing _classicalControlled nested children 1`] = `
 <line x1=\\"165\\" x2=\\"195\\" y1=\\"40\\" y2=\\"40\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
 </g>
 </g></g>
-<rect x=\\"190\\" y =\\"5\\" width=\\"20\\" height=\\"130\\" stroke=\\"black\\" fill-opacity=\\"0\\" stroke-dasharray=\\"8, 8\\" stroke-width=\\"1\\"></rect>
+<rect class=\\"cls-container\\" x=\\"190\\" y=\\"5\\" width=\\"20\\" height=\\"130\\" stroke=\\"black\\" fill-opacity=\\"0\\" stroke-dasharray=\\"8, 8\\" stroke-width=\\"1\\"></rect>
 </g>
 </g></g>
-<rect x=\\"120\\" y =\\"5\\" width=\\"100\\" height=\\"130\\" stroke=\\"black\\" fill-opacity=\\"0\\" stroke-dasharray=\\"8, 8\\" stroke-width=\\"1\\"></rect>
+<rect class=\\"cls-container\\" x=\\"120\\" y=\\"5\\" width=\\"100\\" height=\\"130\\" stroke=\\"black\\" fill-opacity=\\"0\\" stroke-dasharray=\\"8, 8\\" stroke-width=\\"1\\"></rect>
 </g>
 </g>"
 `;
@@ -122,8 +122,8 @@ exports[`Testing _classicalControlled nested children 1`] = `
 exports[`Testing _classicalControlled one 'one' child 1`] = `
 "<g>
 <g class=\\"cls-control-1-group cls-control-unknown\\">
-<line x1=\\"95\\" x2=\\"120\\" y1=\\"180\\" y2=\\"180\\" stroke=\\"black\\" stroke-dasharray=\\"8, 8\\" stroke-width=\\"1\\"></line>
-<line x1=\\"95\\" x2=\\"95\\" y1=\\"175\\" y2=\\"180\\" stroke=\\"black\\" stroke-dasharray=\\"8, 8\\" stroke-width=\\"1\\"></line>
+<line class=\\"cls-line\\" x1=\\"95\\" x2=\\"120\\" y1=\\"180\\" y2=\\"180\\" stroke=\\"black\\" stroke-dasharray=\\"8, 8\\" stroke-width=\\"1\\"></line>
+<line class=\\"cls-line\\" x1=\\"95\\" x2=\\"95\\" y1=\\"175\\" y2=\\"180\\" stroke=\\"black\\" stroke-dasharray=\\"8, 8\\" stroke-width=\\"1\\"></line>
 <g class=\\"cls-control-btn cls-control-1\\" onClick=\\"toggleClassicalBtn('cls-control-1')\\">
 <circle class=\\"cls-control-1\\" cx=\\"95\\" cy=\\"160\\" r=\\"15\\" stroke=\\"black\\" stroke-width=\\"1\\"></circle>
 <text class=\\"cls-control-1 cls-control-text\\" font-size=\\"14\\" font-family=\\"Arial\\" x=\\"95\\" y=\\"160\\" dominant-baseline=\\"middle\\" text-anchor=\\"middle\\" fill=\\"black\\">?</text>
@@ -132,10 +132,10 @@ exports[`Testing _classicalControlled one 'one' child 1`] = `
 </g>
 <g class=\\"cls-control-1-one\\">
 <g>
-<rect x=\\"90\\" y=\\"20\\" width=\\"40\\" height=\\"40\\" stroke=\\"black\\" fill=\\"white\\" stroke-width=\\"1\\"></rect>
+<rect class=\\"gate-unitary\\" x=\\"90\\" y=\\"20\\" width=\\"40\\" height=\\"40\\" stroke=\\"black\\" stroke-width=\\"1\\"></rect>
 <text font-size=\\"14\\" font-family=\\"Arial\\" x=\\"110\\" y=\\"40\\" dominant-baseline=\\"middle\\" text-anchor=\\"middle\\" fill=\\"black\\">X</text>
 </g></g>
-<rect x=\\"120\\" y =\\"5\\" width=\\"20\\" height=\\"130\\" stroke=\\"black\\" fill-opacity=\\"0\\" stroke-dasharray=\\"8, 8\\" stroke-width=\\"1\\"></rect>
+<rect class=\\"cls-container\\" x=\\"120\\" y=\\"5\\" width=\\"20\\" height=\\"130\\" stroke=\\"black\\" fill-opacity=\\"0\\" stroke-dasharray=\\"8, 8\\" stroke-width=\\"1\\"></rect>
 </g>
 </g>"
 `;
@@ -143,20 +143,20 @@ exports[`Testing _classicalControlled one 'one' child 1`] = `
 exports[`Testing _classicalControlled one 'zero' child 1`] = `
 "<g>
 <g class=\\"cls-control-1-group cls-control-unknown\\">
-<line x1=\\"95\\" x2=\\"120\\" y1=\\"180\\" y2=\\"180\\" stroke=\\"black\\" stroke-dasharray=\\"8, 8\\" stroke-width=\\"1\\"></line>
-<line x1=\\"95\\" x2=\\"95\\" y1=\\"175\\" y2=\\"180\\" stroke=\\"black\\" stroke-dasharray=\\"8, 8\\" stroke-width=\\"1\\"></line>
+<line class=\\"cls-line\\" x1=\\"95\\" x2=\\"120\\" y1=\\"180\\" y2=\\"180\\" stroke=\\"black\\" stroke-dasharray=\\"8, 8\\" stroke-width=\\"1\\"></line>
+<line class=\\"cls-line\\" x1=\\"95\\" x2=\\"95\\" y1=\\"175\\" y2=\\"180\\" stroke=\\"black\\" stroke-dasharray=\\"8, 8\\" stroke-width=\\"1\\"></line>
 <g class=\\"cls-control-btn cls-control-1\\" onClick=\\"toggleClassicalBtn('cls-control-1')\\">
 <circle class=\\"cls-control-1\\" cx=\\"95\\" cy=\\"160\\" r=\\"15\\" stroke=\\"black\\" stroke-width=\\"1\\"></circle>
 <text class=\\"cls-control-1 cls-control-text\\" font-size=\\"14\\" font-family=\\"Arial\\" x=\\"95\\" y=\\"160\\" dominant-baseline=\\"middle\\" text-anchor=\\"middle\\" fill=\\"black\\">?</text>
 </g>
 <g class=\\"cls-control-1-zero hidden\\">
 <g>
-<rect x=\\"90\\" y=\\"20\\" width=\\"40\\" height=\\"40\\" stroke=\\"black\\" fill=\\"white\\" stroke-width=\\"1\\"></rect>
+<rect class=\\"gate-unitary\\" x=\\"90\\" y=\\"20\\" width=\\"40\\" height=\\"40\\" stroke=\\"black\\" stroke-width=\\"1\\"></rect>
 <text font-size=\\"14\\" font-family=\\"Arial\\" x=\\"110\\" y=\\"40\\" dominant-baseline=\\"middle\\" text-anchor=\\"middle\\" fill=\\"black\\">X</text>
 </g></g>
 <g class=\\"cls-control-1-one\\">
 </g>
-<rect x=\\"120\\" y =\\"5\\" width=\\"20\\" height=\\"130\\" stroke=\\"black\\" fill-opacity=\\"0\\" stroke-dasharray=\\"8, 8\\" stroke-width=\\"1\\"></rect>
+<rect class=\\"cls-container\\" x=\\"120\\" y=\\"5\\" width=\\"20\\" height=\\"130\\" stroke=\\"black\\" fill-opacity=\\"0\\" stroke-dasharray=\\"8, 8\\" stroke-width=\\"1\\"></rect>
 </g>
 </g>"
 `;
@@ -190,7 +190,7 @@ exports[`Testing _controlledGate Controlled U gate with 1 control + 1 target 1`]
 <line x1=\\"80\\" x2=\\"80\\" y1=\\"40\\" y2=\\"100\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
 <circle cx=\\"80\\" cy=\\"40\\" r=\\"5\\" stroke=\\"black\\" fill=\\"black\\" stroke-width=\\"1\\"></circle>
 <g>
-<rect x=\\"57.5\\" y=\\"80\\" width=\\"45\\" height=\\"40\\" stroke=\\"black\\" fill=\\"white\\" stroke-width=\\"1\\"></rect>
+<rect class=\\"gate-unitary\\" x=\\"57.5\\" y=\\"80\\" width=\\"45\\" height=\\"40\\" stroke=\\"black\\" stroke-width=\\"1\\"></rect>
 <text font-size=\\"14\\" font-family=\\"Arial\\" x=\\"80\\" y=\\"100\\" dominant-baseline=\\"middle\\" text-anchor=\\"middle\\" fill=\\"black\\">Foo</text>
 </g>
 </g>"
@@ -201,7 +201,7 @@ exports[`Testing _controlledGate Controlled U gate with 1 control + 1 target 2`]
 <line x1=\\"80\\" x2=\\"80\\" y1=\\"40\\" y2=\\"100\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
 <circle cx=\\"80\\" cy=\\"100\\" r=\\"5\\" stroke=\\"black\\" fill=\\"black\\" stroke-width=\\"1\\"></circle>
 <g>
-<rect x=\\"57.5\\" y=\\"20\\" width=\\"45\\" height=\\"40\\" stroke=\\"black\\" fill=\\"white\\" stroke-width=\\"1\\"></rect>
+<rect class=\\"gate-unitary\\" x=\\"57.5\\" y=\\"20\\" width=\\"45\\" height=\\"40\\" stroke=\\"black\\" stroke-width=\\"1\\"></rect>
 <text font-size=\\"14\\" font-family=\\"Arial\\" x=\\"80\\" y=\\"40\\" dominant-baseline=\\"middle\\" text-anchor=\\"middle\\" fill=\\"black\\">Foo</text>
 </g>
 </g>"
@@ -212,7 +212,7 @@ exports[`Testing _controlledGate Controlled U gate with 1 control + 2 targets 1`
 <line x1=\\"80\\" x2=\\"80\\" y1=\\"40\\" y2=\\"160\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
 <circle cx=\\"80\\" cy=\\"160\\" r=\\"5\\" stroke=\\"black\\" fill=\\"black\\" stroke-width=\\"1\\"></circle>
 <g>
-<rect x=\\"57.5\\" y=\\"20\\" width=\\"45\\" height=\\"100\\" stroke=\\"black\\" fill=\\"white\\" stroke-width=\\"1\\"></rect>
+<rect class=\\"gate-unitary\\" x=\\"57.5\\" y=\\"20\\" width=\\"45\\" height=\\"100\\" stroke=\\"black\\" stroke-width=\\"1\\"></rect>
 <text font-size=\\"14\\" font-family=\\"Arial\\" x=\\"80\\" y=\\"70\\" dominant-baseline=\\"middle\\" text-anchor=\\"middle\\" fill=\\"black\\">Foo</text>
 </g>
 </g>"
@@ -223,7 +223,7 @@ exports[`Testing _controlledGate Controlled U gate with 1 control + 2 targets 2`
 <line x1=\\"80\\" x2=\\"80\\" y1=\\"40\\" y2=\\"160\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
 <circle cx=\\"80\\" cy=\\"40\\" r=\\"5\\" stroke=\\"black\\" fill=\\"black\\" stroke-width=\\"1\\"></circle>
 <g>
-<rect x=\\"57.5\\" y=\\"80\\" width=\\"45\\" height=\\"100\\" stroke=\\"black\\" fill=\\"white\\" stroke-width=\\"1\\"></rect>
+<rect class=\\"gate-unitary\\" x=\\"57.5\\" y=\\"80\\" width=\\"45\\" height=\\"100\\" stroke=\\"black\\" stroke-width=\\"1\\"></rect>
 <text font-size=\\"14\\" font-family=\\"Arial\\" x=\\"80\\" y=\\"130\\" dominant-baseline=\\"middle\\" text-anchor=\\"middle\\" fill=\\"black\\">Foo</text>
 </g>
 </g>"
@@ -234,11 +234,11 @@ exports[`Testing _controlledGate Controlled U gate with 1 control + 2 targets 3`
 <line x1=\\"80\\" x2=\\"80\\" y1=\\"40\\" y2=\\"160\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
 <circle cx=\\"80\\" cy=\\"100\\" r=\\"5\\" stroke=\\"black\\" fill=\\"black\\" stroke-width=\\"1\\"></circle>
 <g>
-<rect x=\\"57.5\\" y=\\"20\\" width=\\"45\\" height=\\"40\\" stroke=\\"black\\" fill=\\"white\\" stroke-width=\\"1\\"></rect>
+<rect class=\\"gate-unitary\\" x=\\"57.5\\" y=\\"20\\" width=\\"45\\" height=\\"40\\" stroke=\\"black\\" stroke-width=\\"1\\"></rect>
 <text font-size=\\"14\\" font-family=\\"Arial\\" x=\\"80\\" y=\\"40\\" dominant-baseline=\\"middle\\" text-anchor=\\"middle\\" fill=\\"black\\">Foo</text>
 </g>
 <g>
-<rect x=\\"57.5\\" y=\\"140\\" width=\\"45\\" height=\\"40\\" stroke=\\"black\\" fill=\\"white\\" stroke-width=\\"1\\"></rect>
+<rect class=\\"gate-unitary\\" x=\\"57.5\\" y=\\"140\\" width=\\"45\\" height=\\"40\\" stroke=\\"black\\" stroke-width=\\"1\\"></rect>
 <text font-size=\\"14\\" font-family=\\"Arial\\" x=\\"80\\" y=\\"160\\" dominant-baseline=\\"middle\\" text-anchor=\\"middle\\" fill=\\"black\\">Foo</text>
 </g>
 </g>"
@@ -250,7 +250,7 @@ exports[`Testing _controlledGate Controlled U gate with 2 controls + 2 targets 1
 <circle cx=\\"80\\" cy=\\"160\\" r=\\"5\\" stroke=\\"black\\" fill=\\"black\\" stroke-width=\\"1\\"></circle>
 <circle cx=\\"80\\" cy=\\"220\\" r=\\"5\\" stroke=\\"black\\" fill=\\"black\\" stroke-width=\\"1\\"></circle>
 <g>
-<rect x=\\"57.5\\" y=\\"20\\" width=\\"45\\" height=\\"100\\" stroke=\\"black\\" fill=\\"white\\" stroke-width=\\"1\\"></rect>
+<rect class=\\"gate-unitary\\" x=\\"57.5\\" y=\\"20\\" width=\\"45\\" height=\\"100\\" stroke=\\"black\\" stroke-width=\\"1\\"></rect>
 <text font-size=\\"14\\" font-family=\\"Arial\\" x=\\"80\\" y=\\"70\\" dominant-baseline=\\"middle\\" text-anchor=\\"middle\\" fill=\\"black\\">Foo</text>
 </g>
 </g>"
@@ -262,7 +262,7 @@ exports[`Testing _controlledGate Controlled U gate with 2 controls + 2 targets 2
 <circle cx=\\"80\\" cy=\\"40\\" r=\\"5\\" stroke=\\"black\\" fill=\\"black\\" stroke-width=\\"1\\"></circle>
 <circle cx=\\"80\\" cy=\\"100\\" r=\\"5\\" stroke=\\"black\\" fill=\\"black\\" stroke-width=\\"1\\"></circle>
 <g>
-<rect x=\\"57.5\\" y=\\"140\\" width=\\"45\\" height=\\"100\\" stroke=\\"black\\" fill=\\"white\\" stroke-width=\\"1\\"></rect>
+<rect class=\\"gate-unitary\\" x=\\"57.5\\" y=\\"140\\" width=\\"45\\" height=\\"100\\" stroke=\\"black\\" stroke-width=\\"1\\"></rect>
 <text font-size=\\"14\\" font-family=\\"Arial\\" x=\\"80\\" y=\\"190\\" dominant-baseline=\\"middle\\" text-anchor=\\"middle\\" fill=\\"black\\">Foo</text>
 </g>
 </g>"
@@ -274,11 +274,11 @@ exports[`Testing _controlledGate Controlled U gate with 2 controls + 2 targets 3
 <circle cx=\\"80\\" cy=\\"100\\" r=\\"5\\" stroke=\\"black\\" fill=\\"black\\" stroke-width=\\"1\\"></circle>
 <circle cx=\\"80\\" cy=\\"160\\" r=\\"5\\" stroke=\\"black\\" fill=\\"black\\" stroke-width=\\"1\\"></circle>
 <g>
-<rect x=\\"57.5\\" y=\\"20\\" width=\\"45\\" height=\\"40\\" stroke=\\"black\\" fill=\\"white\\" stroke-width=\\"1\\"></rect>
+<rect class=\\"gate-unitary\\" x=\\"57.5\\" y=\\"20\\" width=\\"45\\" height=\\"40\\" stroke=\\"black\\" stroke-width=\\"1\\"></rect>
 <text font-size=\\"14\\" font-family=\\"Arial\\" x=\\"80\\" y=\\"40\\" dominant-baseline=\\"middle\\" text-anchor=\\"middle\\" fill=\\"black\\">Foo</text>
 </g>
 <g>
-<rect x=\\"57.5\\" y=\\"200\\" width=\\"45\\" height=\\"40\\" stroke=\\"black\\" fill=\\"white\\" stroke-width=\\"1\\"></rect>
+<rect class=\\"gate-unitary\\" x=\\"57.5\\" y=\\"200\\" width=\\"45\\" height=\\"40\\" stroke=\\"black\\" stroke-width=\\"1\\"></rect>
 <text font-size=\\"14\\" font-family=\\"Arial\\" x=\\"80\\" y=\\"220\\" dominant-baseline=\\"middle\\" text-anchor=\\"middle\\" fill=\\"black\\">Foo</text>
 </g>
 </g>"
@@ -290,11 +290,11 @@ exports[`Testing _controlledGate Controlled U gate with 2 controls + 2 targets 4
 <circle cx=\\"80\\" cy=\\"100\\" r=\\"5\\" stroke=\\"black\\" fill=\\"black\\" stroke-width=\\"1\\"></circle>
 <circle cx=\\"80\\" cy=\\"220\\" r=\\"5\\" stroke=\\"black\\" fill=\\"black\\" stroke-width=\\"1\\"></circle>
 <g>
-<rect x=\\"57.5\\" y=\\"20\\" width=\\"45\\" height=\\"40\\" stroke=\\"black\\" fill=\\"white\\" stroke-width=\\"1\\"></rect>
+<rect class=\\"gate-unitary\\" x=\\"57.5\\" y=\\"20\\" width=\\"45\\" height=\\"40\\" stroke=\\"black\\" stroke-width=\\"1\\"></rect>
 <text font-size=\\"14\\" font-family=\\"Arial\\" x=\\"80\\" y=\\"40\\" dominant-baseline=\\"middle\\" text-anchor=\\"middle\\" fill=\\"black\\">Foo</text>
 </g>
 <g>
-<rect x=\\"57.5\\" y=\\"140\\" width=\\"45\\" height=\\"40\\" stroke=\\"black\\" fill=\\"white\\" stroke-width=\\"1\\"></rect>
+<rect class=\\"gate-unitary\\" x=\\"57.5\\" y=\\"140\\" width=\\"45\\" height=\\"40\\" stroke=\\"black\\" stroke-width=\\"1\\"></rect>
 <text font-size=\\"14\\" font-family=\\"Arial\\" x=\\"80\\" y=\\"160\\" dominant-baseline=\\"middle\\" text-anchor=\\"middle\\" fill=\\"black\\">Foo</text>
 </g>
 </g>"
@@ -306,7 +306,7 @@ exports[`Testing _controlledGate Controlled U gate with multiple controls + 1 ta
 <circle cx=\\"80\\" cy=\\"40\\" r=\\"5\\" stroke=\\"black\\" fill=\\"black\\" stroke-width=\\"1\\"></circle>
 <circle cx=\\"80\\" cy=\\"100\\" r=\\"5\\" stroke=\\"black\\" fill=\\"black\\" stroke-width=\\"1\\"></circle>
 <g>
-<rect x=\\"57.5\\" y=\\"140\\" width=\\"45\\" height=\\"40\\" stroke=\\"black\\" fill=\\"white\\" stroke-width=\\"1\\"></rect>
+<rect class=\\"gate-unitary\\" x=\\"57.5\\" y=\\"140\\" width=\\"45\\" height=\\"40\\" stroke=\\"black\\" stroke-width=\\"1\\"></rect>
 <text font-size=\\"14\\" font-family=\\"Arial\\" x=\\"80\\" y=\\"160\\" dominant-baseline=\\"middle\\" text-anchor=\\"middle\\" fill=\\"black\\">Foo</text>
 </g>
 </g>"
@@ -318,7 +318,7 @@ exports[`Testing _controlledGate Controlled U gate with multiple controls + 1 ta
 <circle cx=\\"80\\" cy=\\"100\\" r=\\"5\\" stroke=\\"black\\" fill=\\"black\\" stroke-width=\\"1\\"></circle>
 <circle cx=\\"80\\" cy=\\"160\\" r=\\"5\\" stroke=\\"black\\" fill=\\"black\\" stroke-width=\\"1\\"></circle>
 <g>
-<rect x=\\"57.5\\" y=\\"20\\" width=\\"45\\" height=\\"40\\" stroke=\\"black\\" fill=\\"white\\" stroke-width=\\"1\\"></rect>
+<rect class=\\"gate-unitary\\" x=\\"57.5\\" y=\\"20\\" width=\\"45\\" height=\\"40\\" stroke=\\"black\\" stroke-width=\\"1\\"></rect>
 <text font-size=\\"14\\" font-family=\\"Arial\\" x=\\"80\\" y=\\"40\\" dominant-baseline=\\"middle\\" text-anchor=\\"middle\\" fill=\\"black\\">Foo</text>
 </g>
 </g>"
@@ -330,7 +330,7 @@ exports[`Testing _controlledGate Controlled U gate with multiple controls + 1 ta
 <circle cx=\\"80\\" cy=\\"40\\" r=\\"5\\" stroke=\\"black\\" fill=\\"black\\" stroke-width=\\"1\\"></circle>
 <circle cx=\\"80\\" cy=\\"160\\" r=\\"5\\" stroke=\\"black\\" fill=\\"black\\" stroke-width=\\"1\\"></circle>
 <g>
-<rect x=\\"57.5\\" y=\\"80\\" width=\\"45\\" height=\\"40\\" stroke=\\"black\\" fill=\\"white\\" stroke-width=\\"1\\"></rect>
+<rect class=\\"gate-unitary\\" x=\\"57.5\\" y=\\"80\\" width=\\"45\\" height=\\"40\\" stroke=\\"black\\" stroke-width=\\"1\\"></rect>
 <text font-size=\\"14\\" font-family=\\"Arial\\" x=\\"80\\" y=\\"100\\" dominant-baseline=\\"middle\\" text-anchor=\\"middle\\" fill=\\"black\\">Foo</text>
 </g>
 </g>"
@@ -384,8 +384,8 @@ exports[`Testing _formatGate CNOT gate 1`] = `
 exports[`Testing _formatGate classically controlled gate 1`] = `
 "<g>
 <g class=\\"cls-control-group cls-control-unknown\\">
-<line x1=\\"95\\" x2=\\"120\\" y1=\\"180\\" y2=\\"180\\" stroke=\\"black\\" stroke-dasharray=\\"8, 8\\" stroke-width=\\"1\\"></line>
-<line x1=\\"95\\" x2=\\"95\\" y1=\\"175\\" y2=\\"180\\" stroke=\\"black\\" stroke-dasharray=\\"8, 8\\" stroke-width=\\"1\\"></line>
+<line class=\\"cls-line\\" x1=\\"95\\" x2=\\"120\\" y1=\\"180\\" y2=\\"180\\" stroke=\\"black\\" stroke-dasharray=\\"8, 8\\" stroke-width=\\"1\\"></line>
+<line class=\\"cls-line\\" x1=\\"95\\" x2=\\"95\\" y1=\\"175\\" y2=\\"180\\" stroke=\\"black\\" stroke-dasharray=\\"8, 8\\" stroke-width=\\"1\\"></line>
 <g class=\\"cls-control-btn cls-control\\" onClick=\\"toggleClassicalBtn('cls-control')\\">
 <circle class=\\"cls-control\\" cx=\\"95\\" cy=\\"160\\" r=\\"15\\" stroke=\\"black\\" stroke-width=\\"1\\"></circle>
 <text class=\\"cls-control cls-control-text\\" font-size=\\"14\\" font-family=\\"Arial\\" x=\\"95\\" y=\\"160\\" dominant-baseline=\\"middle\\" text-anchor=\\"middle\\" fill=\\"black\\">?</text>
@@ -394,7 +394,7 @@ exports[`Testing _formatGate classically controlled gate 1`] = `
 </g>
 <g class=\\"cls-control-one\\">
 </g>
-<rect x=\\"120\\" y =\\"5\\" width=\\"0\\" height=\\"130\\" stroke=\\"black\\" fill-opacity=\\"0\\" stroke-dasharray=\\"8, 8\\" stroke-width=\\"1\\"></rect>
+<rect class=\\"cls-container\\" x=\\"120\\" y=\\"5\\" width=\\"0\\" height=\\"130\\" stroke=\\"black\\" fill-opacity=\\"0\\" stroke-dasharray=\\"8, 8\\" stroke-width=\\"1\\"></rect>
 </g>
 </g>"
 `;
@@ -415,7 +415,7 @@ exports[`Testing _formatGate controlled unitary gate 1`] = `
 <line x1=\\"80\\" x2=\\"80\\" y1=\\"40\\" y2=\\"100\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
 <circle cx=\\"80\\" cy=\\"40\\" r=\\"5\\" stroke=\\"black\\" fill=\\"black\\" stroke-width=\\"1\\"></circle>
 <g>
-<rect x=\\"60\\" y=\\"80\\" width=\\"40\\" height=\\"40\\" stroke=\\"black\\" fill=\\"white\\" stroke-width=\\"1\\"></rect>
+<rect class=\\"gate-unitary\\" x=\\"60\\" y=\\"80\\" width=\\"40\\" height=\\"40\\" stroke=\\"black\\" stroke-width=\\"1\\"></rect>
 <text font-size=\\"14\\" font-family=\\"Arial\\" x=\\"80\\" y=\\"100\\" dominant-baseline=\\"middle\\" text-anchor=\\"middle\\" fill=\\"black\\">U</text>
 </g>
 </g>"
@@ -426,7 +426,7 @@ exports[`Testing _formatGate controlled unitary gate with arguments 1`] = `
 <line x1=\\"80\\" x2=\\"80\\" y1=\\"40\\" y2=\\"100\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
 <circle cx=\\"80\\" cy=\\"40\\" r=\\"5\\" stroke=\\"black\\" fill=\\"black\\" stroke-width=\\"1\\"></circle>
 <g>
-<rect x=\\"41.5\\" y=\\"80\\" width=\\"77\\" height=\\"40\\" stroke=\\"black\\" fill=\\"white\\" stroke-width=\\"1\\"></rect>
+<rect class=\\"gate-unitary\\" x=\\"41.5\\" y=\\"80\\" width=\\"77\\" height=\\"40\\" stroke=\\"black\\" stroke-width=\\"1\\"></rect>
 <text font-size=\\"14\\" font-family=\\"Arial\\" x=\\"80\\" y=\\"93\\" dominant-baseline=\\"middle\\" text-anchor=\\"middle\\" fill=\\"black\\">U</text>
 <text font-size=\\"12\\" font-family=\\"Arial\\" x=\\"80\\" y=\\"108\\" dominant-baseline=\\"middle\\" text-anchor=\\"middle\\" fill=\\"black\\">('foo', 'bar')</text>
 </g>
@@ -435,7 +435,7 @@ exports[`Testing _formatGate controlled unitary gate with arguments 1`] = `
 
 exports[`Testing _formatGate measure gate 1`] = `
 "<g>
-<rect x=\\"60\\" y=\\"20\\" width=\\"40\\" height=\\"40\\" stroke=\\"black\\" fill=\\"white\\" stroke-width=\\"1\\"></rect>
+<rect class=\\"gate-measure\\" x=\\"60\\" y=\\"20\\" width=\\"40\\" height=\\"40\\" stroke=\\"black\\" stroke-width=\\"1\\"></rect>
 <path d=\\"M 95 42 A 15 12 0 0 0 65 42\\" stroke=\\"black\\" fill=\\"none\\" stroke-width=\\"1\\"></path>
 <line x1=\\"80\\" x2=\\"92\\" y1=\\"48\\" y2=\\"28\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
 </g>"
@@ -443,7 +443,7 @@ exports[`Testing _formatGate measure gate 1`] = `
 
 exports[`Testing _formatGate multi-qubit unitary gate 1`] = `
 "<g>
-<rect x=\\"60\\" y=\\"20\\" width=\\"40\\" height=\\"100\\" stroke=\\"black\\" fill=\\"white\\" stroke-width=\\"1\\"></rect>
+<rect class=\\"gate-unitary\\" x=\\"60\\" y=\\"20\\" width=\\"40\\" height=\\"100\\" stroke=\\"black\\" stroke-width=\\"1\\"></rect>
 <text font-size=\\"14\\" font-family=\\"Arial\\" x=\\"80\\" y=\\"70\\" dominant-baseline=\\"middle\\" text-anchor=\\"middle\\" fill=\\"black\\">U</text>
 </g>"
 `;
@@ -452,7 +452,7 @@ exports[`Testing _formatGate multi-qubit unitary gate with arguments 1`] = `
 "<g>
 <line x1=\\"80\\" x2=\\"80\\" y1=\\"40\\" y2=\\"100\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
 <g>
-<rect x=\\"41.5\\" y=\\"20\\" width=\\"77\\" height=\\"100\\" stroke=\\"black\\" fill=\\"white\\" stroke-width=\\"1\\"></rect>
+<rect class=\\"gate-unitary\\" x=\\"41.5\\" y=\\"20\\" width=\\"77\\" height=\\"100\\" stroke=\\"black\\" stroke-width=\\"1\\"></rect>
 <text font-size=\\"14\\" font-family=\\"Arial\\" x=\\"80\\" y=\\"63\\" dominant-baseline=\\"middle\\" text-anchor=\\"middle\\" fill=\\"black\\">U</text>
 <text font-size=\\"12\\" font-family=\\"Arial\\" x=\\"80\\" y=\\"78\\" dominant-baseline=\\"middle\\" text-anchor=\\"middle\\" fill=\\"black\\">('foo', 'bar')</text>
 </g>
@@ -461,14 +461,14 @@ exports[`Testing _formatGate multi-qubit unitary gate with arguments 1`] = `
 
 exports[`Testing _formatGate single-qubit unitary gate 1`] = `
 "<g>
-<rect x=\\"60\\" y=\\"20\\" width=\\"40\\" height=\\"40\\" stroke=\\"black\\" fill=\\"white\\" stroke-width=\\"1\\"></rect>
+<rect class=\\"gate-unitary\\" x=\\"60\\" y=\\"20\\" width=\\"40\\" height=\\"40\\" stroke=\\"black\\" stroke-width=\\"1\\"></rect>
 <text font-size=\\"14\\" font-family=\\"Arial\\" x=\\"80\\" y=\\"40\\" dominant-baseline=\\"middle\\" text-anchor=\\"middle\\" fill=\\"black\\">H</text>
 </g>"
 `;
 
 exports[`Testing _formatGate single-qubit unitary gate with arguments 1`] = `
 "<g>
-<rect x=\\"54\\" y=\\"20\\" width=\\"52\\" height=\\"40\\" stroke=\\"black\\" fill=\\"white\\" stroke-width=\\"1\\"></rect>
+<rect class=\\"gate-unitary\\" x=\\"54\\" y=\\"20\\" width=\\"52\\" height=\\"40\\" stroke=\\"black\\" stroke-width=\\"1\\"></rect>
 <text font-size=\\"14\\" font-family=\\"Arial\\" x=\\"80\\" y=\\"33\\" dominant-baseline=\\"middle\\" text-anchor=\\"middle\\" fill=\\"black\\">Ry</text>
 <text font-size=\\"12\\" font-family=\\"Arial\\" x=\\"80\\" y=\\"48\\" dominant-baseline=\\"middle\\" text-anchor=\\"middle\\" fill=\\"black\\">(0.25)</text>
 </g>"
@@ -486,7 +486,7 @@ exports[`Testing _formatGate swap gate 1`] = `
 
 exports[`Testing _measure 1 qubit + 1 classical registers 1`] = `
 "<g>
-<rect x=\\"60\\" y=\\"20\\" width=\\"40\\" height=\\"40\\" stroke=\\"black\\" fill=\\"white\\" stroke-width=\\"1\\"></rect>
+<rect class=\\"gate-measure\\" x=\\"60\\" y=\\"20\\" width=\\"40\\" height=\\"40\\" stroke=\\"black\\" stroke-width=\\"1\\"></rect>
 <path d=\\"M 95 42 A 15 12 0 0 0 65 42\\" stroke=\\"black\\" fill=\\"none\\" stroke-width=\\"1\\"></path>
 <line x1=\\"80\\" x2=\\"92\\" y1=\\"48\\" y2=\\"28\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
 </g>"
@@ -494,7 +494,7 @@ exports[`Testing _measure 1 qubit + 1 classical registers 1`] = `
 
 exports[`Testing _measure 2 qubit + 1 classical registers 1`] = `
 "<g>
-<rect x=\\"60\\" y=\\"20\\" width=\\"40\\" height=\\"40\\" stroke=\\"black\\" fill=\\"white\\" stroke-width=\\"1\\"></rect>
+<rect class=\\"gate-measure\\" x=\\"60\\" y=\\"20\\" width=\\"40\\" height=\\"40\\" stroke=\\"black\\" stroke-width=\\"1\\"></rect>
 <path d=\\"M 95 42 A 15 12 0 0 0 65 42\\" stroke=\\"black\\" fill=\\"none\\" stroke-width=\\"1\\"></path>
 <line x1=\\"80\\" x2=\\"92\\" y1=\\"48\\" y2=\\"28\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
 </g>"
@@ -502,7 +502,7 @@ exports[`Testing _measure 2 qubit + 1 classical registers 1`] = `
 
 exports[`Testing _measure 2 qubit + 2 classical registers 1`] = `
 "<g>
-<rect x=\\"60\\" y=\\"20\\" width=\\"40\\" height=\\"40\\" stroke=\\"black\\" fill=\\"white\\" stroke-width=\\"1\\"></rect>
+<rect class=\\"gate-measure\\" x=\\"60\\" y=\\"20\\" width=\\"40\\" height=\\"40\\" stroke=\\"black\\" stroke-width=\\"1\\"></rect>
 <path d=\\"M 95 42 A 15 12 0 0 0 65 42\\" stroke=\\"black\\" fill=\\"none\\" stroke-width=\\"1\\"></path>
 <line x1=\\"80\\" x2=\\"92\\" y1=\\"48\\" y2=\\"28\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
 </g>"
@@ -510,7 +510,7 @@ exports[`Testing _measure 2 qubit + 2 classical registers 1`] = `
 
 exports[`Testing _measure 2 qubit + 2 classical registers 2`] = `
 "<g>
-<rect x=\\"60\\" y=\\"80\\" width=\\"40\\" height=\\"40\\" stroke=\\"black\\" fill=\\"white\\" stroke-width=\\"1\\"></rect>
+<rect class=\\"gate-measure\\" x=\\"60\\" y=\\"80\\" width=\\"40\\" height=\\"40\\" stroke=\\"black\\" stroke-width=\\"1\\"></rect>
 <path d=\\"M 95 102 A 15 12 0 0 0 65 102\\" stroke=\\"black\\" fill=\\"none\\" stroke-width=\\"1\\"></path>
 <line x1=\\"80\\" x2=\\"92\\" y1=\\"108\\" y2=\\"88\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
 </g>"
@@ -558,14 +558,14 @@ exports[`Testing _swap Non-adjacent swap 2`] = `
 
 exports[`Testing _unitary Multiqubit unitary on consecutive registers 1`] = `
 "<g>
-<rect x=\\"60\\" y=\\"20\\" width=\\"40\\" height=\\"100\\" stroke=\\"black\\" fill=\\"white\\" stroke-width=\\"1\\"></rect>
+<rect class=\\"gate-unitary\\" x=\\"60\\" y=\\"20\\" width=\\"40\\" height=\\"100\\" stroke=\\"black\\" stroke-width=\\"1\\"></rect>
 <text font-size=\\"14\\" font-family=\\"Arial\\" x=\\"80\\" y=\\"70\\" dominant-baseline=\\"middle\\" text-anchor=\\"middle\\" fill=\\"black\\">ZZ</text>
 </g>"
 `;
 
 exports[`Testing _unitary Multiqubit unitary on consecutive registers 2`] = `
 "<g>
-<rect x=\\"60\\" y=\\"20\\" width=\\"40\\" height=\\"160\\" stroke=\\"black\\" fill=\\"white\\" stroke-width=\\"1\\"></rect>
+<rect class=\\"gate-unitary\\" x=\\"60\\" y=\\"20\\" width=\\"40\\" height=\\"160\\" stroke=\\"black\\" stroke-width=\\"1\\"></rect>
 <text font-size=\\"14\\" font-family=\\"Arial\\" x=\\"80\\" y=\\"100\\" dominant-baseline=\\"middle\\" text-anchor=\\"middle\\" fill=\\"black\\">ZZZ</text>
 </g>"
 `;
@@ -573,11 +573,11 @@ exports[`Testing _unitary Multiqubit unitary on consecutive registers 2`] = `
 exports[`Testing _unitary Multiqubit unitary on non-consecutive registers 1`] = `
 "<line x1=\\"80\\" x2=\\"80\\" y1=\\"40\\" y2=\\"160\\" stroke=\\"black\\" stroke-dasharray=\\"8, 8\\" stroke-width=\\"1\\"></line>
 <g>
-<rect x=\\"60\\" y=\\"20\\" width=\\"40\\" height=\\"40\\" stroke=\\"black\\" fill=\\"white\\" stroke-width=\\"1\\"></rect>
+<rect class=\\"gate-unitary\\" x=\\"60\\" y=\\"20\\" width=\\"40\\" height=\\"40\\" stroke=\\"black\\" stroke-width=\\"1\\"></rect>
 <text font-size=\\"14\\" font-family=\\"Arial\\" x=\\"80\\" y=\\"40\\" dominant-baseline=\\"middle\\" text-anchor=\\"middle\\" fill=\\"black\\">ZZ</text>
 </g>
 <g>
-<rect x=\\"60\\" y=\\"140\\" width=\\"40\\" height=\\"40\\" stroke=\\"black\\" fill=\\"white\\" stroke-width=\\"1\\"></rect>
+<rect class=\\"gate-unitary\\" x=\\"60\\" y=\\"140\\" width=\\"40\\" height=\\"40\\" stroke=\\"black\\" stroke-width=\\"1\\"></rect>
 <text font-size=\\"14\\" font-family=\\"Arial\\" x=\\"80\\" y=\\"160\\" dominant-baseline=\\"middle\\" text-anchor=\\"middle\\" fill=\\"black\\">ZZ</text>
 </g>"
 `;
@@ -585,40 +585,40 @@ exports[`Testing _unitary Multiqubit unitary on non-consecutive registers 1`] = 
 exports[`Testing _unitary Multiqubit unitary on non-consecutive registers 2`] = `
 "<line x1=\\"80\\" x2=\\"80\\" y1=\\"40\\" y2=\\"220\\" stroke=\\"black\\" stroke-dasharray=\\"8, 8\\" stroke-width=\\"1\\"></line>
 <g>
-<rect x=\\"60\\" y=\\"20\\" width=\\"40\\" height=\\"40\\" stroke=\\"black\\" fill=\\"white\\" stroke-width=\\"1\\"></rect>
+<rect class=\\"gate-unitary\\" x=\\"60\\" y=\\"20\\" width=\\"40\\" height=\\"40\\" stroke=\\"black\\" stroke-width=\\"1\\"></rect>
 <text font-size=\\"14\\" font-family=\\"Arial\\" x=\\"80\\" y=\\"40\\" dominant-baseline=\\"middle\\" text-anchor=\\"middle\\" fill=\\"black\\">ZZZ</text>
 </g>
 <g>
-<rect x=\\"60\\" y=\\"140\\" width=\\"40\\" height=\\"100\\" stroke=\\"black\\" fill=\\"white\\" stroke-width=\\"1\\"></rect>
+<rect class=\\"gate-unitary\\" x=\\"60\\" y=\\"140\\" width=\\"40\\" height=\\"100\\" stroke=\\"black\\" stroke-width=\\"1\\"></rect>
 <text font-size=\\"14\\" font-family=\\"Arial\\" x=\\"80\\" y=\\"190\\" dominant-baseline=\\"middle\\" text-anchor=\\"middle\\" fill=\\"black\\">ZZZ</text>
 </g>"
 `;
 
 exports[`Testing _unitary Multiqubit unitary on non-consecutive registers 3`] = `
 "<g>
-<rect x=\\"60\\" y=\\"20\\" width=\\"40\\" height=\\"40\\" stroke=\\"black\\" fill=\\"white\\" stroke-width=\\"1\\"></rect>
+<rect class=\\"gate-unitary\\" x=\\"60\\" y=\\"20\\" width=\\"40\\" height=\\"40\\" stroke=\\"black\\" stroke-width=\\"1\\"></rect>
 <text font-size=\\"14\\" font-family=\\"Arial\\" x=\\"80\\" y=\\"40\\" dominant-baseline=\\"middle\\" text-anchor=\\"middle\\" fill=\\"black\\">ZZ</text>
 </g>
 <g>
-<rect x=\\"60\\" y=\\"140\\" width=\\"40\\" height=\\"40\\" stroke=\\"black\\" fill=\\"white\\" stroke-width=\\"1\\"></rect>
+<rect class=\\"gate-unitary\\" x=\\"60\\" y=\\"140\\" width=\\"40\\" height=\\"40\\" stroke=\\"black\\" stroke-width=\\"1\\"></rect>
 <text font-size=\\"14\\" font-family=\\"Arial\\" x=\\"80\\" y=\\"160\\" dominant-baseline=\\"middle\\" text-anchor=\\"middle\\" fill=\\"black\\">ZZ</text>
 </g>"
 `;
 
 exports[`Testing _unitary Multiqubit unitary on non-consecutive registers 4`] = `
 "<g>
-<rect x=\\"60\\" y=\\"20\\" width=\\"40\\" height=\\"40\\" stroke=\\"black\\" fill=\\"white\\" stroke-width=\\"1\\"></rect>
+<rect class=\\"gate-unitary\\" x=\\"60\\" y=\\"20\\" width=\\"40\\" height=\\"40\\" stroke=\\"black\\" stroke-width=\\"1\\"></rect>
 <text font-size=\\"14\\" font-family=\\"Arial\\" x=\\"80\\" y=\\"40\\" dominant-baseline=\\"middle\\" text-anchor=\\"middle\\" fill=\\"black\\">ZZZ</text>
 </g>
 <g>
-<rect x=\\"60\\" y=\\"140\\" width=\\"40\\" height=\\"100\\" stroke=\\"black\\" fill=\\"white\\" stroke-width=\\"1\\"></rect>
+<rect class=\\"gate-unitary\\" x=\\"60\\" y=\\"140\\" width=\\"40\\" height=\\"100\\" stroke=\\"black\\" stroke-width=\\"1\\"></rect>
 <text font-size=\\"14\\" font-family=\\"Arial\\" x=\\"80\\" y=\\"190\\" dominant-baseline=\\"middle\\" text-anchor=\\"middle\\" fill=\\"black\\">ZZZ</text>
 </g>"
 `;
 
 exports[`Testing _unitary Single qubit unitary 1`] = `
 "<g>
-<rect x=\\"60\\" y=\\"20\\" width=\\"40\\" height=\\"40\\" stroke=\\"black\\" fill=\\"white\\" stroke-width=\\"1\\"></rect>
+<rect class=\\"gate-unitary\\" x=\\"60\\" y=\\"20\\" width=\\"40\\" height=\\"40\\" stroke=\\"black\\" stroke-width=\\"1\\"></rect>
 <text font-size=\\"14\\" font-family=\\"Arial\\" x=\\"80\\" y=\\"40\\" dominant-baseline=\\"middle\\" text-anchor=\\"middle\\" fill=\\"black\\">H</text>
 </g>"
 `;
@@ -637,16 +637,16 @@ exports[`Testing formatGates Multiple gates 1`] = `
 <line x1=\\"80\\" x2=\\"80\\" y1=\\"100\\" y2=\\"160\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
 <circle cx=\\"80\\" cy=\\"100\\" r=\\"5\\" stroke=\\"black\\" fill=\\"black\\" stroke-width=\\"1\\"></circle>
 <g>
-<rect x=\\"60\\" y=\\"140\\" width=\\"40\\" height=\\"40\\" stroke=\\"black\\" fill=\\"white\\" stroke-width=\\"1\\"></rect>
+<rect class=\\"gate-unitary\\" x=\\"60\\" y=\\"140\\" width=\\"40\\" height=\\"40\\" stroke=\\"black\\" stroke-width=\\"1\\"></rect>
 <text font-size=\\"14\\" font-family=\\"Arial\\" x=\\"80\\" y=\\"160\\" dominant-baseline=\\"middle\\" text-anchor=\\"middle\\" fill=\\"black\\">X</text>
 </g>
 </g>
 <g>
-<rect x=\\"60\\" y=\\"140\\" width=\\"40\\" height=\\"40\\" stroke=\\"black\\" fill=\\"white\\" stroke-width=\\"1\\"></rect>
+<rect class=\\"gate-unitary\\" x=\\"60\\" y=\\"140\\" width=\\"40\\" height=\\"40\\" stroke=\\"black\\" stroke-width=\\"1\\"></rect>
 <text font-size=\\"14\\" font-family=\\"Arial\\" x=\\"80\\" y=\\"160\\" dominant-baseline=\\"middle\\" text-anchor=\\"middle\\" fill=\\"black\\">X</text>
 </g>
 <g>
-<rect x=\\"60\\" y=\\"20\\" width=\\"40\\" height=\\"40\\" stroke=\\"black\\" fill=\\"white\\" stroke-width=\\"1\\"></rect>
+<rect class=\\"gate-measure\\" x=\\"60\\" y=\\"20\\" width=\\"40\\" height=\\"40\\" stroke=\\"black\\" stroke-width=\\"1\\"></rect>
 <path d=\\"M 95 42 A 15 12 0 0 0 65 42\\" stroke=\\"black\\" fill=\\"none\\" stroke-width=\\"1\\"></path>
 <line x1=\\"80\\" x2=\\"92\\" y1=\\"48\\" y2=\\"28\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
 </g>"

--- a/src/Kernel/client/__tests__/ExecutionPathVisualizerTests/__snapshots__/registerFormatter.test.ts.snap
+++ b/src/Kernel/client/__tests__/ExecutionPathVisualizerTests/__snapshots__/registerFormatter.test.ts.snap
@@ -1,322 +1,322 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Testing _classicalRegister register with label offset 1`] = `
-"<line x1=\\"11\\" x2=\\"11\\" y1=\\"10\\" y2=\\"19\\" stroke=\\"black\\" stroke-width=\\"0.5\\"></line>
-<line x1=\\"9\\" x2=\\"9\\" y1=\\"10\\" y2=\\"21\\" stroke=\\"black\\" stroke-width=\\"0.5\\"></line>
-<line x1=\\"11\\" x2=\\"100\\" y1=\\"19\\" y2=\\"19\\" stroke=\\"black\\" stroke-width=\\"0.5\\"></line>
-<line x1=\\"9\\" x2=\\"100\\" y1=\\"21\\" y2=\\"21\\" stroke=\\"black\\" stroke-width=\\"0.5\\"></line>"
+"<line class=\\"register-classical\\" x1=\\"11\\" x2=\\"11\\" y1=\\"10\\" y2=\\"19\\"></line>
+<line class=\\"register-classical\\" x1=\\"9\\" x2=\\"9\\" y1=\\"10\\" y2=\\"21\\"></line>
+<line class=\\"register-classical\\" x1=\\"11\\" x2=\\"100\\" y1=\\"19\\" y2=\\"19\\"></line>
+<line class=\\"register-classical\\" x1=\\"9\\" x2=\\"100\\" y1=\\"21\\" y2=\\"21\\"></line>"
 `;
 
 exports[`Testing _classicalRegister register with label offset 2`] = `
-"<line x1=\\"11\\" x2=\\"11\\" y1=\\"10\\" y2=\\"19\\" stroke=\\"black\\" stroke-width=\\"0.5\\"></line>
-<line x1=\\"9\\" x2=\\"9\\" y1=\\"10\\" y2=\\"21\\" stroke=\\"black\\" stroke-width=\\"0.5\\"></line>
-<line x1=\\"11\\" x2=\\"100\\" y1=\\"19\\" y2=\\"19\\" stroke=\\"black\\" stroke-width=\\"0.5\\"></line>
-<line x1=\\"9\\" x2=\\"100\\" y1=\\"21\\" y2=\\"21\\" stroke=\\"black\\" stroke-width=\\"0.5\\"></line>"
+"<line class=\\"register-classical\\" x1=\\"11\\" x2=\\"11\\" y1=\\"10\\" y2=\\"19\\"></line>
+<line class=\\"register-classical\\" x1=\\"9\\" x2=\\"9\\" y1=\\"10\\" y2=\\"21\\"></line>
+<line class=\\"register-classical\\" x1=\\"11\\" x2=\\"100\\" y1=\\"19\\" y2=\\"19\\"></line>
+<line class=\\"register-classical\\" x1=\\"9\\" x2=\\"100\\" y1=\\"21\\" y2=\\"21\\"></line>"
 `;
 
 exports[`Testing _classicalRegister register with label offset 3`] = `
-"<line x1=\\"11\\" x2=\\"11\\" y1=\\"10\\" y2=\\"19\\" stroke=\\"black\\" stroke-width=\\"0.5\\"></line>
-<line x1=\\"9\\" x2=\\"9\\" y1=\\"10\\" y2=\\"21\\" stroke=\\"black\\" stroke-width=\\"0.5\\"></line>
-<line x1=\\"11\\" x2=\\"100\\" y1=\\"19\\" y2=\\"19\\" stroke=\\"black\\" stroke-width=\\"0.5\\"></line>
-<line x1=\\"9\\" x2=\\"100\\" y1=\\"21\\" y2=\\"21\\" stroke=\\"black\\" stroke-width=\\"0.5\\"></line>"
+"<line class=\\"register-classical\\" x1=\\"11\\" x2=\\"11\\" y1=\\"10\\" y2=\\"19\\"></line>
+<line class=\\"register-classical\\" x1=\\"9\\" x2=\\"9\\" y1=\\"10\\" y2=\\"21\\"></line>
+<line class=\\"register-classical\\" x1=\\"11\\" x2=\\"100\\" y1=\\"19\\" y2=\\"19\\"></line>
+<line class=\\"register-classical\\" x1=\\"9\\" x2=\\"100\\" y1=\\"21\\" y2=\\"21\\"></line>"
 `;
 
 exports[`Testing _classicalRegister register with large width 1`] = `
-"<line x1=\\"11\\" x2=\\"11\\" y1=\\"10\\" y2=\\"19\\" stroke=\\"black\\" stroke-width=\\"0.5\\"></line>
-<line x1=\\"9\\" x2=\\"9\\" y1=\\"10\\" y2=\\"21\\" stroke=\\"black\\" stroke-width=\\"0.5\\"></line>
-<line x1=\\"11\\" x2=\\"500\\" y1=\\"19\\" y2=\\"19\\" stroke=\\"black\\" stroke-width=\\"0.5\\"></line>
-<line x1=\\"9\\" x2=\\"500\\" y1=\\"21\\" y2=\\"21\\" stroke=\\"black\\" stroke-width=\\"0.5\\"></line>"
+"<line class=\\"register-classical\\" x1=\\"11\\" x2=\\"11\\" y1=\\"10\\" y2=\\"19\\"></line>
+<line class=\\"register-classical\\" x1=\\"9\\" x2=\\"9\\" y1=\\"10\\" y2=\\"21\\"></line>
+<line class=\\"register-classical\\" x1=\\"11\\" x2=\\"500\\" y1=\\"19\\" y2=\\"19\\"></line>
+<line class=\\"register-classical\\" x1=\\"9\\" x2=\\"500\\" y1=\\"21\\" y2=\\"21\\"></line>"
 `;
 
 exports[`Testing _classicalRegister register with large width 2`] = `
-"<line x1=\\"11\\" x2=\\"11\\" y1=\\"10\\" y2=\\"19\\" stroke=\\"black\\" stroke-width=\\"0.5\\"></line>
-<line x1=\\"9\\" x2=\\"9\\" y1=\\"10\\" y2=\\"21\\" stroke=\\"black\\" stroke-width=\\"0.5\\"></line>
-<line x1=\\"11\\" x2=\\"500\\" y1=\\"19\\" y2=\\"19\\" stroke=\\"black\\" stroke-width=\\"0.5\\"></line>
-<line x1=\\"9\\" x2=\\"500\\" y1=\\"21\\" y2=\\"21\\" stroke=\\"black\\" stroke-width=\\"0.5\\"></line>"
+"<line class=\\"register-classical\\" x1=\\"11\\" x2=\\"11\\" y1=\\"10\\" y2=\\"19\\"></line>
+<line class=\\"register-classical\\" x1=\\"9\\" x2=\\"9\\" y1=\\"10\\" y2=\\"21\\"></line>
+<line class=\\"register-classical\\" x1=\\"11\\" x2=\\"500\\" y1=\\"19\\" y2=\\"19\\"></line>
+<line class=\\"register-classical\\" x1=\\"9\\" x2=\\"500\\" y1=\\"21\\" y2=\\"21\\"></line>"
 `;
 
 exports[`Testing _classicalRegister register with large width 3`] = `
-"<line x1=\\"11\\" x2=\\"11\\" y1=\\"10\\" y2=\\"19\\" stroke=\\"black\\" stroke-width=\\"0.5\\"></line>
-<line x1=\\"9\\" x2=\\"9\\" y1=\\"10\\" y2=\\"21\\" stroke=\\"black\\" stroke-width=\\"0.5\\"></line>
-<line x1=\\"11\\" x2=\\"500\\" y1=\\"19\\" y2=\\"19\\" stroke=\\"black\\" stroke-width=\\"0.5\\"></line>
-<line x1=\\"9\\" x2=\\"500\\" y1=\\"21\\" y2=\\"21\\" stroke=\\"black\\" stroke-width=\\"0.5\\"></line>"
+"<line class=\\"register-classical\\" x1=\\"11\\" x2=\\"11\\" y1=\\"10\\" y2=\\"19\\"></line>
+<line class=\\"register-classical\\" x1=\\"9\\" x2=\\"9\\" y1=\\"10\\" y2=\\"21\\"></line>
+<line class=\\"register-classical\\" x1=\\"11\\" x2=\\"500\\" y1=\\"19\\" y2=\\"19\\"></line>
+<line class=\\"register-classical\\" x1=\\"9\\" x2=\\"500\\" y1=\\"21\\" y2=\\"21\\"></line>"
 `;
 
 exports[`Testing _classicalRegister register with normal width 1`] = `
-"<line x1=\\"11\\" x2=\\"11\\" y1=\\"10\\" y2=\\"19\\" stroke=\\"black\\" stroke-width=\\"0.5\\"></line>
-<line x1=\\"9\\" x2=\\"9\\" y1=\\"10\\" y2=\\"21\\" stroke=\\"black\\" stroke-width=\\"0.5\\"></line>
-<line x1=\\"11\\" x2=\\"100\\" y1=\\"19\\" y2=\\"19\\" stroke=\\"black\\" stroke-width=\\"0.5\\"></line>
-<line x1=\\"9\\" x2=\\"100\\" y1=\\"21\\" y2=\\"21\\" stroke=\\"black\\" stroke-width=\\"0.5\\"></line>"
+"<line class=\\"register-classical\\" x1=\\"11\\" x2=\\"11\\" y1=\\"10\\" y2=\\"19\\"></line>
+<line class=\\"register-classical\\" x1=\\"9\\" x2=\\"9\\" y1=\\"10\\" y2=\\"21\\"></line>
+<line class=\\"register-classical\\" x1=\\"11\\" x2=\\"100\\" y1=\\"19\\" y2=\\"19\\"></line>
+<line class=\\"register-classical\\" x1=\\"9\\" x2=\\"100\\" y1=\\"21\\" y2=\\"21\\"></line>"
 `;
 
 exports[`Testing _classicalRegister register with normal width 2`] = `
-"<line x1=\\"11\\" x2=\\"11\\" y1=\\"10\\" y2=\\"19\\" stroke=\\"black\\" stroke-width=\\"0.5\\"></line>
-<line x1=\\"9\\" x2=\\"9\\" y1=\\"10\\" y2=\\"21\\" stroke=\\"black\\" stroke-width=\\"0.5\\"></line>
-<line x1=\\"11\\" x2=\\"100\\" y1=\\"19\\" y2=\\"19\\" stroke=\\"black\\" stroke-width=\\"0.5\\"></line>
-<line x1=\\"9\\" x2=\\"100\\" y1=\\"21\\" y2=\\"21\\" stroke=\\"black\\" stroke-width=\\"0.5\\"></line>"
+"<line class=\\"register-classical\\" x1=\\"11\\" x2=\\"11\\" y1=\\"10\\" y2=\\"19\\"></line>
+<line class=\\"register-classical\\" x1=\\"9\\" x2=\\"9\\" y1=\\"10\\" y2=\\"21\\"></line>
+<line class=\\"register-classical\\" x1=\\"11\\" x2=\\"100\\" y1=\\"19\\" y2=\\"19\\"></line>
+<line class=\\"register-classical\\" x1=\\"9\\" x2=\\"100\\" y1=\\"21\\" y2=\\"21\\"></line>"
 `;
 
 exports[`Testing _classicalRegister register with normal width 3`] = `
-"<line x1=\\"11\\" x2=\\"11\\" y1=\\"10\\" y2=\\"19\\" stroke=\\"black\\" stroke-width=\\"0.5\\"></line>
-<line x1=\\"9\\" x2=\\"9\\" y1=\\"10\\" y2=\\"21\\" stroke=\\"black\\" stroke-width=\\"0.5\\"></line>
-<line x1=\\"11\\" x2=\\"100\\" y1=\\"19\\" y2=\\"19\\" stroke=\\"black\\" stroke-width=\\"0.5\\"></line>
-<line x1=\\"9\\" x2=\\"100\\" y1=\\"21\\" y2=\\"21\\" stroke=\\"black\\" stroke-width=\\"0.5\\"></line>"
+"<line class=\\"register-classical\\" x1=\\"11\\" x2=\\"11\\" y1=\\"10\\" y2=\\"19\\"></line>
+<line class=\\"register-classical\\" x1=\\"9\\" x2=\\"9\\" y1=\\"10\\" y2=\\"21\\"></line>
+<line class=\\"register-classical\\" x1=\\"11\\" x2=\\"100\\" y1=\\"19\\" y2=\\"19\\"></line>
+<line class=\\"register-classical\\" x1=\\"9\\" x2=\\"100\\" y1=\\"21\\" y2=\\"21\\"></line>"
 `;
 
 exports[`Testing _classicalRegister register with small width 1`] = `
-"<line x1=\\"11\\" x2=\\"11\\" y1=\\"10\\" y2=\\"19\\" stroke=\\"black\\" stroke-width=\\"0.5\\"></line>
-<line x1=\\"9\\" x2=\\"9\\" y1=\\"10\\" y2=\\"21\\" stroke=\\"black\\" stroke-width=\\"0.5\\"></line>
-<line x1=\\"11\\" x2=\\"5\\" y1=\\"19\\" y2=\\"19\\" stroke=\\"black\\" stroke-width=\\"0.5\\"></line>
-<line x1=\\"9\\" x2=\\"5\\" y1=\\"21\\" y2=\\"21\\" stroke=\\"black\\" stroke-width=\\"0.5\\"></line>"
+"<line class=\\"register-classical\\" x1=\\"11\\" x2=\\"11\\" y1=\\"10\\" y2=\\"19\\"></line>
+<line class=\\"register-classical\\" x1=\\"9\\" x2=\\"9\\" y1=\\"10\\" y2=\\"21\\"></line>
+<line class=\\"register-classical\\" x1=\\"11\\" x2=\\"5\\" y1=\\"19\\" y2=\\"19\\"></line>
+<line class=\\"register-classical\\" x1=\\"9\\" x2=\\"5\\" y1=\\"21\\" y2=\\"21\\"></line>"
 `;
 
 exports[`Testing _classicalRegister register with small width 2`] = `
-"<line x1=\\"11\\" x2=\\"11\\" y1=\\"10\\" y2=\\"19\\" stroke=\\"black\\" stroke-width=\\"0.5\\"></line>
-<line x1=\\"9\\" x2=\\"9\\" y1=\\"10\\" y2=\\"21\\" stroke=\\"black\\" stroke-width=\\"0.5\\"></line>
-<line x1=\\"11\\" x2=\\"5\\" y1=\\"19\\" y2=\\"19\\" stroke=\\"black\\" stroke-width=\\"0.5\\"></line>
-<line x1=\\"9\\" x2=\\"5\\" y1=\\"21\\" y2=\\"21\\" stroke=\\"black\\" stroke-width=\\"0.5\\"></line>"
+"<line class=\\"register-classical\\" x1=\\"11\\" x2=\\"11\\" y1=\\"10\\" y2=\\"19\\"></line>
+<line class=\\"register-classical\\" x1=\\"9\\" x2=\\"9\\" y1=\\"10\\" y2=\\"21\\"></line>
+<line class=\\"register-classical\\" x1=\\"11\\" x2=\\"5\\" y1=\\"19\\" y2=\\"19\\"></line>
+<line class=\\"register-classical\\" x1=\\"9\\" x2=\\"5\\" y1=\\"21\\" y2=\\"21\\"></line>"
 `;
 
 exports[`Testing _classicalRegister register with small width 3`] = `
-"<line x1=\\"11\\" x2=\\"11\\" y1=\\"10\\" y2=\\"19\\" stroke=\\"black\\" stroke-width=\\"0.5\\"></line>
-<line x1=\\"9\\" x2=\\"9\\" y1=\\"10\\" y2=\\"21\\" stroke=\\"black\\" stroke-width=\\"0.5\\"></line>
-<line x1=\\"11\\" x2=\\"5\\" y1=\\"19\\" y2=\\"19\\" stroke=\\"black\\" stroke-width=\\"0.5\\"></line>
-<line x1=\\"9\\" x2=\\"5\\" y1=\\"21\\" y2=\\"21\\" stroke=\\"black\\" stroke-width=\\"0.5\\"></line>"
+"<line class=\\"register-classical\\" x1=\\"11\\" x2=\\"11\\" y1=\\"10\\" y2=\\"19\\"></line>
+<line class=\\"register-classical\\" x1=\\"9\\" x2=\\"9\\" y1=\\"10\\" y2=\\"21\\"></line>
+<line class=\\"register-classical\\" x1=\\"11\\" x2=\\"5\\" y1=\\"19\\" y2=\\"19\\"></line>
+<line class=\\"register-classical\\" x1=\\"9\\" x2=\\"5\\" y1=\\"21\\" y2=\\"21\\"></line>"
 `;
 
 exports[`Testing _qubitRegister register with label offset 1`] = `
-"<line x1=\\"40\\" x2=\\"100\\" y1=\\"20\\" y2=\\"20\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
+"<line x1=\\"40\\" x2=\\"100\\" y1=\\"20\\" y2=\\"20\\"></line>
 <text x=\\"40\\" y=\\"20\\" dominant-baseline=\\"hanging\\" text-anchor=\\"start\\" font-size=\\"75%\\">q0</text>"
 `;
 
 exports[`Testing _qubitRegister register with label offset 2`] = `
-"<line x1=\\"40\\" x2=\\"100\\" y1=\\"20\\" y2=\\"20\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
+"<line x1=\\"40\\" x2=\\"100\\" y1=\\"20\\" y2=\\"20\\"></line>
 <text x=\\"40\\" y=\\"15\\" dominant-baseline=\\"hanging\\" text-anchor=\\"start\\" font-size=\\"75%\\">q1</text>"
 `;
 
 exports[`Testing _qubitRegister register with label offset 3`] = `
-"<line x1=\\"40\\" x2=\\"100\\" y1=\\"20\\" y2=\\"20\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
+"<line x1=\\"40\\" x2=\\"100\\" y1=\\"20\\" y2=\\"20\\"></line>
 <text x=\\"40\\" y=\\"-30\\" dominant-baseline=\\"hanging\\" text-anchor=\\"start\\" font-size=\\"75%\\">q2</text>"
 `;
 
 exports[`Testing _qubitRegister register with large width 1`] = `
-"<line x1=\\"40\\" x2=\\"500\\" y1=\\"20\\" y2=\\"20\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
+"<line x1=\\"40\\" x2=\\"500\\" y1=\\"20\\" y2=\\"20\\"></line>
 <text x=\\"40\\" y=\\"4\\" dominant-baseline=\\"hanging\\" text-anchor=\\"start\\" font-size=\\"75%\\">q0</text>"
 `;
 
 exports[`Testing _qubitRegister register with large width 2`] = `
-"<line x1=\\"40\\" x2=\\"500\\" y1=\\"20\\" y2=\\"20\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
+"<line x1=\\"40\\" x2=\\"500\\" y1=\\"20\\" y2=\\"20\\"></line>
 <text x=\\"40\\" y=\\"4\\" dominant-baseline=\\"hanging\\" text-anchor=\\"start\\" font-size=\\"75%\\">q1</text>"
 `;
 
 exports[`Testing _qubitRegister register with large width 3`] = `
-"<line x1=\\"40\\" x2=\\"500\\" y1=\\"20\\" y2=\\"20\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
+"<line x1=\\"40\\" x2=\\"500\\" y1=\\"20\\" y2=\\"20\\"></line>
 <text x=\\"40\\" y=\\"4\\" dominant-baseline=\\"hanging\\" text-anchor=\\"start\\" font-size=\\"75%\\">q2</text>"
 `;
 
 exports[`Testing _qubitRegister register with normal width 1`] = `
-"<line x1=\\"40\\" x2=\\"100\\" y1=\\"20\\" y2=\\"20\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
+"<line x1=\\"40\\" x2=\\"100\\" y1=\\"20\\" y2=\\"20\\"></line>
 <text x=\\"40\\" y=\\"4\\" dominant-baseline=\\"hanging\\" text-anchor=\\"start\\" font-size=\\"75%\\">q0</text>"
 `;
 
 exports[`Testing _qubitRegister register with normal width 2`] = `
-"<line x1=\\"40\\" x2=\\"100\\" y1=\\"20\\" y2=\\"20\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
+"<line x1=\\"40\\" x2=\\"100\\" y1=\\"20\\" y2=\\"20\\"></line>
 <text x=\\"40\\" y=\\"4\\" dominant-baseline=\\"hanging\\" text-anchor=\\"start\\" font-size=\\"75%\\">q1</text>"
 `;
 
 exports[`Testing _qubitRegister register with normal width 3`] = `
-"<line x1=\\"40\\" x2=\\"100\\" y1=\\"20\\" y2=\\"20\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
+"<line x1=\\"40\\" x2=\\"100\\" y1=\\"20\\" y2=\\"20\\"></line>
 <text x=\\"40\\" y=\\"4\\" dominant-baseline=\\"hanging\\" text-anchor=\\"start\\" font-size=\\"75%\\">q2</text>"
 `;
 
 exports[`Testing _qubitRegister register with small width 1`] = `
-"<line x1=\\"40\\" x2=\\"5\\" y1=\\"20\\" y2=\\"20\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
+"<line x1=\\"40\\" x2=\\"5\\" y1=\\"20\\" y2=\\"20\\"></line>
 <text x=\\"40\\" y=\\"4\\" dominant-baseline=\\"hanging\\" text-anchor=\\"start\\" font-size=\\"75%\\">q0</text>"
 `;
 
 exports[`Testing _qubitRegister register with small width 2`] = `
-"<line x1=\\"40\\" x2=\\"5\\" y1=\\"20\\" y2=\\"20\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
+"<line x1=\\"40\\" x2=\\"5\\" y1=\\"20\\" y2=\\"20\\"></line>
 <text x=\\"40\\" y=\\"4\\" dominant-baseline=\\"hanging\\" text-anchor=\\"start\\" font-size=\\"75%\\">q1</text>"
 `;
 
 exports[`Testing _qubitRegister register with small width 3`] = `
-"<line x1=\\"40\\" x2=\\"5\\" y1=\\"20\\" y2=\\"20\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
+"<line x1=\\"40\\" x2=\\"5\\" y1=\\"20\\" y2=\\"20\\"></line>
 <text x=\\"40\\" y=\\"4\\" dominant-baseline=\\"hanging\\" text-anchor=\\"start\\" font-size=\\"75%\\">q2</text>"
 `;
 
 exports[`Testing formatRegisters 1 quantum register 1`] = `
-"<line x1=\\"40\\" x2=\\"180\\" y1=\\"40\\" y2=\\"40\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
+"<line x1=\\"40\\" x2=\\"180\\" y1=\\"40\\" y2=\\"40\\"></line>
 <text x=\\"40\\" y=\\"24\\" dominant-baseline=\\"hanging\\" text-anchor=\\"start\\" font-size=\\"75%\\">q0</text>"
 `;
 
 exports[`Testing formatRegisters 1 quantum register 2`] = `
-"<line x1=\\"40\\" x2=\\"85\\" y1=\\"40\\" y2=\\"40\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
+"<line x1=\\"40\\" x2=\\"85\\" y1=\\"40\\" y2=\\"40\\"></line>
 <text x=\\"40\\" y=\\"24\\" dominant-baseline=\\"hanging\\" text-anchor=\\"start\\" font-size=\\"75%\\">q0</text>"
 `;
 
 exports[`Testing formatRegisters 1 quantum register 3`] = `
-"<line x1=\\"40\\" x2=\\"580\\" y1=\\"40\\" y2=\\"40\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
+"<line x1=\\"40\\" x2=\\"580\\" y1=\\"40\\" y2=\\"40\\"></line>
 <text x=\\"40\\" y=\\"24\\" dominant-baseline=\\"hanging\\" text-anchor=\\"start\\" font-size=\\"75%\\">q0</text>"
 `;
 
 exports[`Testing formatRegisters Multiple quantum registers 1`] = `
-"<line x1=\\"40\\" x2=\\"180\\" y1=\\"40\\" y2=\\"40\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
+"<line x1=\\"40\\" x2=\\"180\\" y1=\\"40\\" y2=\\"40\\"></line>
 <text x=\\"40\\" y=\\"24\\" dominant-baseline=\\"hanging\\" text-anchor=\\"start\\" font-size=\\"75%\\">q0</text>
-<line x1=\\"40\\" x2=\\"180\\" y1=\\"100\\" y2=\\"100\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
+<line x1=\\"40\\" x2=\\"180\\" y1=\\"100\\" y2=\\"100\\"></line>
 <text x=\\"40\\" y=\\"84\\" dominant-baseline=\\"hanging\\" text-anchor=\\"start\\" font-size=\\"75%\\">q1</text>
-<line x1=\\"40\\" x2=\\"180\\" y1=\\"160\\" y2=\\"160\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
+<line x1=\\"40\\" x2=\\"180\\" y1=\\"160\\" y2=\\"160\\"></line>
 <text x=\\"40\\" y=\\"144\\" dominant-baseline=\\"hanging\\" text-anchor=\\"start\\" font-size=\\"75%\\">q2</text>
-<line x1=\\"40\\" x2=\\"180\\" y1=\\"220\\" y2=\\"220\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
+<line x1=\\"40\\" x2=\\"180\\" y1=\\"220\\" y2=\\"220\\"></line>
 <text x=\\"40\\" y=\\"204\\" dominant-baseline=\\"hanging\\" text-anchor=\\"start\\" font-size=\\"75%\\">q3</text>"
 `;
 
 exports[`Testing formatRegisters Multiple quantum registers 2`] = `
-"<line x1=\\"40\\" x2=\\"85\\" y1=\\"40\\" y2=\\"40\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
+"<line x1=\\"40\\" x2=\\"85\\" y1=\\"40\\" y2=\\"40\\"></line>
 <text x=\\"40\\" y=\\"24\\" dominant-baseline=\\"hanging\\" text-anchor=\\"start\\" font-size=\\"75%\\">q0</text>
-<line x1=\\"40\\" x2=\\"85\\" y1=\\"100\\" y2=\\"100\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
+<line x1=\\"40\\" x2=\\"85\\" y1=\\"100\\" y2=\\"100\\"></line>
 <text x=\\"40\\" y=\\"84\\" dominant-baseline=\\"hanging\\" text-anchor=\\"start\\" font-size=\\"75%\\">q1</text>
-<line x1=\\"40\\" x2=\\"85\\" y1=\\"160\\" y2=\\"160\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
+<line x1=\\"40\\" x2=\\"85\\" y1=\\"160\\" y2=\\"160\\"></line>
 <text x=\\"40\\" y=\\"144\\" dominant-baseline=\\"hanging\\" text-anchor=\\"start\\" font-size=\\"75%\\">q2</text>
-<line x1=\\"40\\" x2=\\"85\\" y1=\\"220\\" y2=\\"220\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
+<line x1=\\"40\\" x2=\\"85\\" y1=\\"220\\" y2=\\"220\\"></line>
 <text x=\\"40\\" y=\\"204\\" dominant-baseline=\\"hanging\\" text-anchor=\\"start\\" font-size=\\"75%\\">q3</text>"
 `;
 
 exports[`Testing formatRegisters Multiple quantum registers 3`] = `
-"<line x1=\\"40\\" x2=\\"580\\" y1=\\"40\\" y2=\\"40\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
+"<line x1=\\"40\\" x2=\\"580\\" y1=\\"40\\" y2=\\"40\\"></line>
 <text x=\\"40\\" y=\\"24\\" dominant-baseline=\\"hanging\\" text-anchor=\\"start\\" font-size=\\"75%\\">q0</text>
-<line x1=\\"40\\" x2=\\"580\\" y1=\\"100\\" y2=\\"100\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
+<line x1=\\"40\\" x2=\\"580\\" y1=\\"100\\" y2=\\"100\\"></line>
 <text x=\\"40\\" y=\\"84\\" dominant-baseline=\\"hanging\\" text-anchor=\\"start\\" font-size=\\"75%\\">q1</text>
-<line x1=\\"40\\" x2=\\"580\\" y1=\\"160\\" y2=\\"160\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
+<line x1=\\"40\\" x2=\\"580\\" y1=\\"160\\" y2=\\"160\\"></line>
 <text x=\\"40\\" y=\\"144\\" dominant-baseline=\\"hanging\\" text-anchor=\\"start\\" font-size=\\"75%\\">q2</text>
-<line x1=\\"40\\" x2=\\"580\\" y1=\\"220\\" y2=\\"220\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
+<line x1=\\"40\\" x2=\\"580\\" y1=\\"220\\" y2=\\"220\\"></line>
 <text x=\\"40\\" y=\\"204\\" dominant-baseline=\\"hanging\\" text-anchor=\\"start\\" font-size=\\"75%\\">q3</text>"
 `;
 
 exports[`Testing formatRegisters Quantum and classical registers 1`] = `
-"<line x1=\\"40\\" x2=\\"180\\" y1=\\"40\\" y2=\\"40\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
+"<line x1=\\"40\\" x2=\\"180\\" y1=\\"40\\" y2=\\"40\\"></line>
 <text x=\\"40\\" y=\\"24\\" dominant-baseline=\\"hanging\\" text-anchor=\\"start\\" font-size=\\"75%\\">q0</text>
-<line x1=\\"40\\" x2=\\"180\\" y1=\\"120\\" y2=\\"120\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
+<line x1=\\"40\\" x2=\\"180\\" y1=\\"120\\" y2=\\"120\\"></line>
 <text x=\\"40\\" y=\\"104\\" dominant-baseline=\\"hanging\\" text-anchor=\\"start\\" font-size=\\"75%\\">q1</text>
-<line x1=\\"40\\" x2=\\"180\\" y1=\\"180\\" y2=\\"180\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
+<line x1=\\"40\\" x2=\\"180\\" y1=\\"180\\" y2=\\"180\\"></line>
 <text x=\\"40\\" y=\\"164\\" dominant-baseline=\\"hanging\\" text-anchor=\\"start\\" font-size=\\"75%\\">q2</text>
-<line x1=\\"81\\" x2=\\"81\\" y1=\\"40\\" y2=\\"79\\" stroke=\\"black\\" stroke-width=\\"0.5\\"></line>
-<line x1=\\"79\\" x2=\\"79\\" y1=\\"40\\" y2=\\"81\\" stroke=\\"black\\" stroke-width=\\"0.5\\"></line>
-<line x1=\\"81\\" x2=\\"180\\" y1=\\"79\\" y2=\\"79\\" stroke=\\"black\\" stroke-width=\\"0.5\\"></line>
-<line x1=\\"79\\" x2=\\"180\\" y1=\\"81\\" y2=\\"81\\" stroke=\\"black\\" stroke-width=\\"0.5\\"></line>"
+<line class=\\"register-classical\\" x1=\\"81\\" x2=\\"81\\" y1=\\"40\\" y2=\\"79\\"></line>
+<line class=\\"register-classical\\" x1=\\"79\\" x2=\\"79\\" y1=\\"40\\" y2=\\"81\\"></line>
+<line class=\\"register-classical\\" x1=\\"81\\" x2=\\"180\\" y1=\\"79\\" y2=\\"79\\"></line>
+<line class=\\"register-classical\\" x1=\\"79\\" x2=\\"180\\" y1=\\"81\\" y2=\\"81\\"></line>"
 `;
 
 exports[`Testing formatRegisters Quantum and classical registers 2`] = `
-"<line x1=\\"40\\" x2=\\"85\\" y1=\\"40\\" y2=\\"40\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
+"<line x1=\\"40\\" x2=\\"85\\" y1=\\"40\\" y2=\\"40\\"></line>
 <text x=\\"40\\" y=\\"24\\" dominant-baseline=\\"hanging\\" text-anchor=\\"start\\" font-size=\\"75%\\">q0</text>
-<line x1=\\"40\\" x2=\\"85\\" y1=\\"120\\" y2=\\"120\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
+<line x1=\\"40\\" x2=\\"85\\" y1=\\"120\\" y2=\\"120\\"></line>
 <text x=\\"40\\" y=\\"104\\" dominant-baseline=\\"hanging\\" text-anchor=\\"start\\" font-size=\\"75%\\">q1</text>
-<line x1=\\"40\\" x2=\\"85\\" y1=\\"180\\" y2=\\"180\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
+<line x1=\\"40\\" x2=\\"85\\" y1=\\"180\\" y2=\\"180\\"></line>
 <text x=\\"40\\" y=\\"164\\" dominant-baseline=\\"hanging\\" text-anchor=\\"start\\" font-size=\\"75%\\">q2</text>
-<line x1=\\"81\\" x2=\\"81\\" y1=\\"40\\" y2=\\"79\\" stroke=\\"black\\" stroke-width=\\"0.5\\"></line>
-<line x1=\\"79\\" x2=\\"79\\" y1=\\"40\\" y2=\\"81\\" stroke=\\"black\\" stroke-width=\\"0.5\\"></line>
-<line x1=\\"81\\" x2=\\"85\\" y1=\\"79\\" y2=\\"79\\" stroke=\\"black\\" stroke-width=\\"0.5\\"></line>
-<line x1=\\"79\\" x2=\\"85\\" y1=\\"81\\" y2=\\"81\\" stroke=\\"black\\" stroke-width=\\"0.5\\"></line>"
+<line class=\\"register-classical\\" x1=\\"81\\" x2=\\"81\\" y1=\\"40\\" y2=\\"79\\"></line>
+<line class=\\"register-classical\\" x1=\\"79\\" x2=\\"79\\" y1=\\"40\\" y2=\\"81\\"></line>
+<line class=\\"register-classical\\" x1=\\"81\\" x2=\\"85\\" y1=\\"79\\" y2=\\"79\\"></line>
+<line class=\\"register-classical\\" x1=\\"79\\" x2=\\"85\\" y1=\\"81\\" y2=\\"81\\"></line>"
 `;
 
 exports[`Testing formatRegisters Quantum and classical registers 3`] = `
-"<line x1=\\"40\\" x2=\\"580\\" y1=\\"40\\" y2=\\"40\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
+"<line x1=\\"40\\" x2=\\"580\\" y1=\\"40\\" y2=\\"40\\"></line>
 <text x=\\"40\\" y=\\"24\\" dominant-baseline=\\"hanging\\" text-anchor=\\"start\\" font-size=\\"75%\\">q0</text>
-<line x1=\\"40\\" x2=\\"580\\" y1=\\"120\\" y2=\\"120\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
+<line x1=\\"40\\" x2=\\"580\\" y1=\\"120\\" y2=\\"120\\"></line>
 <text x=\\"40\\" y=\\"104\\" dominant-baseline=\\"hanging\\" text-anchor=\\"start\\" font-size=\\"75%\\">q1</text>
-<line x1=\\"40\\" x2=\\"580\\" y1=\\"180\\" y2=\\"180\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
+<line x1=\\"40\\" x2=\\"580\\" y1=\\"180\\" y2=\\"180\\"></line>
 <text x=\\"40\\" y=\\"164\\" dominant-baseline=\\"hanging\\" text-anchor=\\"start\\" font-size=\\"75%\\">q2</text>
-<line x1=\\"81\\" x2=\\"81\\" y1=\\"40\\" y2=\\"79\\" stroke=\\"black\\" stroke-width=\\"0.5\\"></line>
-<line x1=\\"79\\" x2=\\"79\\" y1=\\"40\\" y2=\\"81\\" stroke=\\"black\\" stroke-width=\\"0.5\\"></line>
-<line x1=\\"81\\" x2=\\"580\\" y1=\\"79\\" y2=\\"79\\" stroke=\\"black\\" stroke-width=\\"0.5\\"></line>
-<line x1=\\"79\\" x2=\\"580\\" y1=\\"81\\" y2=\\"81\\" stroke=\\"black\\" stroke-width=\\"0.5\\"></line>"
+<line class=\\"register-classical\\" x1=\\"81\\" x2=\\"81\\" y1=\\"40\\" y2=\\"79\\"></line>
+<line class=\\"register-classical\\" x1=\\"79\\" x2=\\"79\\" y1=\\"40\\" y2=\\"81\\"></line>
+<line class=\\"register-classical\\" x1=\\"81\\" x2=\\"580\\" y1=\\"79\\" y2=\\"79\\"></line>
+<line class=\\"register-classical\\" x1=\\"79\\" x2=\\"580\\" y1=\\"81\\" y2=\\"81\\"></line>"
 `;
 
 exports[`Testing formatRegisters Quantum and classical registers 4`] = `
-"<line x1=\\"40\\" x2=\\"180\\" y1=\\"40\\" y2=\\"40\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
+"<line x1=\\"40\\" x2=\\"180\\" y1=\\"40\\" y2=\\"40\\"></line>
 <text x=\\"40\\" y=\\"24\\" dominant-baseline=\\"hanging\\" text-anchor=\\"start\\" font-size=\\"75%\\">q0</text>
-<line x1=\\"40\\" x2=\\"180\\" y1=\\"100\\" y2=\\"100\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
+<line x1=\\"40\\" x2=\\"180\\" y1=\\"100\\" y2=\\"100\\"></line>
 <text x=\\"40\\" y=\\"84\\" dominant-baseline=\\"hanging\\" text-anchor=\\"start\\" font-size=\\"75%\\">q1</text>
-<line x1=\\"40\\" x2=\\"180\\" y1=\\"220\\" y2=\\"220\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
+<line x1=\\"40\\" x2=\\"180\\" y1=\\"220\\" y2=\\"220\\"></line>
 <text x=\\"40\\" y=\\"204\\" dominant-baseline=\\"hanging\\" text-anchor=\\"start\\" font-size=\\"75%\\">q2</text>
-<line x1=\\"81\\" x2=\\"81\\" y1=\\"40\\" y2=\\"79\\" stroke=\\"black\\" stroke-width=\\"0.5\\"></line>
-<line x1=\\"79\\" x2=\\"79\\" y1=\\"40\\" y2=\\"81\\" stroke=\\"black\\" stroke-width=\\"0.5\\"></line>
-<line x1=\\"81\\" x2=\\"180\\" y1=\\"79\\" y2=\\"79\\" stroke=\\"black\\" stroke-width=\\"0.5\\"></line>
-<line x1=\\"79\\" x2=\\"180\\" y1=\\"81\\" y2=\\"81\\" stroke=\\"black\\" stroke-width=\\"0.5\\"></line>
-<line x1=\\"81\\" x2=\\"81\\" y1=\\"40\\" y2=\\"119\\" stroke=\\"black\\" stroke-width=\\"0.5\\"></line>
-<line x1=\\"79\\" x2=\\"79\\" y1=\\"40\\" y2=\\"121\\" stroke=\\"black\\" stroke-width=\\"0.5\\"></line>
-<line x1=\\"81\\" x2=\\"180\\" y1=\\"119\\" y2=\\"119\\" stroke=\\"black\\" stroke-width=\\"0.5\\"></line>
-<line x1=\\"79\\" x2=\\"180\\" y1=\\"121\\" y2=\\"121\\" stroke=\\"black\\" stroke-width=\\"0.5\\"></line>
-<line x1=\\"81\\" x2=\\"81\\" y1=\\"160\\" y2=\\"199\\" stroke=\\"black\\" stroke-width=\\"0.5\\"></line>
-<line x1=\\"79\\" x2=\\"79\\" y1=\\"160\\" y2=\\"201\\" stroke=\\"black\\" stroke-width=\\"0.5\\"></line>
-<line x1=\\"81\\" x2=\\"180\\" y1=\\"199\\" y2=\\"199\\" stroke=\\"black\\" stroke-width=\\"0.5\\"></line>
-<line x1=\\"79\\" x2=\\"180\\" y1=\\"201\\" y2=\\"201\\" stroke=\\"black\\" stroke-width=\\"0.5\\"></line>"
+<line class=\\"register-classical\\" x1=\\"81\\" x2=\\"81\\" y1=\\"40\\" y2=\\"79\\"></line>
+<line class=\\"register-classical\\" x1=\\"79\\" x2=\\"79\\" y1=\\"40\\" y2=\\"81\\"></line>
+<line class=\\"register-classical\\" x1=\\"81\\" x2=\\"180\\" y1=\\"79\\" y2=\\"79\\"></line>
+<line class=\\"register-classical\\" x1=\\"79\\" x2=\\"180\\" y1=\\"81\\" y2=\\"81\\"></line>
+<line class=\\"register-classical\\" x1=\\"81\\" x2=\\"81\\" y1=\\"40\\" y2=\\"119\\"></line>
+<line class=\\"register-classical\\" x1=\\"79\\" x2=\\"79\\" y1=\\"40\\" y2=\\"121\\"></line>
+<line class=\\"register-classical\\" x1=\\"81\\" x2=\\"180\\" y1=\\"119\\" y2=\\"119\\"></line>
+<line class=\\"register-classical\\" x1=\\"79\\" x2=\\"180\\" y1=\\"121\\" y2=\\"121\\"></line>
+<line class=\\"register-classical\\" x1=\\"81\\" x2=\\"81\\" y1=\\"160\\" y2=\\"199\\"></line>
+<line class=\\"register-classical\\" x1=\\"79\\" x2=\\"79\\" y1=\\"160\\" y2=\\"201\\"></line>
+<line class=\\"register-classical\\" x1=\\"81\\" x2=\\"180\\" y1=\\"199\\" y2=\\"199\\"></line>
+<line class=\\"register-classical\\" x1=\\"79\\" x2=\\"180\\" y1=\\"201\\" y2=\\"201\\"></line>"
 `;
 
 exports[`Testing formatRegisters Quantum and classical registers 5`] = `
-"<line x1=\\"40\\" x2=\\"85\\" y1=\\"40\\" y2=\\"40\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
+"<line x1=\\"40\\" x2=\\"85\\" y1=\\"40\\" y2=\\"40\\"></line>
 <text x=\\"40\\" y=\\"24\\" dominant-baseline=\\"hanging\\" text-anchor=\\"start\\" font-size=\\"75%\\">q0</text>
-<line x1=\\"40\\" x2=\\"85\\" y1=\\"100\\" y2=\\"100\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
+<line x1=\\"40\\" x2=\\"85\\" y1=\\"100\\" y2=\\"100\\"></line>
 <text x=\\"40\\" y=\\"84\\" dominant-baseline=\\"hanging\\" text-anchor=\\"start\\" font-size=\\"75%\\">q1</text>
-<line x1=\\"40\\" x2=\\"85\\" y1=\\"220\\" y2=\\"220\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
+<line x1=\\"40\\" x2=\\"85\\" y1=\\"220\\" y2=\\"220\\"></line>
 <text x=\\"40\\" y=\\"204\\" dominant-baseline=\\"hanging\\" text-anchor=\\"start\\" font-size=\\"75%\\">q2</text>
-<line x1=\\"81\\" x2=\\"81\\" y1=\\"40\\" y2=\\"79\\" stroke=\\"black\\" stroke-width=\\"0.5\\"></line>
-<line x1=\\"79\\" x2=\\"79\\" y1=\\"40\\" y2=\\"81\\" stroke=\\"black\\" stroke-width=\\"0.5\\"></line>
-<line x1=\\"81\\" x2=\\"85\\" y1=\\"79\\" y2=\\"79\\" stroke=\\"black\\" stroke-width=\\"0.5\\"></line>
-<line x1=\\"79\\" x2=\\"85\\" y1=\\"81\\" y2=\\"81\\" stroke=\\"black\\" stroke-width=\\"0.5\\"></line>
-<line x1=\\"81\\" x2=\\"81\\" y1=\\"40\\" y2=\\"119\\" stroke=\\"black\\" stroke-width=\\"0.5\\"></line>
-<line x1=\\"79\\" x2=\\"79\\" y1=\\"40\\" y2=\\"121\\" stroke=\\"black\\" stroke-width=\\"0.5\\"></line>
-<line x1=\\"81\\" x2=\\"85\\" y1=\\"119\\" y2=\\"119\\" stroke=\\"black\\" stroke-width=\\"0.5\\"></line>
-<line x1=\\"79\\" x2=\\"85\\" y1=\\"121\\" y2=\\"121\\" stroke=\\"black\\" stroke-width=\\"0.5\\"></line>
-<line x1=\\"81\\" x2=\\"81\\" y1=\\"160\\" y2=\\"199\\" stroke=\\"black\\" stroke-width=\\"0.5\\"></line>
-<line x1=\\"79\\" x2=\\"79\\" y1=\\"160\\" y2=\\"201\\" stroke=\\"black\\" stroke-width=\\"0.5\\"></line>
-<line x1=\\"81\\" x2=\\"85\\" y1=\\"199\\" y2=\\"199\\" stroke=\\"black\\" stroke-width=\\"0.5\\"></line>
-<line x1=\\"79\\" x2=\\"85\\" y1=\\"201\\" y2=\\"201\\" stroke=\\"black\\" stroke-width=\\"0.5\\"></line>"
+<line class=\\"register-classical\\" x1=\\"81\\" x2=\\"81\\" y1=\\"40\\" y2=\\"79\\"></line>
+<line class=\\"register-classical\\" x1=\\"79\\" x2=\\"79\\" y1=\\"40\\" y2=\\"81\\"></line>
+<line class=\\"register-classical\\" x1=\\"81\\" x2=\\"85\\" y1=\\"79\\" y2=\\"79\\"></line>
+<line class=\\"register-classical\\" x1=\\"79\\" x2=\\"85\\" y1=\\"81\\" y2=\\"81\\"></line>
+<line class=\\"register-classical\\" x1=\\"81\\" x2=\\"81\\" y1=\\"40\\" y2=\\"119\\"></line>
+<line class=\\"register-classical\\" x1=\\"79\\" x2=\\"79\\" y1=\\"40\\" y2=\\"121\\"></line>
+<line class=\\"register-classical\\" x1=\\"81\\" x2=\\"85\\" y1=\\"119\\" y2=\\"119\\"></line>
+<line class=\\"register-classical\\" x1=\\"79\\" x2=\\"85\\" y1=\\"121\\" y2=\\"121\\"></line>
+<line class=\\"register-classical\\" x1=\\"81\\" x2=\\"81\\" y1=\\"160\\" y2=\\"199\\"></line>
+<line class=\\"register-classical\\" x1=\\"79\\" x2=\\"79\\" y1=\\"160\\" y2=\\"201\\"></line>
+<line class=\\"register-classical\\" x1=\\"81\\" x2=\\"85\\" y1=\\"199\\" y2=\\"199\\"></line>
+<line class=\\"register-classical\\" x1=\\"79\\" x2=\\"85\\" y1=\\"201\\" y2=\\"201\\"></line>"
 `;
 
 exports[`Testing formatRegisters Quantum and classical registers 6`] = `
-"<line x1=\\"40\\" x2=\\"580\\" y1=\\"40\\" y2=\\"40\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
+"<line x1=\\"40\\" x2=\\"580\\" y1=\\"40\\" y2=\\"40\\"></line>
 <text x=\\"40\\" y=\\"24\\" dominant-baseline=\\"hanging\\" text-anchor=\\"start\\" font-size=\\"75%\\">q0</text>
-<line x1=\\"40\\" x2=\\"580\\" y1=\\"100\\" y2=\\"100\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
+<line x1=\\"40\\" x2=\\"580\\" y1=\\"100\\" y2=\\"100\\"></line>
 <text x=\\"40\\" y=\\"84\\" dominant-baseline=\\"hanging\\" text-anchor=\\"start\\" font-size=\\"75%\\">q1</text>
-<line x1=\\"40\\" x2=\\"580\\" y1=\\"220\\" y2=\\"220\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
+<line x1=\\"40\\" x2=\\"580\\" y1=\\"220\\" y2=\\"220\\"></line>
 <text x=\\"40\\" y=\\"204\\" dominant-baseline=\\"hanging\\" text-anchor=\\"start\\" font-size=\\"75%\\">q2</text>
-<line x1=\\"81\\" x2=\\"81\\" y1=\\"40\\" y2=\\"79\\" stroke=\\"black\\" stroke-width=\\"0.5\\"></line>
-<line x1=\\"79\\" x2=\\"79\\" y1=\\"40\\" y2=\\"81\\" stroke=\\"black\\" stroke-width=\\"0.5\\"></line>
-<line x1=\\"81\\" x2=\\"580\\" y1=\\"79\\" y2=\\"79\\" stroke=\\"black\\" stroke-width=\\"0.5\\"></line>
-<line x1=\\"79\\" x2=\\"580\\" y1=\\"81\\" y2=\\"81\\" stroke=\\"black\\" stroke-width=\\"0.5\\"></line>
-<line x1=\\"81\\" x2=\\"81\\" y1=\\"40\\" y2=\\"119\\" stroke=\\"black\\" stroke-width=\\"0.5\\"></line>
-<line x1=\\"79\\" x2=\\"79\\" y1=\\"40\\" y2=\\"121\\" stroke=\\"black\\" stroke-width=\\"0.5\\"></line>
-<line x1=\\"81\\" x2=\\"580\\" y1=\\"119\\" y2=\\"119\\" stroke=\\"black\\" stroke-width=\\"0.5\\"></line>
-<line x1=\\"79\\" x2=\\"580\\" y1=\\"121\\" y2=\\"121\\" stroke=\\"black\\" stroke-width=\\"0.5\\"></line>
-<line x1=\\"81\\" x2=\\"81\\" y1=\\"160\\" y2=\\"199\\" stroke=\\"black\\" stroke-width=\\"0.5\\"></line>
-<line x1=\\"79\\" x2=\\"79\\" y1=\\"160\\" y2=\\"201\\" stroke=\\"black\\" stroke-width=\\"0.5\\"></line>
-<line x1=\\"81\\" x2=\\"580\\" y1=\\"199\\" y2=\\"199\\" stroke=\\"black\\" stroke-width=\\"0.5\\"></line>
-<line x1=\\"79\\" x2=\\"580\\" y1=\\"201\\" y2=\\"201\\" stroke=\\"black\\" stroke-width=\\"0.5\\"></line>"
+<line class=\\"register-classical\\" x1=\\"81\\" x2=\\"81\\" y1=\\"40\\" y2=\\"79\\"></line>
+<line class=\\"register-classical\\" x1=\\"79\\" x2=\\"79\\" y1=\\"40\\" y2=\\"81\\"></line>
+<line class=\\"register-classical\\" x1=\\"81\\" x2=\\"580\\" y1=\\"79\\" y2=\\"79\\"></line>
+<line class=\\"register-classical\\" x1=\\"79\\" x2=\\"580\\" y1=\\"81\\" y2=\\"81\\"></line>
+<line class=\\"register-classical\\" x1=\\"81\\" x2=\\"81\\" y1=\\"40\\" y2=\\"119\\"></line>
+<line class=\\"register-classical\\" x1=\\"79\\" x2=\\"79\\" y1=\\"40\\" y2=\\"121\\"></line>
+<line class=\\"register-classical\\" x1=\\"81\\" x2=\\"580\\" y1=\\"119\\" y2=\\"119\\"></line>
+<line class=\\"register-classical\\" x1=\\"79\\" x2=\\"580\\" y1=\\"121\\" y2=\\"121\\"></line>
+<line class=\\"register-classical\\" x1=\\"81\\" x2=\\"81\\" y1=\\"160\\" y2=\\"199\\"></line>
+<line class=\\"register-classical\\" x1=\\"79\\" x2=\\"79\\" y1=\\"160\\" y2=\\"201\\"></line>
+<line class=\\"register-classical\\" x1=\\"81\\" x2=\\"580\\" y1=\\"199\\" y2=\\"199\\"></line>
+<line class=\\"register-classical\\" x1=\\"79\\" x2=\\"580\\" y1=\\"201\\" y2=\\"201\\"></line>"
 `;
 
 exports[`Testing formatRegisters Skipped quantum registers 1`] = `
-"<line x1=\\"40\\" x2=\\"180\\" y1=\\"40\\" y2=\\"40\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
+"<line x1=\\"40\\" x2=\\"180\\" y1=\\"40\\" y2=\\"40\\"></line>
 <text x=\\"40\\" y=\\"24\\" dominant-baseline=\\"hanging\\" text-anchor=\\"start\\" font-size=\\"75%\\">q0</text>
-<line x1=\\"40\\" x2=\\"180\\" y1=\\"160\\" y2=\\"160\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
+<line x1=\\"40\\" x2=\\"180\\" y1=\\"160\\" y2=\\"160\\"></line>
 <text x=\\"40\\" y=\\"144\\" dominant-baseline=\\"hanging\\" text-anchor=\\"start\\" font-size=\\"75%\\">q2</text>
-<line x1=\\"40\\" x2=\\"180\\" y1=\\"220\\" y2=\\"220\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
+<line x1=\\"40\\" x2=\\"180\\" y1=\\"220\\" y2=\\"220\\"></line>
 <text x=\\"40\\" y=\\"204\\" dominant-baseline=\\"hanging\\" text-anchor=\\"start\\" font-size=\\"75%\\">q3</text>"
 `;
 
 exports[`Testing formatRegisters Skipped quantum registers 2`] = `
-"<line x1=\\"40\\" x2=\\"85\\" y1=\\"40\\" y2=\\"40\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
+"<line x1=\\"40\\" x2=\\"85\\" y1=\\"40\\" y2=\\"40\\"></line>
 <text x=\\"40\\" y=\\"24\\" dominant-baseline=\\"hanging\\" text-anchor=\\"start\\" font-size=\\"75%\\">q0</text>
-<line x1=\\"40\\" x2=\\"85\\" y1=\\"160\\" y2=\\"160\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
+<line x1=\\"40\\" x2=\\"85\\" y1=\\"160\\" y2=\\"160\\"></line>
 <text x=\\"40\\" y=\\"144\\" dominant-baseline=\\"hanging\\" text-anchor=\\"start\\" font-size=\\"75%\\">q2</text>
-<line x1=\\"40\\" x2=\\"85\\" y1=\\"220\\" y2=\\"220\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
+<line x1=\\"40\\" x2=\\"85\\" y1=\\"220\\" y2=\\"220\\"></line>
 <text x=\\"40\\" y=\\"204\\" dominant-baseline=\\"hanging\\" text-anchor=\\"start\\" font-size=\\"75%\\">q3</text>"
 `;
 
 exports[`Testing formatRegisters Skipped quantum registers 3`] = `
-"<line x1=\\"40\\" x2=\\"580\\" y1=\\"40\\" y2=\\"40\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
+"<line x1=\\"40\\" x2=\\"580\\" y1=\\"40\\" y2=\\"40\\"></line>
 <text x=\\"40\\" y=\\"24\\" dominant-baseline=\\"hanging\\" text-anchor=\\"start\\" font-size=\\"75%\\">q0</text>
-<line x1=\\"40\\" x2=\\"580\\" y1=\\"160\\" y2=\\"160\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
+<line x1=\\"40\\" x2=\\"580\\" y1=\\"160\\" y2=\\"160\\"></line>
 <text x=\\"40\\" y=\\"144\\" dominant-baseline=\\"hanging\\" text-anchor=\\"start\\" font-size=\\"75%\\">q2</text>
-<line x1=\\"40\\" x2=\\"580\\" y1=\\"220\\" y2=\\"220\\" stroke=\\"black\\" stroke-width=\\"1\\"></line>
+<line x1=\\"40\\" x2=\\"580\\" y1=\\"220\\" y2=\\"220\\"></line>
 <text x=\\"40\\" y=\\"204\\" dominant-baseline=\\"hanging\\" text-anchor=\\"start\\" font-size=\\"75%\\">q3</text>"
 `;

--- a/src/Kernel/client/__tests__/ExecutionPathVisualizerTests/gateFormatter.test.ts
+++ b/src/Kernel/client/__tests__/ExecutionPathVisualizerTests/gateFormatter.test.ts
@@ -37,7 +37,7 @@ describe("Testing _classicalControlled", () => {
                 }],
                 []
             ],
-            htmlClass: 'cls-control-1'
+            htmlClass: 'classically-controlled-1'
         };
         expect(_classicalControlled(metadata)).toMatchSnapshot();
     });
@@ -60,7 +60,7 @@ describe("Testing _classicalControlled", () => {
                     width: minGateWidth
                 }]
             ],
-            htmlClass: 'cls-control-1'
+            htmlClass: 'classically-controlled-1'
         };
         expect(_classicalControlled(metadata)).toMatchSnapshot();
     });
@@ -72,7 +72,7 @@ describe("Testing _classicalControlled", () => {
             targetsY: [startY, startY + registerHeight],
             width: minGateWidth * 2 + gatePadding * 4,
             label: 'if',
-            htmlClass: 'cls-control-1',
+            htmlClass: 'classically-controlled-1',
             children: [
                 [{
                     type: GateType.Unitary,
@@ -112,7 +112,7 @@ describe("Testing _classicalControlled", () => {
             targetsY: [startY, startY + registerHeight],
             width: minGateWidth * 2 + gatePadding * 6,
             label: 'if',
-            htmlClass: 'cls-control-1',
+            htmlClass: 'classically-controlled-1',
             children: [
                 [],
                 [
@@ -131,7 +131,7 @@ describe("Testing _classicalControlled", () => {
                         targetsY: [startY, startY + registerHeight],
                         width: minGateWidth + gatePadding * 2,
                         label: 'if',
-                        htmlClass: 'cls-control-1',
+                        htmlClass: 'classically-controlled-1',
                         children: [
                             [],
                             [{
@@ -190,7 +190,7 @@ describe("Testing _classicalControlled", () => {
                     width: minGateWidth
                 }]
             ],
-            htmlClass: 'cls-control-1'
+            htmlClass: 'classically-controlled-1'
         };
         expect(_classicalControlled(metadata, 20)).toMatchSnapshot();
     });

--- a/src/Kernel/client/kernel.ts
+++ b/src/Kernel/client/kernel.ts
@@ -9,6 +9,7 @@ declare var IPython: IPython;
 
 import { Telemetry, ClientInfo } from "./telemetry.js";
 import { executionPathToHtml } from "./ExecutionPathVisualizer";
+import { StyleConfig, STYLES } from "./ExecutionPathVisualizer/styles";
 
 function defineQSharpMode() {
     console.log("Loading IQ# kernel-specific extension...");
@@ -231,8 +232,9 @@ class Kernel {
         IPython.notebook.kernel.register_iopub_handler(
             "render_execution_path",
             message => {
-                const { executionPath, id } = message.content;
-                const html: string = executionPathToHtml(executionPath);
+                const { executionPath, id, style } = message.content;
+                const userStyleConfig: StyleConfig = STYLES[style] || {};
+                const html: string = executionPathToHtml(executionPath, userStyleConfig);
                 const container: HTMLElement = document.getElementById(id);
                 if (container == null) throw new Error(`Div with ID ${id} not found.`);
                 container.innerHTML = html;


### PR DESCRIPTION
This PR is sets the groundwork for adding colours to the path visualizer and the possibility for customizing the colours. Specifically, this PR accomplishes the following:

- Add colours to unitary (blue) and measurement (yellow) gates
- A small tweak where the gate labels and gate outline of classically controlled gates are no longer red/blue but black
![image](https://user-images.githubusercontent.com/19257435/89959533-a7ba2780-dc0a-11ea-97ea-41b9aa30530b.png)
- Add `userStyleConfig` as an argument to `executionPathToHtml` to allow users to customize colours in visualization.
- Allow users to choose between the following 3 styles using `%config trace.style="<style>"`:

1. `Default`
<p align="center">
<img src="https://user-images.githubusercontent.com/19257435/90071235-35594e00-dcc3-11ea-9b97-d259d71eb9e5.png" width="500" />
</p>

2.  `BlackAndWhite`
<p align="center">
<img src="https://user-images.githubusercontent.com/19257435/90071308-53bf4980-dcc3-11ea-83ce-12217191a439.png" width="500" />
</p>

3. `Inverted` (e.g. under "high contrast" setting)
<p align="center">
<img src="https://user-images.githubusercontent.com/19257435/90071439-9123d700-dcc3-11ea-8882-6be683dc72f6.png" width="500" />
</p>

Note: These colours have been checked to pass the accessibility tests using [this program](https://contrastchecker.com/).

Enhancement feature for #158.