### PR TITLE
Pass RuntimeCapabilities to for Azure execution targets to compiler

### DIFF
--- a/src/AzureClient/AzureClient.cs
+++ b/src/AzureClient/AzureClient.cs
@@ -163,7 +163,7 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
             IEntryPoint? entryPoint = null;
             try
             {
-                entryPoint = EntryPointGenerator.Generate(submissionContext.OperationName, ActiveTarget.TargetId);
+                entryPoint = EntryPointGenerator.Generate(submissionContext.OperationName, ActiveTarget.TargetId, ActiveTarget.RuntimeCapabilities);
             }
             catch (UnsupportedOperationException e)
             {

--- a/src/AzureClient/AzureExecutionTarget.cs
+++ b/src/AzureClient/AzureExecutionTarget.cs
@@ -4,6 +4,7 @@
 #nullable enable
 
 using System;
+using Microsoft.Quantum.QsCompiler.ReservedKeywords;
 
 namespace Microsoft.Quantum.IQSharp.AzureClient
 {
@@ -12,7 +13,16 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
     internal class AzureExecutionTarget
     {
         public string TargetId { get; private set; } = string.Empty;
+
         public string PackageName => $"Microsoft.Quantum.Providers.{GetProvider(TargetId)}";
+
+        public AssemblyConstants.RuntimeCapabilities RuntimeCapabilities => GetProvider(TargetId) switch
+        {
+            AzureProvider.IonQ      => AssemblyConstants.RuntimeCapabilities.QPRGen0,
+            AzureProvider.Honeywell => AssemblyConstants.RuntimeCapabilities.QPRGen1,
+            AzureProvider.QCI       => AssemblyConstants.RuntimeCapabilities.QPRGen1,
+            _                       => AssemblyConstants.RuntimeCapabilities.Unknown
+        };
 
         public static bool IsValid(string targetId) => GetProvider(targetId) != null;
 

--- a/src/AzureClient/EntryPoint/EntryPointGenerator.cs
+++ b/src/AzureClient/EntryPoint/EntryPointGenerator.cs
@@ -10,6 +10,7 @@ using System.Reflection;
 using System.Runtime.Loader;
 using Microsoft.Extensions.Logging;
 using Microsoft.Quantum.IQSharp.Common;
+using Microsoft.Quantum.QsCompiler.ReservedKeywords;
 using Microsoft.Quantum.Simulation.Common;
 using Microsoft.Quantum.Simulation.Core;
 
@@ -58,7 +59,8 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
             _ => null
         };
 
-        public IEntryPoint Generate(string operationName, string? executionTarget)
+        public IEntryPoint Generate(string operationName, string? executionTarget,
+            AssemblyConstants.RuntimeCapabilities runtimeCapabilities = AssemblyConstants.RuntimeCapabilities.Unknown)
         {
             Logger?.LogDebug($"Generating entry point: operationName={operationName}, executionTarget={executionTarget}");
 
@@ -76,7 +78,7 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
             {
                 Logger?.LogDebug($"{workspaceFiles.Length} files found in workspace. Compiling.");
                 WorkspaceAssemblyInfo = Compiler.BuildFiles(
-                    workspaceFiles, compilerMetadata, logger, Path.Combine(Workspace.CacheFolder, "__entrypoint__workspace__.dll"), executionTarget);
+                    workspaceFiles, compilerMetadata, logger, Path.Combine(Workspace.CacheFolder, "__entrypoint__workspace__.dll"), executionTarget, runtimeCapabilities);
                 if (WorkspaceAssemblyInfo == null || logger.HasErrors)
                 {
                     Logger?.LogError($"Error compiling workspace.");
@@ -92,7 +94,7 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
             {
                 Logger?.LogDebug($"{snippets.Length} items found in snippets. Compiling.");
                 SnippetsAssemblyInfo = Compiler.BuildSnippets(
-                    snippets, compilerMetadata, logger, Path.Combine(Workspace.CacheFolder, "__entrypoint__snippets__.dll"), executionTarget);
+                    snippets, compilerMetadata, logger, Path.Combine(Workspace.CacheFolder, "__entrypoint__snippets__.dll"), executionTarget, runtimeCapabilities);
                 if (SnippetsAssemblyInfo == null || logger.HasErrors)
                 {
                     Logger?.LogError($"Error compiling snippets.");
@@ -111,7 +113,7 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
             }
 
             EntryPointAssemblyInfo = Compiler.BuildEntryPoint(
-                operationInfo, compilerMetadata, logger, Path.Combine(Workspace.CacheFolder, "__entrypoint__.dll"), executionTarget);
+                operationInfo, compilerMetadata, logger, Path.Combine(Workspace.CacheFolder, "__entrypoint__.dll"), executionTarget, runtimeCapabilities);
             if (EntryPointAssemblyInfo == null || logger.HasErrors)
             {
                 Logger?.LogError($"Error compiling entry point for operation {operationName}.");

--- a/src/AzureClient/EntryPoint/IEntryPointGenerator.cs
+++ b/src/AzureClient/EntryPoint/IEntryPointGenerator.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections.Generic;
 using System.Text;
+using Microsoft.Quantum.QsCompiler.ReservedKeywords;
 
 namespace Microsoft.Quantum.IQSharp.AzureClient
 {
@@ -41,7 +42,9 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
         /// </summary>
         /// <param name="operationName">The name of the operation to wrap in an entry point.</param>
         /// <param name="executionTarget">The intended execution target for the compiled entry point.</param>
+        /// <param name="runtimeCapabilities">The runtime capabilities of the intended execution target.</param>
         /// <returns>The generated entry point.</returns>
-        public IEntryPoint Generate(string operationName, string? executionTarget);
+        public IEntryPoint Generate(string operationName, string? executionTarget,
+            AssemblyConstants.RuntimeCapabilities runtimeCapabilities = AssemblyConstants.RuntimeCapabilities.Unknown);
     }
 }

--- a/src/Core/Compiler/CompilerService.cs
+++ b/src/Core/Compiler/CompilerService.cs
@@ -126,19 +126,28 @@ namespace Microsoft.Quantum.IQSharp
         /// if the keys of the given references differ from the currently loaded ones.
         /// Returns an enumerable of all namespaces, including the content from both source files and references.
         /// </summary> 
-        private QsCompilation UpdateCompilation(ImmutableDictionary<Uri, string> sources, QsReferences? references = null, QSharpLogger? logger = null, bool compileAsExecutable = false)
+        private QsCompilation UpdateCompilation(
+            ImmutableDictionary<Uri, string> sources,
+            QsReferences? references = null,
+            QSharpLogger? logger = null,
+            bool compileAsExecutable = false,
+            string? executionTarget = null,
+            AssemblyConstants.RuntimeCapabilities runtimeCapabilities = AssemblyConstants.RuntimeCapabilities.Unknown)
         {
             var loadOptions = new CompilationLoader.Configuration
             {
                 GenerateFunctorSupport = true,
-                IsExecutable = compileAsExecutable
+                IsExecutable = compileAsExecutable,
+                AssemblyConstants = new Dictionary<string, string> { [AssemblyConstants.ProcessorArchitecture] = executionTarget ?? string.Empty },
+                RuntimeCapabilities = runtimeCapabilities
             };
             var loaded = new CompilationLoader(_ => sources, _ => references, loadOptions, logger);
             return loaded.CompilationOutput;
         }
 
         /// <inheritdoc/>
-        public AssemblyInfo? BuildEntryPoint(OperationInfo operation, CompilerMetadata metadatas, QSharpLogger logger, string dllName, string? executionTarget = null)
+        public AssemblyInfo? BuildEntryPoint(OperationInfo operation, CompilerMetadata metadatas, QSharpLogger logger, string dllName, string? executionTarget = null,
+            AssemblyConstants.RuntimeCapabilities runtimeCapabilities = AssemblyConstants.RuntimeCapabilities.Unknown)
         {
             var signature = operation.Header.PrintSignature();
             var argumentTuple = SyntaxTreeToQsharp.ArgumentTuple(operation.Header.ArgumentTuple, type => type.ToString(), symbolsOnly: true);
@@ -155,7 +164,7 @@ namespace Microsoft.Quantum.IQSharp
                 }}";
 
             var sources = new Dictionary<Uri, string>() {{ entryPointUri, entryPointSnippet }}.ToImmutableDictionary();
-            return BuildAssembly(sources, metadatas, logger, dllName, compileAsExecutable: true, executionTarget: executionTarget);
+            return BuildAssembly(sources, metadatas, logger, dllName, compileAsExecutable: true, executionTarget, runtimeCapabilities);
         }
 
         /// <summary>
@@ -163,7 +172,8 @@ namespace Microsoft.Quantum.IQSharp
         /// Each snippet code is wrapped inside the 'SNIPPETS_NAMESPACE' namespace and processed as a file
         /// with the same name as the snippet id.
         /// </summary>
-        public AssemblyInfo? BuildSnippets(Snippet[] snippets, CompilerMetadata metadatas, QSharpLogger logger, string dllName, string? executionTarget = null)
+        public AssemblyInfo? BuildSnippets(Snippet[] snippets, CompilerMetadata metadatas, QSharpLogger logger, string dllName, string? executionTarget = null,
+            AssemblyConstants.RuntimeCapabilities runtimeCapabilities = AssemblyConstants.RuntimeCapabilities.Unknown)
         {
             string openStatements = string.Join("", AutoOpenNamespaces.Select(
                 entry => string.IsNullOrEmpty(entry.Value) 
@@ -183,7 +193,7 @@ namespace Microsoft.Quantum.IQSharp
             };
 
             errorCodesToIgnore.ForEach(code => logger.ErrorCodesToIgnore.Add(code));
-            var assembly = BuildAssembly(sources, metadatas, logger, dllName, compileAsExecutable: false, executionTarget: executionTarget);
+            var assembly = BuildAssembly(sources, metadatas, logger, dllName, compileAsExecutable: false, executionTarget, runtimeCapabilities);
             errorCodesToIgnore.ForEach(code => logger.ErrorCodesToIgnore.Remove(code));
 
             return assembly;
@@ -192,22 +202,24 @@ namespace Microsoft.Quantum.IQSharp
         /// <summary>
         /// Builds the corresponding .net core assembly from the code in the given files.
         /// </summary>
-        public AssemblyInfo? BuildFiles(string[] files, CompilerMetadata metadatas, QSharpLogger logger, string dllName, string? executionTarget = null)
+        public AssemblyInfo? BuildFiles(string[] files, CompilerMetadata metadatas, QSharpLogger logger, string dllName, string? executionTarget = null,
+            AssemblyConstants.RuntimeCapabilities runtimeCapabilities = AssemblyConstants.RuntimeCapabilities.Unknown)
         {
             var sources = ProjectManager.LoadSourceFiles(files, d => logger?.Log(d), ex => logger?.Log(ex));
-            return BuildAssembly(sources, metadatas, logger, dllName, compileAsExecutable: false, executionTarget: executionTarget);
+            return BuildAssembly(sources, metadatas, logger, dllName, compileAsExecutable: false, executionTarget, runtimeCapabilities);
         }
 
         /// <summary>
         /// Builds the corresponding .net core assembly from the Q# syntax tree.
         /// </summary>
-        private AssemblyInfo? BuildAssembly(ImmutableDictionary<Uri, string> sources, CompilerMetadata metadata, QSharpLogger logger, string dllName, bool compileAsExecutable, string? executionTarget)
+        private AssemblyInfo? BuildAssembly(ImmutableDictionary<Uri, string> sources, CompilerMetadata metadata, QSharpLogger logger, string dllName, bool compileAsExecutable, string? executionTarget,
+            AssemblyConstants.RuntimeCapabilities runtimeCapabilities)
         {
             logger.LogDebug($"Compiling the following Q# files: {string.Join(",", sources.Keys.Select(f => f.LocalPath))}");
 
             // Ignore any @EntryPoint() attributes found in libraries.
             logger.ErrorCodesToIgnore.Add(QsCompiler.Diagnostics.ErrorCode.EntryPointInLibrary);
-            var qsCompilation = this.UpdateCompilation(sources, metadata.QsMetadatas, logger, compileAsExecutable);
+            var qsCompilation = this.UpdateCompilation(sources, metadata.QsMetadatas, logger, compileAsExecutable, executionTarget, runtimeCapabilities);
             logger.ErrorCodesToIgnore.Remove(QsCompiler.Diagnostics.ErrorCode.EntryPointInLibrary);
 
             if (logger.HasErrors) return null;

--- a/src/Core/Compiler/ICompilerService.cs
+++ b/src/Core/Compiler/ICompilerService.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using Microsoft.Quantum.IQSharp.Common;
+using Microsoft.Quantum.QsCompiler.ReservedKeywords;
 using Microsoft.Quantum.QsCompiler.SyntaxTree;
 
 namespace Microsoft.Quantum.IQSharp
@@ -23,17 +24,20 @@ namespace Microsoft.Quantum.IQSharp
         /// Builds an executable assembly with an entry point that invokes the Q# operation specified
         /// by the provided <see cref="OperationInfo"/> object.
         /// </summary>
-        AssemblyInfo BuildEntryPoint(OperationInfo operation, CompilerMetadata metadatas, QSharpLogger logger, string dllName, string executionTarget = null);
+        AssemblyInfo BuildEntryPoint(OperationInfo operation, CompilerMetadata metadatas, QSharpLogger logger, string dllName, string executionTarget = null,
+            AssemblyConstants.RuntimeCapabilities runtimeCapabilities = AssemblyConstants.RuntimeCapabilities.Unknown);
 
         /// <summary>
         /// Builds the corresponding .net core assembly from the code in the given Q# Snippets.
         /// </summary>
-        AssemblyInfo BuildSnippets(Snippet[] snippets, CompilerMetadata metadatas, QSharpLogger logger, string dllName, string executionTarget = null);
+        AssemblyInfo BuildSnippets(Snippet[] snippets, CompilerMetadata metadatas, QSharpLogger logger, string dllName, string executionTarget = null,
+            AssemblyConstants.RuntimeCapabilities runtimeCapabilities = AssemblyConstants.RuntimeCapabilities.Unknown);
 
         /// <summary>
         /// Builds the corresponding .net core assembly from the code in the given files.
         /// </summary>
-        AssemblyInfo BuildFiles(string[] files, CompilerMetadata metadatas, QSharpLogger logger, string dllName, string executionTarget = null);
+        AssemblyInfo BuildFiles(string[] files, CompilerMetadata metadatas, QSharpLogger logger, string dllName, string executionTarget = null,
+            AssemblyConstants.RuntimeCapabilities runtimeCapabilities = AssemblyConstants.RuntimeCapabilities.Unknown);
 
         /// <summary>
         /// Returns the names of all declared callables and types. 

--- a/src/Tests/AzureClientTests.cs
+++ b/src/Tests/AzureClientTests.cs
@@ -12,6 +12,7 @@ using Microsoft.Azure.Quantum;
 using Microsoft.Azure.Quantum.Client.Models;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Jupyter.Core;
+using Microsoft.Quantum.IQSharp;
 using Microsoft.Quantum.IQSharp.AzureClient;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -278,7 +279,9 @@ namespace Tests.IQSharp
 
             // Choose an operation with measurement result comparison, which should
             // fail to compile on QPRGen0 targets but succeed on QPRGen1 targets
-            var submissionContext = new AzureSubmissionContext() { OperationName = "Tests.qss.CompareMeasurementResult" };
+            var snippets = services.GetService<ISnippets>();
+            snippets.Compile(SNIPPETS.CompareMeasurementResult);
+            var submissionContext = new AzureSubmissionContext() { OperationName = "CompareMeasurementResult" };
             ExpectSuccess<IEnumerable<TargetStatus>>(ConnectToWorkspaceAsync(azureClient));
 
             // Set up workspace with mock providers

--- a/src/Tests/AzureClientTests.cs
+++ b/src/Tests/AzureClientTests.cs
@@ -274,14 +274,12 @@ namespace Tests.IQSharp
         [TestMethod]
         public void TestRuntimeCapabilities()
         {
-            var services = Startup.CreateServiceProvider("Workspace");
+            var services = Startup.CreateServiceProvider("Workspace.QPRGen1");
             var azureClient = (AzureClient)services.GetService<IAzureClient>();
 
             // Choose an operation with measurement result comparison, which should
             // fail to compile on QPRGen0 targets but succeed on QPRGen1 targets
-            var snippets = services.GetService<ISnippets>();
-            snippets.Compile(SNIPPETS.CompareMeasurementResult);
-            var submissionContext = new AzureSubmissionContext() { OperationName = "CompareMeasurementResult" };
+            var submissionContext = new AzureSubmissionContext() { OperationName = "Tests.qss.CompareMeasurementResult" };
             ExpectSuccess<IEnumerable<TargetStatus>>(ConnectToWorkspaceAsync(azureClient));
 
             // Set up workspace with mock providers

--- a/src/Tests/SNIPPETS.cs
+++ b/src/Tests/SNIPPETS.cs
@@ -253,7 +253,7 @@ namespace Tests.IQSharp
     /// # Summary
     ///     This script returns the same array in reverse order.
     ///     Used to make sure we can pass arguments to snippets simulation.
-        operation Reverse(name : String, array: Int[]) : Int[] {
+    operation Reverse(name : String, array: Int[]) : Int[] {
          Message($""Hello {name}"");
          
         let n = Length(array);
@@ -267,6 +267,19 @@ namespace Tests.IQSharp
     }
 ";
 
+        public static string CompareMeasurementResult =
+@"
+    operation CompareMeasurementResult() : Result {
+        using (qubits = Qubit[2]) {
+            let r = M(qubits[0]);
+            if (r == One) {
+                H(qubits[1]);
+                Reset(qubits[1]);
+            }
+            return r;
+        }
+    }
+";
 
     }
 }

--- a/src/Tests/Tests.IQsharp.csproj
+++ b/src/Tests/Tests.IQsharp.csproj
@@ -63,6 +63,9 @@
     <None Update="Workspace.ExecutionPathTracer\Measurement.qs">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="Workspace.QPRGen1\Operations.qs">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
 </Project>

--- a/src/Tests/Workspace.QPRGen1/Operations.qs
+++ b/src/Tests/Workspace.QPRGen1/Operations.qs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Tests.qss {
+    
+    open Microsoft.Quantum.Intrinsic;
+
+    @EntryPoint()
+    operation CompareMeasurementResult() : Result {
+        using (q = Qubit()) {
+            let r = M(q);
+            if (r == One) {
+                H(q);
+                Reset(q);
+            }
+            return r;
+        }
+    }
+}
+
+

--- a/src/Tests/Workspace/BasicOps.qs
+++ b/src/Tests/Workspace/BasicOps.qs
@@ -42,6 +42,16 @@ namespace Tests.qss {
             CCNOT(qubits[0], qubits[1], qubits[2]);
         } 
     }
+
+    operation CompareMeasurementResult() : Unit {
+        using (qubits = Qubit[2]) {
+            let r = M(qubits[0]);
+            if (r == One) {
+                H(qubits[1]);
+                Reset(qubits[1]);
+            }
+        }
+    }
 }
 
 

--- a/src/Tests/Workspace/BasicOps.qs
+++ b/src/Tests/Workspace/BasicOps.qs
@@ -42,16 +42,6 @@ namespace Tests.qss {
             CCNOT(qubits[0], qubits[1], qubits[2]);
         } 
     }
-
-    operation CompareMeasurementResult() : Unit {
-        using (qubits = Qubit[2]) {
-            let r = M(qubits[0]);
-            if (r == One) {
-                H(qubits[1]);
-                Reset(qubits[1]);
-            }
-        }
-    }
 }
 
 


### PR DESCRIPTION
Fixes #185 by passing `RuntimeCapabilities` for the specified Azure execution target down to the compiler.

Here's an example of the messaging with this change. Note that we get specific file and line number information from the compiler, as expected.
![image](https://user-images.githubusercontent.com/3620100/90028681-d79b1680-dc6e-11ea-92e2-cdb17992ad36.png)

Note that it's not ideal to have the logic mapping the `RuntimeCapabilities` for each provider embedded in IQ# code, since this already exists in the compiler repo here:
https://github.com/microsoft/qsharp-compiler/blob/b77641106b8faaa9046e119dec9f704f200bce46/src/QuantumSdk/DefaultItems/DefaultItems.targets#L50-L56

However, I don't see any easy way to re-use that logic at the moment.