### PR TITLE
Publish ExecutionPathTracer as a Nuget package

### DIFF
--- a/build/pack.ps1
+++ b/build/pack.ps1
@@ -10,6 +10,8 @@ function Pack-Nuget() {
         [string]$project
     );
 
+    Write-Host "##[info]Packing $project..."
+
     dotnet pack (Join-Path $PSScriptRoot $project) `
         --no-build `
         -c $Env:BUILD_CONFIGURATION `
@@ -94,14 +96,10 @@ function Pack-Image() {
     }
 }
 
-Write-Host "##[info]Packing IQ# library..."
 Pack-Nuget '../src/Core/Core.csproj'
-
-Write-Host "##[info]Packing IQ# library with Jupyter extensions..."
 Pack-Nuget '../src/Jupyter/Jupyter.csproj'
-
-Write-Host "##[info]Packing IQ# tool..."
 Pack-Nuget '../src/Tool/Tool.csproj'
+Pack-Nuget '../src/ExecutionPathTracer/ExecutionPathTracer.csproj'
 
 if ($Env:ENABLE_PYTHON -eq "false") {
     Write-Host "##vso[task.logissue type=warning;]Skipping Creating Python packages. Env:ENABLE_PYTHON was set to 'false'."

--- a/build/pack.ps1
+++ b/build/pack.ps1
@@ -97,9 +97,9 @@ function Pack-Image() {
 }
 
 Pack-Nuget '../src/Core/Core.csproj'
+Pack-Nuget '../src/ExecutionPathTracer/ExecutionPathTracer.csproj'
 Pack-Nuget '../src/Jupyter/Jupyter.csproj'
 Pack-Nuget '../src/Tool/Tool.csproj'
-Pack-Nuget '../src/ExecutionPathTracer/ExecutionPathTracer.csproj'
 
 if ($Env:ENABLE_PYTHON -eq "false") {
     Write-Host "##vso[task.logissue type=warning;]Skipping Creating Python packages. Env:ENABLE_PYTHON was set to 'false'."

--- a/src/ExecutionPathTracer/ExecutionPathTracer.csproj
+++ b/src/ExecutionPathTracer/ExecutionPathTracer.csproj
@@ -8,6 +8,25 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <NoWarn>0162</NoWarn>
+    <Authors>Microsoft</Authors>
+    <Description>Microsoft Quantum's Execution Path Tracer.</Description>
+    <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
+    <PackageReleaseNotes>See: https://docs.microsoft.com/en-us/quantum/relnotes/</PackageReleaseNotes>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageProjectUrl>https://github.com/Microsoft/IQsharp/tree/master/src/ExecutionPathTracer</PackageProjectUrl>
+    <PackageIcon>qdk-nuget-icon.png</PackageIcon>
+    <PackageTags>Quantum Q# Qsharp</PackageTags>
+    <PackageId>Microsoft.Quantum.IQSharp.ExecutionPathTracer</PackageId>
+    <ContentTargetFolders>\</ContentTargetFolders>
+    <ApplicationIcon />
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="..\..\build\DelaySign.cs" Link="Properties\DelaySign.cs" />
+  </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.12.20073008-beta" />
   </ItemGroup>

--- a/src/ExecutionPathTracer/ExecutionPathTracer.csproj
+++ b/src/ExecutionPathTracer/ExecutionPathTracer.csproj
@@ -31,4 +31,8 @@
     <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.12.20073008-beta" />
   </ItemGroup>
 
+  <ItemGroup>
+    <None Include="..\..\build\assets\qdk-nuget-icon.png" Pack="true" Visible="false" PackagePath="" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
This PR publishes the `ExecutionPathTracer` project as a Nuget package for easier plug-and-play into other parts of our stack.