### PR TITLE
Consume CloudJob.Uri property for Azure jobs

### DIFF
--- a/src/AzureClient/Visualization/CloudJobEncoders.cs
+++ b/src/AzureClient/Visualization/CloudJobEncoders.cs
@@ -25,10 +25,10 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
         internal static Dictionary<string, object?> ToDictionary(this CloudJob cloudJob) =>
             new Dictionary<string, object?>()
             {
-                // TODO: add cloudJob.Uri after https://github.com/microsoft/qsharp-runtime/issues/236 is fixed.
                 ["id"] = cloudJob.Id,
                 ["name"] = cloudJob.Details.Name,
                 ["status"] = cloudJob.Status,
+                ["uri"] = cloudJob.Uri.ToString(),
                 ["provider"] = cloudJob.Details.ProviderId,
                 ["target"] = cloudJob.Details.Target,
                 ["creation_time"] = cloudJob.Details.CreationTime.ToDateTime()?.ToUniversalTime(),
@@ -41,9 +41,8 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
             {
                 Columns = new List<(string, Func<CloudJob, string>)>
                 {
-                    // TODO: add cloudJob.Uri after https://github.com/microsoft/qsharp-runtime/issues/236 is fixed.
                     ("Job Name", cloudJob => cloudJob.Details.Name),
-                    ("Job ID", cloudJob => cloudJob.Id),
+                    ("Job ID", cloudJob => $"<a href=\"{cloudJob.Uri}\" target=\"_blank\">{cloudJob.Id}</a>"),
                     ("Job Status", cloudJob => cloudJob.Status),
                     ("Target", cloudJob => cloudJob.Details.Target),
                     ("Creation Time", cloudJob => cloudJob.Details.CreationTime.ToDateTime()?.ToString() ?? string.Empty),

--- a/src/Python/qsharp-core/qsharp/azure.py
+++ b/src/Python/qsharp-core/qsharp/azure.py
@@ -64,6 +64,7 @@ class AzureJob(object):
         self.id = data["id"]
         self.name = data["name"]
         self.status = data["status"]
+        self.uri = data["uri"]
         self.provider = data["provider"]
         self.target = data["target"]
         self.creation_time = data["creation_time"]


### PR DESCRIPTION
Fixes #194 by consuming the `CloudJob.Uri` property, which is now implemented thanks to https://github.com/microsoft/qsharp-runtime/pull/294.

This will be rendered as a link in HTML clients (e.g. Jupyter Notebook) and as an additional `uri` field for other clients (e.g. text-based clients and the Python API).