### PR TITLE
Add MockAzureExecutionTarget for Python tests

### DIFF
--- a/src/AzureClient/AzureClient.cs
+++ b/src/AzureClient/AzureClient.cs
@@ -263,7 +263,7 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
         /// <inheritdoc/>
         public async Task<ExecutionResult> SetActiveTargetAsync(IChannel channel, string targetId)
         {
-            if (AvailableProviders == null)
+            if (ActiveWorkspace == null || AvailableProviders == null)
             {
                 channel.Stderr($"Please call {GetCommandDisplayName("connect")} before setting an execution target.");
                 return AzureClientError.NotConnected.ToExecutionResult();
@@ -278,7 +278,7 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
             }
 
             // Validate that we know which package to load for this target.
-            var executionTarget = AzureExecutionTarget.Create(targetId);
+            var executionTarget = ActiveWorkspace.CreateExecutionTarget(targetId);
             if (executionTarget == null)
             {
                 channel.Stderr($"Target {targetId} does not support executing Q# jobs.");
@@ -289,11 +289,8 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
             // Set the active target and load the package.
             ActiveTarget = executionTarget;
 
-            if (!(ActiveWorkspace is MockAzureWorkspace))
-            {
-                channel.Stdout($"Loading package {ActiveTarget.PackageName} and dependencies...");
-                await References.AddPackage(ActiveTarget.PackageName);
-            }
+            channel.Stdout($"Loading package {ActiveTarget.PackageName} and dependencies...");
+            await References.AddPackage(ActiveTarget.PackageName);
 
             channel.Stdout($"Active target is now {ActiveTarget.TargetId}");
 

--- a/src/AzureClient/AzureExecutionTarget.cs
+++ b/src/AzureClient/AzureExecutionTarget.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
     internal class AzureExecutionTarget
     {
         public string TargetId { get; protected set; } = string.Empty;
-        public string PackageName => $"Microsoft.Quantum.Providers.{GetProvider(TargetId)}";
+        public virtual string PackageName => $"Microsoft.Quantum.Providers.{GetProvider(TargetId)}";
 
         public static bool IsValid(string targetId) => GetProvider(targetId) != null;
 

--- a/src/AzureClient/AzureExecutionTarget.cs
+++ b/src/AzureClient/AzureExecutionTarget.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
 
     internal class AzureExecutionTarget
     {
-        public string TargetId { get; private set; } = string.Empty;
+        public string TargetId { get; protected set; } = string.Empty;
         public string PackageName => $"Microsoft.Quantum.Providers.{GetProvider(TargetId)}";
 
         public static bool IsValid(string targetId) => GetProvider(targetId) != null;
@@ -30,7 +30,7 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
         ///     Valid target IDs are structured as "provider.target".
         ///     For example, "ionq.simulator" or "honeywell.qpu".
         /// </remarks>
-        private static AzureProvider? GetProvider(string targetId)
+        protected static AzureProvider? GetProvider(string targetId)
         {
             var parts = targetId.Split('.', 2);
             if (Enum.TryParse(parts[0], true, out AzureProvider provider))

--- a/src/AzureClient/AzureWorkspace.cs
+++ b/src/AzureClient/AzureWorkspace.cs
@@ -70,9 +70,10 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
             return null;
         }
 
-        public IQuantumMachine? CreateQuantumMachine(string targetId, string storageAccountConnectionString)
-        {
-            return QuantumMachineFactory.CreateMachine(AzureQuantumWorkspace, targetId, storageAccountConnectionString);
-        }
+        public IQuantumMachine? CreateQuantumMachine(string targetId, string storageAccountConnectionString) =>
+            QuantumMachineFactory.CreateMachine(AzureQuantumWorkspace, targetId, storageAccountConnectionString);
+
+        public AzureExecutionTarget? CreateExecutionTarget(string targetId) =>
+            AzureExecutionTarget.Create(targetId);
     }
 }

--- a/src/AzureClient/IAzureWorkspace.cs
+++ b/src/AzureClient/IAzureWorkspace.cs
@@ -19,5 +19,6 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
         public Task<CloudJob?> GetJobAsync(string jobId);
         public Task<IEnumerable<CloudJob>?> ListJobsAsync();
         public IQuantumMachine? CreateQuantumMachine(string targetId, string storageAccountConnectionString);
+        public AzureExecutionTarget? CreateExecutionTarget(string targetId);
     }
 }

--- a/src/AzureClient/Mocks/MockAzureExecutionTarget.cs
+++ b/src/AzureClient/Mocks/MockAzureExecutionTarget.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#nullable enable
+
+namespace Microsoft.Quantum.IQSharp.AzureClient
+{
+    internal class MockAzureExecutionTarget : AzureExecutionTarget
+    {
+        new public string PackageName => $"Microsoft.Quantum.Providers.{GetProvider(TargetId)}::0.12.20072031";
+
+        new public static MockAzureExecutionTarget? Create(string targetId) =>
+            IsValid(targetId)
+            ? new MockAzureExecutionTarget() { TargetId = targetId }
+            : null;
+    }
+}

--- a/src/AzureClient/Mocks/MockAzureExecutionTarget.cs
+++ b/src/AzureClient/Mocks/MockAzureExecutionTarget.cs
@@ -7,9 +7,9 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
 {
     internal class MockAzureExecutionTarget : AzureExecutionTarget
     {
-        new public string PackageName => $"Microsoft.Quantum.Providers.{GetProvider(TargetId)}::0.12.20072031";
+        public override string PackageName => $"Microsoft.Quantum.Providers.{GetProvider(TargetId)}::0.12.20072031";
 
-        new public static MockAzureExecutionTarget? Create(string targetId) =>
+        public static MockAzureExecutionTarget? CreateMock(string targetId) =>
             IsValid(targetId)
             ? new MockAzureExecutionTarget() { TargetId = targetId }
             : null;

--- a/src/AzureClient/Mocks/MockAzureWorkspace.cs
+++ b/src/AzureClient/Mocks/MockAzureWorkspace.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
 
         public IQuantumMachine? CreateQuantumMachine(string targetId, string storageAccountConnectionString) => new MockQuantumMachine(this);
 
-        public AzureExecutionTarget? CreateExecutionTarget(string targetId) => MockAzureExecutionTarget.Create(targetId);
+        public AzureExecutionTarget? CreateExecutionTarget(string targetId) => MockAzureExecutionTarget.CreateMock(targetId);
 
         public void AddMockJobs(params string[] jobIds)
         {

--- a/src/AzureClient/Mocks/MockAzureWorkspace.cs
+++ b/src/AzureClient/Mocks/MockAzureWorkspace.cs
@@ -44,6 +44,8 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
 
         public IQuantumMachine? CreateQuantumMachine(string targetId, string storageAccountConnectionString) => new MockQuantumMachine(this);
 
+        public AzureExecutionTarget? CreateExecutionTarget(string targetId) => MockAzureExecutionTarget.Create(targetId);
+
         public void AddMockJobs(params string[] jobIds)
         {
             foreach (var jobId in jobIds)


### PR DESCRIPTION
Fixes #223 by adding a `MockAzureExecutionTarget` class which uses a fixed version of provider packages. This allows Python tests to successfully load packages in the end-to-end QDK builds where the "current" version of these provider packages is not available.