### PR TITLE
Ensure valid access token before each Azure service call

### DIFF
--- a/src/AzureClient/AzureClient.cs
+++ b/src/AzureClient/AzureClient.cs
@@ -94,13 +94,6 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
                 return AzureClientError.WorkspaceNotFound.ToExecutionResult();
             }
 
-            var providers = await ActiveWorkspace.GetProvidersAsync();
-            if (providers == null)
-            {
-                return AzureClientError.WorkspaceNotFound.ToExecutionResult();
-            }
-            
-            AvailableProviders = providers;
             ConnectionString = storageAccountConnectionString;
             ActiveTarget = null;
             MostRecentJobId = string.Empty;
@@ -139,7 +132,14 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
                 return AzureClientError.AuthenticationFailed.ToExecutionResult();
             }
 
+            var providers = await workspace.GetProvidersAsync();
+            if (providers == null)
+            {
+                return AzureClientError.WorkspaceNotFound.ToExecutionResult();
+            }
+
             ActiveWorkspace = workspace;
+            AvailableProviders = providers;
 
             return ExecuteStatus.Ok.ToExecutionResult();
         }

--- a/src/AzureClient/AzureWorkspace.cs
+++ b/src/AzureClient/AzureWorkspace.cs
@@ -17,6 +17,8 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
     internal class AzureWorkspace : IAzureWorkspace
     {
         public string? Name => AzureQuantumClient?.WorkspaceName;
+        public string? SubscriptionId => AzureQuantumClient?.SubscriptionId;
+        public string? ResourceGroup => AzureQuantumClient?.ResourceGroupName;
 
         private Azure.Quantum.IWorkspace AzureQuantumWorkspace { get; set; }
         private QuantumClient AzureQuantumClient { get; set; }

--- a/src/AzureClient/IAzureWorkspace.cs
+++ b/src/AzureClient/IAzureWorkspace.cs
@@ -14,6 +14,8 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
     internal interface IAzureWorkspace
     {
         public string? Name { get; }
+        public string? SubscriptionId { get; }
+        public string? ResourceGroup { get; }
 
         public Task<IEnumerable<ProviderStatus>?> GetProvidersAsync();
         public Task<CloudJob?> GetJobAsync(string jobId);

--- a/src/AzureClient/Mocks/MockAzureWorkspace.cs
+++ b/src/AzureClient/Mocks/MockAzureWorkspace.cs
@@ -17,24 +17,30 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
     {
         public const string NameWithMockProviders = "WorkspaceNameWithMockProviders";
 
-        public string Name { get; private set; }
+        public static string[] MockJobIds { get; set; } = Array.Empty<string>();
 
-        public List<ProviderStatus> Providers { get; } = new List<ProviderStatus>();
-        
-        public List<CloudJob> Jobs { get; } = new List<CloudJob>();
+        public static string[] MockTargetIds { get; set; } = Array.Empty<string>();
 
-        public MockAzureWorkspace(string workspaceName)
+        public string Name { get; private set; } = string.Empty;
+
+        public string SubscriptionId { get; private set; } = string.Empty;
+
+        public string ResourceGroup { get; private set; } = string.Empty;
+
+        public List<ProviderStatus> Providers => new List<ProviderStatus>
         {
-            Name = workspaceName;
-            if (Name == NameWithMockProviders)
-            {
-                // add a mock target for each provider: "ionq.mock", "honeywell.mock", etc.
-                AddMockTargets(
-                    Enum.GetNames(typeof(AzureProvider))
-                        .Select(provider => $"{provider.ToLowerInvariant()}.mock")
-                        .ToArray());
-            }
-        }
+            new ProviderStatus(null, null,
+                ((Name == NameWithMockProviders)
+                        ? Enum.GetNames(typeof(AzureProvider))
+                            .Select(provider => $"{provider.ToLowerInvariant()}.mock")
+                            .ToArray()
+                        : MockTargetIds
+                ).Select(id => new TargetStatus(id)).ToList())
+        };
+
+        public List<CloudJob> Jobs => MockJobIds.Select(jobId => new MockCloudJob(jobId)).ToList<CloudJob>();
+
+        public MockAzureWorkspace(string workspaceName) => Name = workspaceName;
 
         public async Task<CloudJob?> GetJobAsync(string jobId) => Jobs.FirstOrDefault(job => job.Id == jobId);
 
@@ -43,21 +49,5 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
         public async Task<IEnumerable<CloudJob>?> ListJobsAsync() => Jobs;
 
         public IQuantumMachine? CreateQuantumMachine(string targetId, string storageAccountConnectionString) => new MockQuantumMachine(this);
-
-        public void AddMockJobs(params string[] jobIds)
-        {
-            foreach (var jobId in jobIds)
-            {
-                var mockJob = new MockCloudJob();
-                mockJob.Details.Id = jobId;
-                Jobs.Add(mockJob);
-            }
-        }
-
-        public void AddMockTargets(params string[] targetIds)
-        {
-            var targets = targetIds.Select(id => new TargetStatus(id)).ToList();
-            Providers.Add(new ProviderStatus(null, null, targets));
-        }
     }
 }

