### PR TITLE
Fix Jupyter kernel script not executing on page refresh or new tab

### DIFF
--- a/src/Kernel/client/ipython.d.ts
+++ b/src/Kernel/client/ipython.d.ts
@@ -30,6 +30,7 @@ export interface Events {
 export interface Kernel {
     events: Events;
 
+    is_connected: () => Boolean;
     execute(code: string, callbacks: ShellCallbacks | undefined, options: {silent?: boolean, user_expressions?: object, allow_stdin?: boolean} | undefined): string;
     register_iopub_handler(msg_type: string, callback: (message: Message) => void);
     send_shell_message(msg_type: string, content: object, callbacks?: ShellCallbacks, metadata?: object, buffers?: Array<any>) : string;

--- a/src/Kernel/client/kernel.ts
+++ b/src/Kernel/client/kernel.ts
@@ -123,11 +123,17 @@ class Kernel {
     telemetryOptOut?: boolean | null;
 
     constructor() {
-        IPython.notebook.kernel.events.on("kernel_ready.Kernel", args => {
-            this.requestEcho();
-            this.requestClientInfo();
-            this.initExecutionPathVisualizer();
-        });
+        if (IPython.notebook.kernel.is_connected()) {
+            this.onStart();
+        } else {
+            IPython.notebook.kernel.events.on("kernel_ready.Kernel", args => this.onStart());
+        }
+    }
+
+    onStart() {
+        this.requestEcho();
+        this.requestClientInfo();
+        this.initExecutionPathVisualizer();
     }
 
     requestEcho() {


### PR DESCRIPTION
Currently, any tools using iopub/shell handlers to communicate with the Jupyter Notebook will not execute on page refresh or on a new tab. After investigation, this is because the `IPython.notebook.kernel.events` are not being sent to the new/reloaded JavaScript client if the kernel is already up and running.   It's not clear to me if _all_ `IPython.notebook.kernel.events` aren't being sent, but at least the following aren't:
- `kernel_ready.Kernel`
- `kernel_connected.Kernel`
- `kernel_created.Kernel`
- `kernel_created.Session`

To fix this, this PR first checks if `IPython.notebook.kernel.is_connected()` is `true`. If so, there's no need to wait on the above events, we just call the startup scripts. Otherwise, the kernel isn't ready and we proceed as usual.

Note: this does not solve the separate issue of the syntax highlighting for code mirror. That might be a separate problem with loading code mirror into the notebook.