--- a/src/AzureClient/Mocks/MockCloudJob.cs
+++ b/src/AzureClient/Mocks/MockCloudJob.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
 {
     internal class MockCloudJob : CloudJob
     {
-        public MockCloudJob()
+        public MockCloudJob(string? id = null)
             : base(
                 new Azure.Quantum.Workspace("mockSubscriptionId", "mockResourceGroupName", "mockWorkspaceName"),
                 new JobDetails(
@@ -20,7 +20,7 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
                     inputDataFormat: null,
                     providerId: null,
                     target: null,
-                    id: Guid.NewGuid().ToString(),
+                    id: id ?? Guid.NewGuid().ToString(),
                     status: "Succeeded",
                     outputDataUri: CreateMockOutputFileUri()
                 ))

--- a/src/AzureClient/Mocks/MockQuantumMachine.cs
+++ b/src/AzureClient/Mocks/MockQuantumMachine.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
         public Task<IQuantumMachineJob> SubmitAsync<TInput, TOutput>(EntryPointInfo<TInput, TOutput> info, TInput input, IQuantumMachineSubmissionContext? submissionContext, IQuantumMachine.ConfigureJob? configureJobCallback)
         {
             var job = new MockCloudJob();
-            Workspace?.AddMockJobs(job.Id);
+            MockAzureWorkspace.MockJobIds = new string[] { job.Id };
             return Task.FromResult(job as IQuantumMachineJob);
         }
 

--- a/src/Python/qsharp-core/qsharp/tests/test_azure.py
+++ b/src/Python/qsharp-core/qsharp/tests/test_azure.py
@@ -140,12 +140,16 @@ def _test_workspace_job_execution():
     assert isinstance(retrieved_histogram, dict)
     assert histogram == retrieved_histogram
 
-    # Check that both submitted jobs exist in the workspace
+    # Check that the submitted job exists in the workspace
     jobs = qsharp.azure.jobs()
     assert isinstance(jobs, list)
-    assert len(jobs) == 2
+    assert len(jobs) == 1
 
     # Check that job filtering works
     jobs = qsharp.azure.jobs(jobs[0].id)
     assert isinstance(jobs, list)
     assert len(jobs) == 1
+
+    jobs = qsharp.azure.jobs("invalid")
+    assert isinstance(jobs, list)
+    assert len(jobs) == 0

--- a/src/Tests/AzureClientTests.cs
+++ b/src/Tests/AzureClientTests.cs
@@ -287,8 +287,7 @@ namespace Tests.IQSharp
             // Set up workspace with mock providers
             var azureWorkspace = azureClient.ActiveWorkspace as MockAzureWorkspace;
             Assert.IsNotNull(azureWorkspace);
-            azureWorkspace?.AddMockTargets("ionq.mock");
-            azureWorkspace?.AddMockTargets("honeywell.mock");
+            MockAzureWorkspace.MockTargetIds = new string[] { "ionq.mock", "honeywell.mock" };
 
             // Verify that IonQ job fails to compile (QPRGen0)
             ExpectSuccess<TargetStatus>(azureClient.SetActiveTargetAsync(new MockChannel(), "ionq.mock"));

--- a/src/Tests/AzureClientTests.cs
+++ b/src/Tests/AzureClientTests.cs
@@ -53,6 +53,8 @@ namespace Tests.IQSharp
 
         private Task<ExecutionResult> ConnectToWorkspaceAsync(IAzureClient azureClient, string workspaceName = "TEST_WORKSPACE_NAME")
         {
+            MockAzureWorkspace.MockJobIds = new string[] { };
+            MockAzureWorkspace.MockTargetIds = new string[] { };
             return azureClient.ConnectAsync(
                 new MockChannel(),
                 "TEST_SUBSCRIPTION_ID",
@@ -123,7 +125,7 @@ namespace Tests.IQSharp
             // set up the mock workspace
             var azureWorkspace = azureClient.ActiveWorkspace as MockAzureWorkspace;
             Assert.IsNotNull(azureWorkspace);
-            azureWorkspace?.AddMockJobs("JOB_ID_1", "JOB_ID_2");
+            MockAzureWorkspace.MockJobIds = new string[] { "JOB_ID_1", "JOB_ID_2" };
 
             // valid job ID
             var job = ExpectSuccess<CloudJob>(azureClient.GetJobStatusAsync(new MockChannel(), "JOB_ID_1"));
@@ -160,7 +162,7 @@ namespace Tests.IQSharp
             // set up the mock workspace
             var azureWorkspace = azureClient.ActiveWorkspace as MockAzureWorkspace;
             Assert.IsNotNull(azureWorkspace);
-            azureWorkspace?.AddMockTargets("ionq.simulator", "honeywell.qpu", "unrecognized.target");
+            MockAzureWorkspace.MockTargetIds = new string[] { "ionq.simulator", "honeywell.qpu", "unrecognized.target" };
 
             // get connection status to verify list of targets
             targets = ExpectSuccess<IEnumerable<TargetStatus>>(azureClient.GetConnectionStatusAsync(new MockChannel()));
@@ -219,7 +221,7 @@ namespace Tests.IQSharp
             // add a target
             var azureWorkspace = azureClient.ActiveWorkspace as MockAzureWorkspace;
             Assert.IsNotNull(azureWorkspace);
-            azureWorkspace?.AddMockTargets("ionq.simulator");
+            MockAzureWorkspace.MockTargetIds = new string[] { "ionq.simulator" };
 
             // set the active target
             var target = ExpectSuccess<TargetStatus>(azureClient.SetActiveTargetAsync(new MockChannel(), "ionq.simulator"));
@@ -252,7 +254,7 @@ namespace Tests.IQSharp
             // add a target
             var azureWorkspace = azureClient.ActiveWorkspace as MockAzureWorkspace;
             Assert.IsNotNull(azureWorkspace);
-            azureWorkspace?.AddMockTargets("ionq.simulator");
+            MockAzureWorkspace.MockTargetIds = new string[] { "ionq.simulator" };
 
             // set the active target
             var target = ExpectSuccess<TargetStatus>(azureClient.SetActiveTargetAsync(new MockChannel(), "ionq.simulator"));


### PR DESCRIPTION
Fixes #218 by running the MSAL authentication code, which is triggered in this code by calling `RefreshConnectionAsync()`, before every Azure service call. This code ensures that the current access token is not expired and fetches a new one if necessary.