### PR TITLE
Lints, styles, and abstractions

### DIFF
--- a/src/Kernel/Kernel.csproj
+++ b/src/Kernel/Kernel.csproj
@@ -32,7 +32,7 @@
     <Content Include="tsconfig.json">
       <CopyToOutputDirectory>Never</CopyToOutputDirectory>
     </Content>
-    <PackageReference Include="Microsoft.TypeScript.MSBuild" Version="3.7.4">
+    <PackageReference Include="Microsoft.TypeScript.MSBuild" Version="3.9.6">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/src/Kernel/client/ExecutionPathVisualizer/constants.ts
+++ b/src/Kernel/client/ExecutionPathVisualizer/constants.ts
@@ -15,37 +15,37 @@ export enum GateType {
     /** Nested group of classically-controlled gates. */
     ClassicalControlled,
     /** Invalid gate. */
-    Invalid
-};
+    Invalid,
+}
 
 // Display attributes
 /** Left padding of SVG. */
-export const leftPadding: number = 20;
+export const leftPadding = 20;
 /** x coordinate for first operation on each register. */
-export const startX: number = 80;
+export const startX = 80;
 /** y coordinate of first register. */
-export const startY: number = 40;
+export const startY = 40;
 /** Minimum width of each gate. */
-export const minGateWidth: number = 40;
+export const minGateWidth = 40;
 /** Height of each gate. */
-export const gateHeight: number = 40;
+export const gateHeight = 40;
 /** Padding on each side of gate. */
-export const gatePadding: number = 10;
+export const gatePadding = 10;
 /** Padding on each side of gate label. */
-export const labelPadding: number = 10;
+export const labelPadding = 10;
 /** Height between each qubit register. */
 export const registerHeight: number = gateHeight + gatePadding * 2;
 /** Height between classical registers. */
 export const classicalRegHeight: number = gateHeight;
 /** Classical box inner padding. */
-export const classicalBoxPadding: number = 15;
+export const classicalBoxPadding = 15;
 /** Additional offset for control button. */
-export const controlBtnOffset: number = 40;
+export const controlBtnOffset = 40;
 /** Control button radius. */
-export const controlBtnRadius: number = 15;
+export const controlBtnRadius = 15;
 /** Default font size for gate labels. */
-export const labelFontSize: number = 14;
+export const labelFontSize = 14;
 /** Default font size for gate arguments. */
-export const argsFontSize: number = 12;
+export const argsFontSize = 12;
 /** Starting x coord for each register wire. */
-export const regLineStart: number = 40;
+export const regLineStart = 40;

--- a/src/Kernel/client/ExecutionPathVisualizer/executionPath.ts
+++ b/src/Kernel/client/ExecutionPathVisualizer/executionPath.ts
@@ -1,4 +1,4 @@
-import { Register } from "./register";
+import { Register } from './register';
 
 /**
  * Structure of JSON representation of the execution path of a Q# operation.
@@ -7,7 +7,7 @@ export interface ExecutionPath {
     /** Array of qubit resources. */
     qubits: Qubit[];
     operations: Operation[];
-};
+}
 
 /**
  * Represents a unique qubit resource bit.
@@ -17,7 +17,7 @@ export interface Qubit {
     id: number;
     /** Number of classical registers attached to quantum register. */
     numChildren?: number;
-};
+}
 
 /**
  * Represents an operation and the registers it acts on.
@@ -25,12 +25,14 @@ export interface Qubit {
 export interface Operation {
     /** Gate label. */
     gate: string;
+    /** HTML element ID. */
+    id?: string;
     /** Formatted gate arguments to be displayed. */
-    displayArgs?: string,
+    displayArgs?: string;
     /** Classically-controlled gates.
      *  - children[0]: gates when classical control bit is 0.
      *  - children[1]: gates when classical control bit is 1.
-    */
+     */
     children?: Operation[][];
     /** Whether gate is a measurement operation. */
     isMeasurement: boolean;
@@ -42,4 +44,4 @@ export interface Operation {
     controls: Register[];
     /** Target registers the gate acts on. */
     targets: Register[];
-};
+}

--- a/src/Kernel/client/ExecutionPathVisualizer/formatters/formatUtils.ts
+++ b/src/Kernel/client/ExecutionPathVisualizer/formatters/formatUtils.ts
@@ -1,67 +1,72 @@
-import { labelFontSize } from "../constants";
+import { labelFontSize } from '../constants';
 
 // Helper functions for basic SVG components
 
 /**
  * Given an array of SVG elements, group them as an SVG group using the `<g>` tag.
- * 
- * @param svgElems Array of SVG elements.
- * 
+ *
+ * @param svgElems  Array of SVG elements.
+ * @param className Class name of element.
+ * @param id        ID of element.
+ *
  * @returns SVG string for grouped elements.
  */
-export const group = (...svgElems: (string | string[])[]): string =>
-    ['<g>', ...svgElems.flat(), '</g>'].join('\n');
+export const group = (svgElems: string[], className?: string, id?: string): string => {
+    const clsString: string = className != null ? ` class="${className}"` : '';
+    const idString: string = id != null ? ` id="${id}"` : '';
+    return [`<g${clsString}${idString}>`, ...svgElems.flat(), '</g>'].join('\n');
+};
 
 /**
  * Generate the SVG representation of a control dot used for controlled operations.
- * 
+ *
  * @param x      x coord of circle.
  * @param y      y coord of circle.
  * @param radius Radius of circle.
- * 
+ *
  * @returns SVG string for control dot.
  */
-export const controlDot = (x: number, y: number, radius: number = 5): string =>
+export const controlDot = (x: number, y: number, radius = 5): string =>
     `<circle class="control-dot" cx="${x}" cy="${y}" r="${radius}"></circle>`;
 
 /**
  * Generate an SVG line.
- * 
+ *
  * @param x1        x coord of starting point of line.
  * @param y1        y coord of starting point of line.
  * @param x2        x coord of ending point of line.
  * @param y2        y coord fo ending point of line.
  * @param className Class name of element.
- * 
+ *
  * @returns SVG string for line.
  */
 export const line = (x1: number, y1: number, x2: number, y2: number, className?: string): string => {
-    const clsString: string = (className != null) ? ` class="${className}"` : "";
+    const clsString: string = className != null ? ` class="${className}"` : '';
     return `<line${clsString} x1="${x1}" x2="${x2}" y1="${y1}" y2="${y2}"></line>`;
 };
 
 /**
  * Generate the SVG representation of a unitary box that represents an arbitrary unitary operation.
- * 
+ *
  * @param x         x coord of box.
  * @param y         y coord of box.
  * @param width     Width of box.
  * @param height    Height of box.
  * @param className Class name of element.
- * 
+ *
  * @returns SVG string for unitary box.
  */
-export const box = (x: number, y: number, width: number, height: number, className: string = "gate-unitary"): string =>
+export const box = (x: number, y: number, width: number, height: number, className = 'gate-unitary'): string =>
     `<rect class="${className}" x="${x}" y="${y}" width="${width}" height="${height}"></rect>`;
 
 /**
  * Generate the SVG text element from a given text string.
- * 
+ *
  * @param text String to render as SVG text.
  * @param x    Middle x coord of text.
  * @param y    Middle y coord of text.
  * @param fs   Font size of text.
- * 
+ *
  * @returns SVG string for text.
  */
 export const text = (text: string, x: number, y: number, fs: number = labelFontSize): string =>
@@ -69,12 +74,12 @@ export const text = (text: string, x: number, y: number, fs: number = labelFontS
 
 /**
  * Generate the SVG representation of the arc used in the measurement box.
- * 
+ *
  * @param x  x coord of arc.
  * @param y  y coord of arc.
  * @param rx x radius of arc.
  * @param ry y radius of arc.
- * 
+ *
  * @returns SVG string for arc.
  */
 export const arc = (x: number, y: number, rx: number, ry: number): string =>
@@ -82,32 +87,32 @@ export const arc = (x: number, y: number, rx: number, ry: number): string =>
 
 /**
  * Generate a dashed SVG line.
- * 
+ *
  * @param x1        x coord of starting point of line.
  * @param y1        y coord of starting point of line.
  * @param x2        x coord of ending point of line.
  * @param y2        y coord fo ending point of line.
  * @param className Class name of element.
- * 
+ *
  * @returns SVG string for dashed line.
  */
 export const dashedLine = (x1: number, y1: number, x2: number, y2: number, className?: string): string => {
-    const clsString: string = (className != null) ? ` class="${className}"` : "";
+    const clsString: string = className != null ? ` class="${className}"` : '';
     return `<line${clsString} x1="${x1}" x2="${x2}" y1="${y1}" y2="${y2}" stroke-dasharray="8, 8"></line>`;
 };
 
 /**
  * Generate the SVG representation of the dashed box used for enclosing groups of operations controlled on a classical register.
- * 
+ *
  * @param x         x coord of box.
  * @param y         y coord of box.
  * @param width     Width of box.
  * @param height    Height of box.
  * @param className Class name of element.
- * 
+ *
  * @returns SVG string for dashed box.
  */
 export const dashedBox = (x: number, y: number, width: number, height: number, className?: string): string => {
-    const clsString: string = (className != null) ? ` class="${className}"` : "";
+    const clsString: string = className != null ? ` class="${className}"` : '';
     return `<rect${clsString} x="${x}" y="${y}" width="${width}" height="${height}" fill-opacity="0" stroke-dasharray="8, 8"></rect>`;
 };

--- a/src/Kernel/client/ExecutionPathVisualizer/formatters/gateFormatter.ts
+++ b/src/Kernel/client/ExecutionPathVisualizer/formatters/gateFormatter.ts
@@ -310,8 +310,8 @@ const _classicalControlled = (metadata: Metadata, padding: number = classicalBox
  */
 const _controlCircle = (x: number, y: number, cls: string, r: number = controlBtnRadius): string =>
     `<g class="classically-controlled-btn ${cls}" onClick="toggleClassicalBtn('${cls}')">
-<circle class="${cls}" cx="${x}" cy="${y}" r="${r}" stroke="black" stroke-width="1"></circle>
-<text class="${cls} classically-controlled-text" font-size="${labelFontSize}" font-family="Arial" x="${x}" y="${y}" dominant-baseline="middle" text-anchor="middle" fill="black">?</text>
+<circle class="${cls}" cx="${x}" cy="${y}" r="${r}"></circle>
+<text class="${cls} classically-controlled-text" font-size="${labelFontSize}" x="${x}" y="${y}">?</text>
 </g>`;
 
 export { formatGates, _formatGate, _measure, _unitary, _swap, _controlledGate, _classicalControlled };

--- a/src/Kernel/client/ExecutionPathVisualizer/formatters/gateFormatter.ts
+++ b/src/Kernel/client/ExecutionPathVisualizer/formatters/gateFormatter.ts
@@ -1,4 +1,4 @@
-import { Metadata } from "../metadata";
+import { Metadata } from '../metadata';
 import {
     GateType,
     minGateWidth,
@@ -10,23 +10,14 @@ import {
     controlBtnOffset,
     classicalBoxPadding,
     classicalRegHeight,
-} from "../constants";
-import {
-    group,
-    controlDot,
-    line,
-    box,
-    text,
-    arc,
-    dashedLine,
-    dashedBox
-} from "./formatUtils";
+} from '../constants';
+import { group, controlDot, line, box, text, arc, dashedLine, dashedBox } from './formatUtils';
 
 /**
  * Given an array of operations (in metadata format), return the SVG representation.
- * 
+ *
  * @param opsMetadata Array of Metadata representation of operations.
- * 
+ *
  * @returns SVG representation of operations.
  */
 const formatGates = (opsMetadata: Metadata[]): string => {
@@ -35,22 +26,31 @@ const formatGates = (opsMetadata: Metadata[]): string => {
 };
 
 /**
+ * Groups SVG elements into a gate SVG group.
+ *
+ * @param svgElems Array of SVG elements.
+ * @param id       Custom element ID of SVG group.
+ *
+ * @returns SVG representation of a gate.
+ */
+const _createGate = (svgElems: string[], id?: string): string => group(svgElems, 'gate', id);
+
+/**
  * Takes in an operation's metadata and formats it into SVG.
- * 
+ *
  * @param metadata Metadata object representation of gate.
- * 
+ *
  * @returns SVG representation of gate.
  */
 const _formatGate = (metadata: Metadata): string => {
-    const { type, x, controlsY, targetsY, label, displayArgs, width } = metadata;
+    const { type, x, controlsY, targetsY, label, displayArgs, id, width } = metadata;
     switch (type) {
         case GateType.Measure:
-            return _measure(x, controlsY[0], targetsY[0]);
+            return _createGate([_measure(x, controlsY[0])], id);
         case GateType.Unitary:
-            return _unitary(label, x, targetsY, width, displayArgs);
+            return _createGate([_unitary(label, x, targetsY, width, displayArgs)], id);
         case GateType.Swap:
-            if (controlsY.length > 0) return _controlledGate(metadata);
-            else return _swap(x, targetsY);
+            return controlsY.length > 0 ? _controlledGate(metadata) : _createGate([_swap(x, targetsY)], id);
         case GateType.Cnot:
         case GateType.ControlledUnitary:
             return _controlledGate(metadata);
@@ -62,41 +62,45 @@ const _formatGate = (metadata: Metadata): string => {
 };
 
 /**
- * Creates a measurement gate at the x position, where qy and cy are
- * the y coords of the qubit register and classical register, respectively.
- * 
+ * Creates a measurement gate at position (x, y).
+ *
  * @param x  x coord of measurement gate.
- * @param qy y coord of qubit register.
- * @param cy y coord of classical register.
- * 
+ * @param y  y coord of measurement gate.
+ *
  * @returns SVG representation of measurement gate.
  */
-const _measure = (x: number, qy: number, cy: number): string => {
+const _measure = (x: number, y: number): string => {
     x -= minGateWidth / 2;
-    const width: number = minGateWidth, height = gateHeight;
+    const width: number = minGateWidth,
+        height = gateHeight;
     // Draw measurement box
-    const mBox: string = box(x, qy - height / 2, width, height, "gate-measure");
-    const mArc: string = arc(x + 5, qy + 2, width / 2 - 5, height / 2 - 8);
-    const meter: string = line(x + width / 2, qy + 8, x + width - 8, qy - height / 2 + 8);
-    const svg: string = group(mBox, mArc, meter);
-    return svg;
+    const mBox: string = box(x, y - height / 2, width, height, 'gate-measure');
+    const mArc: string = arc(x + 5, y + 2, width / 2 - 5, height / 2 - 8);
+    const meter: string = line(x + width / 2, y + 8, x + width - 8, y - height / 2 + 8);
+    return [mBox, mArc, meter].join('\n');
 };
 
 /**
  * Creates the SVG for a unitary gate on an arbitrary number of qubits.
- * 
+ *
  * @param label            Gate label.
  * @param x                x coord of gate.
  * @param y                Array of y coords of registers acted upon by gate.
  * @param width            Width of gate.
  * @param displayArgs           Arguments passed in to gate.
  * @param renderDashedLine If true, draw dashed lines between non-adjacent unitaries.
- * 
+ *
  * @returns SVG representation of unitary gate.
  */
-const _unitary = (label: string, x: number, y: number[], width: number, displayArgs?: string,
-    renderDashedLine: boolean = true): string => {
-    if (y.length === 0) return "";
+const _unitary = (
+    label: string,
+    x: number,
+    y: number[],
+    width: number,
+    displayArgs?: string,
+    renderDashedLine = true,
+): string => {
+    if (y.length === 0) return '';
 
     // Sort y in ascending order
     y.sort((y1, y2) => y1 - y2);
@@ -115,14 +119,16 @@ const _unitary = (label: string, x: number, y: number[], width: number, displayA
 
     // Render each group as a separate unitary boxes
     const unitaryBoxes: string[] = regGroups.map((group: number[]) => {
-        const maxY: number = group[group.length - 1], minY: number = group[0];
+        const maxY: number = group[group.length - 1],
+            minY: number = group[0];
         const height: number = maxY - minY + gateHeight;
         return _unitaryBox(label, x, minY, width, height, displayArgs);
     });
 
     // Draw dashed line between disconnected unitaries
     if (renderDashedLine && unitaryBoxes.length > 1) {
-        const maxY: number = y[y.length - 1], minY: number = y[0];
+        const maxY: number = y[y.length - 1],
+            minY: number = y[0];
         const vertLine: string = dashedLine(x, minY, x, maxY);
         return [vertLine, ...unitaryBoxes].join('\n');
     } else return unitaryBoxes.join('\n');
@@ -130,21 +136,27 @@ const _unitary = (label: string, x: number, y: number[], width: number, displayA
 
 /**
  * Generates SVG representation of the boxed unitary gate symbol.
- * 
+ *
  * @param label  Label for unitary operation.
  * @param x      x coord of gate.
  * @param y      y coord of gate.
  * @param width  Width of gate.
  * @param height Height of gate.
  * @param displayArgs Arguments passed in to gate.
- * 
+ *
  * @returns SVG representation of unitary box.
  */
-const _unitaryBox = (label: string, x: number, y: number, width: number,
-    height: number = gateHeight, displayArgs?: string): string => {
+const _unitaryBox = (
+    label: string,
+    x: number,
+    y: number,
+    width: number,
+    height: number = gateHeight,
+    displayArgs?: string,
+): string => {
     y -= gateHeight / 2;
     const uBox: string = box(x - width / 2, y, width, height);
-    const labelY = y + height / 2 - ((displayArgs == null) ? 0 : 7);
+    const labelY = y + height / 2 - (displayArgs == null ? 0 : 7);
     const labelText: string = text(label, x, labelY);
     const elems = [uBox, labelText];
     if (displayArgs != null) {
@@ -152,36 +164,34 @@ const _unitaryBox = (label: string, x: number, y: number, width: number,
         const argText: string = text(displayArgs, x, argStrY, argsFontSize);
         elems.push(argText);
     }
-    const svg: string = group(elems);
-    return svg;
+    return elems.join('\n');
 };
 
 /**
  * Creates the SVG for a SWAP gate on y coords given by targetsY.
- * 
+ *
  * @param x          Centre x coord of SWAP gate.
  * @param targetsY   y coords of target registers.
- * 
+ *
  * @returns SVG representation of SWAP gate.
  */
 const _swap = (x: number, targetsY: number[]): string => {
     // Get SVGs of crosses
-    const crosses: string[] = targetsY.map(y => _cross(x, y));
+    const crosses: string[] = targetsY.map((y) => _cross(x, y));
     const vertLine: string = line(x, targetsY[0], x, targetsY[1]);
-    const svg: string = group(crosses, vertLine);
-    return svg;
+    return [crosses, vertLine].join('\n');
 };
 
 /**
  * Generates cross for display in SWAP gate.
- * 
+ *
  * @param x x coord of gate.
  * @param y y coord of gate.
- * 
+ *
  * @returns SVG representation for cross.
  */
 const _cross = (x: number, y: number): string => {
-    const radius: number = 8;
+    const radius = 8;
     const line1: string = line(x - radius, y - radius, x + radius, y + radius);
     const line2: string = line(x - radius, y + radius, x + radius, y - radius);
     return [line1, line2].join('\n');
@@ -189,21 +199,21 @@ const _cross = (x: number, y: number): string => {
 
 /**
  * Produces the SVG representation of a controlled gate on multiple qubits.
- * 
+ *
  * @param metadata Metadata of controlled gate.
- * 
+ *
  * @returns SVG representation of controlled gate.
  */
 const _controlledGate = (metadata: Metadata): string => {
     const targetGateSvgs: string[] = [];
-    const { type, x, controlsY, targetsY, label, displayArgs, width } = metadata;
+    const { type, x, controlsY, targetsY, label, displayArgs, id, width } = metadata;
     // Get SVG for target gates
     switch (type) {
         case GateType.Cnot:
-            targetsY.forEach(y => targetGateSvgs.push(_oplus(x, y)));
+            targetsY.forEach((y) => targetGateSvgs.push(_oplus(x, y)));
             break;
         case GateType.Swap:
-            targetsY.forEach(y => targetGateSvgs.push(_cross(x, y)));
+            targetsY.forEach((y) => targetGateSvgs.push(_cross(x, y)));
             break;
         case GateType.ControlledUnitary:
             targetGateSvgs.push(_unitary(label, x, targetsY, width, displayArgs, false));
@@ -212,61 +222,62 @@ const _controlledGate = (metadata: Metadata): string => {
             throw new Error(`ERROR: Unrecognized gate: ${label} of type ${type}`);
     }
     // Get SVGs for control dots
-    const controlledDotsSvg: string[] = controlsY.map(y => controlDot(x, y));
+    const controlledDotsSvg: string[] = controlsY.map((y) => controlDot(x, y));
     // Create control lines
     const maxY: number = Math.max(...controlsY, ...targetsY);
     const minY: number = Math.min(...controlsY, ...targetsY);
     const vertLine: string = line(x, minY, x, maxY);
-    const svg: string = group(vertLine, controlledDotsSvg, targetGateSvgs);
+    const svg: string = _createGate([vertLine, ...controlledDotsSvg, ...targetGateSvgs], id);
     return svg;
 };
 
 /**
  * Generates $\oplus$ symbol for display in CNOT gate.
- * 
+ *
  * @param x x coordinate of gate.
  * @param y y coordinate of gate.
  * @param r radius of circle.
- * 
+ *
  * @returns SVG representation of $\oplus$ symbol.
  */
-const _oplus = (x: number, y: number, r: number = 15): string => {
-    const circle: string = `<circle class="oplus" cx="${x}" cy="${y}" r="${r}"></circle>`;
+const _oplus = (x: number, y: number, r = 15): string => {
+    const circle = `<circle class="oplus" cx="${x}" cy="${y}" r="${r}"></circle>`;
     const vertLine: string = line(x, y - r, x, y + r);
     const horLine: string = line(x - r, y, x + r, y);
-    const svg: string = group(circle, vertLine, horLine);
-    return svg;
-}
+    return [circle, vertLine, horLine].join('\n');
+};
 
 /**
- * Generates the SVG for a classically controlled group of oeprations.
- * 
+ * Generates the SVG for a classically controlled group of operations.
+ *
  * @param metadata Metadata representation of gate.
  * @param padding  Padding within dashed box.
- * 
+ *
  * @returns SVG representation of gate.
  */
 const _classicalControlled = (metadata: Metadata, padding: number = classicalBoxPadding): string => {
-    let { x, controlsY, targetsY, width, children, htmlClass } = metadata;
+    let { x, width, htmlClass } = metadata;
+    const { controlsY, targetsY, children, id } = metadata;
 
     const controlY = controlsY[0];
     if (htmlClass == null) htmlClass = 'classically-controlled';
 
     // Get SVG for gates controlled on 0 and make them hidden initially
-    let childrenZero: string = (children != null) ? formatGates(children[0]) : '';
+    let childrenZero: string = children != null ? formatGates(children[0]) : '';
     childrenZero = `<g class="${htmlClass}-zero hidden">\r\n${childrenZero}</g>`;
 
     // Get SVG for gates controlled on 1
-    let childrenOne: string = (children != null) ? formatGates(children[1]) : '';
+    let childrenOne: string = children != null ? formatGates(children[1]) : '';
     childrenOne = `<g class="${htmlClass}-one">\r\n${childrenOne}</g>`;
 
     // Draw control button and attached dashed line to dashed box
     const controlCircleX: number = x + controlBtnRadius;
     const controlCircle: string = _controlCircle(controlCircleX, controlY, htmlClass);
-    const lineY1: number = controlY + controlBtnRadius, lineY2: number = controlY + classicalRegHeight / 2;
-    const vertLine: string = dashedLine(controlCircleX, lineY1, controlCircleX, lineY2, "classical-line");
+    const lineY1: number = controlY + controlBtnRadius,
+        lineY2: number = controlY + classicalRegHeight / 2;
+    const vertLine: string = dashedLine(controlCircleX, lineY1, controlCircleX, lineY2, 'classical-line');
     x += controlBtnOffset;
-    const horLine: string = dashedLine(controlCircleX, lineY2, x, lineY2, "classical-line");
+    const horLine: string = dashedLine(controlCircleX, lineY2, x, lineY2, 'classical-line');
 
     width = width - controlBtnOffset + (padding - classicalBoxPadding) * 2;
     x += classicalBoxPadding - padding;
@@ -274,11 +285,14 @@ const _classicalControlled = (metadata: Metadata, padding: number = classicalBox
     const height: number = targetsY[1] - targetsY[0] + gateHeight + padding * 2;
 
     // Draw dashed box around children gates
-    const box: string = dashedBox(x, y, width, height, "classical-container");
+    const box: string = dashedBox(x, y, width, height, 'classical-container');
 
     // Display controlled operation in initial "unknown" state
-    const svg: string = group(`<g class="${htmlClass}-group classically-controlled-unknown">`, horLine, vertLine,
-        controlCircle, childrenZero, childrenOne, box, '</g>');
+    const svg: string = group(
+        [horLine, vertLine, controlCircle, childrenZero, childrenOne, box],
+        `${htmlClass}-group classically-controlled-unknown`,
+        id,
+    );
 
     return svg;
 };
@@ -286,12 +300,12 @@ const _classicalControlled = (metadata: Metadata, padding: number = classicalBox
 /**
  * Generates the SVG representation of the control circle on a classical register with interactivity support
  * for toggling between bit values (unknown, 1, and 0).
- * 
+ *
  * @param x   x coord.
  * @param y   y coord.
  * @param cls Class name.
  * @param r   Radius of circle.
- * 
+ *
  * @returns SVG representation of control circle.
  */
 const _controlCircle = (x: number, y: number, cls: string, r: number = controlBtnRadius): string =>
@@ -300,12 +314,4 @@ const _controlCircle = (x: number, y: number, cls: string, r: number = controlBt
 <text class="${cls} classically-controlled-text" font-size="${labelFontSize}" font-family="Arial" x="${x}" y="${y}" dominant-baseline="middle" text-anchor="middle" fill="black">?</text>
 </g>`;
 
-export {
-    formatGates,
-    _formatGate,
-    _measure,
-    _unitary,
-    _swap,
-    _controlledGate,
-    _classicalControlled,
-};
+export { formatGates, _formatGate, _measure, _unitary, _swap, _controlledGate, _classicalControlled };

--- a/src/Kernel/client/ExecutionPathVisualizer/formatters/inputFormatter.ts
+++ b/src/Kernel/client/ExecutionPathVisualizer/formatters/inputFormatter.ts
@@ -1,22 +1,17 @@
-import { Qubit } from "../executionPath";
-import { RegisterType, RegisterMap, RegisterMetadata } from "../register";
-import {
-    leftPadding,
-    startY,
-    registerHeight,
-    classicalRegHeight,
-} from "../constants";
+import { Qubit } from '../executionPath';
+import { RegisterType, RegisterMap, RegisterMetadata } from '../register';
+import { leftPadding, startY, registerHeight, classicalRegHeight } from '../constants';
 
 /**
  * `formatInputs` takes in an array of Qubits and outputs the SVG string of formatted
  * qubit wires and a mapping from register IDs to register metadata (for rendering).
- * 
+ *
  * @param qubits List of declared qubits.
- * 
+ *
  * @returns returns the SVG string of formatted qubit wires, a mapping from registers
  *          to y coord and total SVG height.
  */
-const formatInputs = (qubits: Qubit[]): { qubitWires: string, registers: RegisterMap, svgHeight: number } => {
+const formatInputs = (qubits: Qubit[]): { qubitWires: string; registers: RegisterMap; svgHeight: number } => {
     const qubitWires: string[] = [];
     const registers: RegisterMap = {};
 
@@ -38,7 +33,7 @@ const formatInputs = (qubits: Qubit[]): { qubitWires: string, registers: Registe
         currY += classicalRegHeight;
 
         // Add classical wires
-        registers[id].children = Array.from(Array(numChildren), _ => {
+        registers[id].children = Array.from(Array(numChildren), () => {
             const clsReg: RegisterMetadata = { type: RegisterType.Classical, y: currY };
             currY += classicalRegHeight;
             return clsReg;
@@ -48,21 +43,18 @@ const formatInputs = (qubits: Qubit[]): { qubitWires: string, registers: Registe
     return {
         qubitWires: qubitWires.join('\n'),
         registers,
-        svgHeight: currY
+        svgHeight: currY,
     };
 };
 
 /**
  * Generate the SVG text component for the input qubit register.
- * 
+ *
  * @param y y coord of input wire to render in SVG.
- * 
+ *
  * @returns SVG text component for the input register.
  */
 const _qubitInput = (y: number): string =>
     `<text x="${leftPadding}" y="${y}" dominant-baseline="middle" text-anchor="start">|0⟩</text>`;
 
-export {
-    formatInputs,
-    _qubitInput,
-};
+export { formatInputs, _qubitInput };

--- a/src/Kernel/client/ExecutionPathVisualizer/formatters/registerFormatter.ts
+++ b/src/Kernel/client/ExecutionPathVisualizer/formatters/registerFormatter.ts
@@ -1,16 +1,16 @@
-import { RegisterMap } from "../register";
-import { regLineStart, GateType } from "../constants";
-import { Metadata } from "../metadata";
-import { line } from "./formatUtils";
+import { RegisterMap } from '../register';
+import { regLineStart, GateType } from '../constants';
+import { Metadata } from '../metadata';
+import { line } from './formatUtils';
 
 /**
  * Generate the SVG representation of the qubit register wires in `registers` and the classical wires
  * stemming from each measurement gate.
- * 
+ *
  * @param registers    Map from register IDs to register metadata.
  * @param measureGates Array of measurement gates metadata.
  * @param endX         End x coord.
- * 
+ *
  * @returns SVG representation of register wires.
  */
 const formatRegisters = (registers: RegisterMap, measureGates: Metadata[], endX: number): string => {
@@ -23,7 +23,7 @@ const formatRegisters = (registers: RegisterMap, measureGates: Metadata[], endX:
     measureGates.forEach(({ type, x, targetsY, controlsY }) => {
         if (type !== GateType.Measure) return;
         const gateY: number = controlsY[0];
-        targetsY.forEach(y => {
+        targetsY.forEach((y) => {
             formattedRegs.push(_classicalRegister(x, gateY, endX, y));
         });
     });
@@ -32,46 +32,66 @@ const formatRegisters = (registers: RegisterMap, measureGates: Metadata[], endX:
 
 /**
  * Generates the SVG representation of a classical register.
- * 
+ *
  * @param startX Start x coord.
  * @param gateY  y coord of measurement gate.
  * @param endX   End x coord.
  * @param wireY  y coord of wire.
- * 
+ *
  * @returns SVG representation of the given classical register.
  */
 const _classicalRegister = (startX: number, gateY: number, endX: number, wireY: number): string => {
-    const wirePadding: number = 1;
+    const wirePadding = 1;
     // Draw vertical lines
-    const vLine1: string = line(startX + wirePadding, gateY, startX + wirePadding, wireY - wirePadding, "register-classical");
-    const vLine2: string = line(startX - wirePadding, gateY, startX - wirePadding, wireY + wirePadding, "register-classical");
+    const vLine1: string = line(
+        startX + wirePadding,
+        gateY,
+        startX + wirePadding,
+        wireY - wirePadding,
+        'register-classical',
+    );
+    const vLine2: string = line(
+        startX - wirePadding,
+        gateY,
+        startX - wirePadding,
+        wireY + wirePadding,
+        'register-classical',
+    );
     // Draw horizontal lines
-    const hLine1: string = line(startX + wirePadding, wireY - wirePadding, endX, wireY - wirePadding, "register-classical");
-    const hLine2: string = line(startX - wirePadding, wireY + wirePadding, endX, wireY + wirePadding, "register-classical");
+    const hLine1: string = line(
+        startX + wirePadding,
+        wireY - wirePadding,
+        endX,
+        wireY - wirePadding,
+        'register-classical',
+    );
+    const hLine2: string = line(
+        startX - wirePadding,
+        wireY + wirePadding,
+        endX,
+        wireY + wirePadding,
+        'register-classical',
+    );
     const svg: string = [vLine1, vLine2, hLine1, hLine2].join('\n');
     return svg;
 };
 
 /**
  * Generates the SVG representation of a qubit register.
- * 
+ *
  * @param qId         Qubit register index.
  * @param endX        End x coord.
  * @param y           y coord of wire.
  * @param labelOffset y offset for wire label.
- * 
+ *
  * @returns SVG representation of the given qubit register.
  */
-const _qubitRegister = (qId: number, endX: number, y: number, labelOffset: number = 16): string => {
+const _qubitRegister = (qId: number, endX: number, y: number, labelOffset = 16): string => {
     const labelY: number = y - labelOffset;
     const wire: string = line(regLineStart, y, endX, y);
-    const label: string = `<text x="${regLineStart}" y="${labelY}" dominant-baseline="hanging" text-anchor="start" font-size="75%">q${qId}</text>`;
+    const label = `<text x="${regLineStart}" y="${labelY}" dominant-baseline="hanging" text-anchor="start" font-size="75%">q${qId}</text>`;
     const svg: string = [wire, label].join('\n');
     return svg;
 };
 
-export {
-    formatRegisters,
-    _classicalRegister,
-    _qubitRegister,
-};
+export { formatRegisters, _classicalRegister, _qubitRegister };

--- a/src/Kernel/client/ExecutionPathVisualizer/index.ts
+++ b/src/Kernel/client/ExecutionPathVisualizer/index.ts
@@ -83,3 +83,4 @@ export const executionPathToHtml = (json: ExecutionPath, userStyleConfig?: Style
 
 // Export types
 export type { ExecutionPath, StyleConfig };
+export { STYLES } from './styles';

--- a/src/Kernel/client/ExecutionPathVisualizer/index.ts
+++ b/src/Kernel/client/ExecutionPathVisualizer/index.ts
@@ -1,17 +1,17 @@
-import { formatInputs } from "./formatters/inputFormatter";
-import { formatGates } from "./formatters/gateFormatter";
-import { formatRegisters } from "./formatters/registerFormatter";
-import { processOperations } from "./process";
-import { ExecutionPath } from "./executionPath";
-import { Metadata } from "./metadata";
-import { GateType } from "./constants";
-import { StyleConfig, style } from "./styles";
+import { formatInputs } from './formatters/inputFormatter';
+import { formatGates } from './formatters/gateFormatter';
+import { formatRegisters } from './formatters/registerFormatter';
+import { processOperations } from './process';
+import { ExecutionPath } from './executionPath';
+import { Metadata } from './metadata';
+import { GateType } from './constants';
+import { StyleConfig, style } from './styles';
 
 /**
  * Custom JavaScript code to be injected into visualization HTML string.
  * Handles interactive elements, such as classically-controlled operations.
  */
-const script: string = `
+const script = `
 <script type="text/JavaScript">
     function toggleClassicalBtn(cls) {
         const textSvg = document.querySelector(\`.\${cls} text\`);
@@ -45,27 +45,41 @@ const script: string = `
 `;
 
 /**
- * Converts JSON representing an execution path of a Q# program given by the simulator and returns its HTML visualization.
- * 
+ * Converts JSON representing an execution path of a Q# program given by the simulator and returns its SVG visualization.
+ *
  * @param json            JSON received from simulator.
  * @param userStyleConfig Custom CSS style config for visualization.
- * 
- * @returns HTML representation of circuit.
+ *
+ * @returns SVG representation of circuit.
  */
-export const executionPathToHtml = (json: ExecutionPath, userStyleConfig?: StyleConfig): string => {
+export const executionPathToSvg = (json: ExecutionPath, userStyleConfig?: StyleConfig): string => {
     const { qubits, operations } = json;
     const { qubitWires, registers, svgHeight } = formatInputs(qubits);
     const { metadataList, svgWidth } = processOperations(operations, registers);
     const formattedGates: string = formatGates(metadataList);
     const measureGates: Metadata[] = metadataList.filter(({ type }) => type === GateType.Measure);
     const formattedRegs: string = formatRegisters(registers, measureGates, svgWidth);
-    return `<html>
-    <svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="${svgWidth}" height="${svgHeight}">
-        ${script}
-        ${style(userStyleConfig)}
-        ${qubitWires}
-        ${formattedRegs}
-        ${formattedGates}
-    </svg>
-</html>`;
+    return `<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="${svgWidth}" height="${svgHeight}">
+    ${script}
+    ${style(userStyleConfig)}
+    ${qubitWires}
+    ${formattedRegs}
+    ${formattedGates}
+</svg>`;
 };
+
+/**
+ * Converts JSON representing an execution path of a Q# program given by the simulator and returns its HTML visualization.
+ *
+ * @param json            JSON received from simulator.
+ * @param userStyleConfig Custom CSS style config for visualization.
+ *
+ * @returns HTML representation of circuit.
+ */
+export const executionPathToHtml = (json: ExecutionPath, userStyleConfig?: StyleConfig): string =>
+    `<html>
+    ${executionPathToSvg(json, userStyleConfig)}
+</html>`;
+
+// Export types
+export type { ExecutionPath, StyleConfig };

--- a/src/Kernel/client/ExecutionPathVisualizer/metadata.ts
+++ b/src/Kernel/client/ExecutionPathVisualizer/metadata.ts
@@ -1,4 +1,4 @@
-import { GateType } from "./constants";
+import { GateType } from './constants';
 
 /**
  * Metadata used to store information pertaining to a given
@@ -16,14 +16,16 @@ export interface Metadata {
     /** Gate label. */
     label: string;
     /** Gate arguments as string. */
-    displayArgs?: string,
+    displayArgs?: string;
+    /** HTML element ID. */
+    id?: string;
     /** Gate width. */
     width: number;
     /** Classically-controlled gates.
      *  - children[0]: gates when classical control bit is 0.
      *  - children[1]: gates when classical control bit is 1.
-    */
+     */
     children?: Metadata[][];
     /** HTML element class for interactivity. */
     htmlClass?: string;
-};
+}

--- a/src/Kernel/client/ExecutionPathVisualizer/process.ts
+++ b/src/Kernel/client/ExecutionPathVisualizer/process.ts
@@ -1,29 +1,23 @@
-import {
-    minGateWidth,
-    startX,
-    gatePadding,
-    GateType,
-    controlBtnOffset,
-    classicalBoxPadding,
-} from "./constants";
-import { Operation } from "./executionPath";
-import { Metadata } from "./metadata";
-import { Register, RegisterMap, RegisterType } from "./register";
-import { getGateWidth } from "./utils";
+import { minGateWidth, startX, gatePadding, GateType, controlBtnOffset, classicalBoxPadding } from './constants';
+import { Operation } from './executionPath';
+import { Metadata } from './metadata';
+import { Register, RegisterMap, RegisterType } from './register';
+import { getGateWidth } from './utils';
 
 /**
  * Takes in a list of operations and maps them to `metadata` objects which
  * contains information for formatting the corresponding SVG.
- * 
+ *
  * @param operations Array of operations.
  * @param registers  Array of registers.
- * 
+ *
  * @returns An object containing `metadataList` (Array of Metadata objects) and
  *          `svgWidth` which is the width of the entire SVG.
  */
-const processOperations = (operations: Operation[], registers: RegisterMap)
-    : { metadataList: Metadata[], svgWidth: number } => {
-
+const processOperations = (
+    operations: Operation[],
+    registers: RegisterMap,
+): { metadataList: Metadata[]; svgWidth: number } => {
     if (operations.length === 0) return { metadataList: [], svgWidth: startX };
 
     // Group operations based on registers
@@ -33,12 +27,12 @@ const processOperations = (operations: Operation[], registers: RegisterMap)
     const alignedOps: (number | null)[][] = _alignOps(groupedOps);
 
     // Maintain widths of each column to account for variable-sized gates
-    const numColumns: number = Math.max(0, ...alignedOps.map(ops => ops.length));
+    const numColumns: number = Math.max(0, ...alignedOps.map((ops) => ops.length));
     const columnsWidths: number[] = new Array(numColumns).fill(minGateWidth);
     // Keep track of which ops are already seen to avoid duplicate rendering
     const visited: { [opIdx: number]: boolean } = {};
     // Unique HTML class for each classically-controlled group of gates.
-    let cls: number = 1;
+    let cls = 1;
 
     // Map operation index to gate metadata for formatting later
     const opsMetadata: Metadata[][] = alignedOps.map((regOps) =>
@@ -63,7 +57,7 @@ const processOperations = (operations: Operation[], registers: RegisterMap)
             }
 
             return metadata;
-        })
+        }),
     );
 
     // Fill in x coord of each gate
@@ -77,10 +71,10 @@ const processOperations = (operations: Operation[], registers: RegisterMap)
 
 /**
  * Group gates provided by operations into their respective registers.
- * 
+ *
  * @param operations Array of operations.
  * @param numRegs    Total number of registers.
- * 
+ *
  * @returns 2D array of indices where `groupedOps[i][j]` is the index of the operations
  *          at register `i` and column `j` (not yet aligned/padded).
  */
@@ -97,8 +91,8 @@ const _groupOperations = (operations: Operation[], registers: RegisterMap): numb
         if (!isClassicallyControlled && qRegs.length === 0) return;
         // If operation is classically-controlled, pad all qubit registers. Otherwise, only pad
         // the contiguous range of registers that it covers.
-        const minRegIdx: number = (isClassicallyControlled) ? 0 : Math.min(...qRegIdxList);
-        const maxRegIdx: number = (isClassicallyControlled) ? numRegs - 1 : Math.max(...qRegIdxList);
+        const minRegIdx: number = isClassicallyControlled ? 0 : Math.min(...qRegIdxList);
+        const maxRegIdx: number = isClassicallyControlled ? numRegs - 1 : Math.max(...qRegIdxList);
         // Add operation also to registers that are in-between target registers
         // so that other gates won't render in the middle.
         for (let i = minRegIdx; i <= maxRegIdx; i++) {
@@ -113,15 +107,15 @@ const _groupOperations = (operations: Operation[], registers: RegisterMap): numb
  * gates are in the same column.
  * e.g. ---[x]---[x]--
  *      ----------|---
- * 
+ *
  * @param ops 2D array of operations. Each row represents a register
  *            and the operations acting on it (in-order).
- * 
+ *
  * @returns 2D array of aligned operations padded with `null`s.
  */
 const _alignOps = (ops: number[][]): (number | null)[][] => {
-    let maxNumOps: number = Math.max(0, ...ops.map(regOps => regOps.length));
-    let col: number = 0;
+    let maxNumOps: number = Math.max(0, ...ops.map((regOps) => regOps.length));
+    let col = 0;
     // Deep copy ops to be returned as paddedOps
     const paddedOps: (number | null)[][] = JSON.parse(JSON.stringify(ops));
     while (col < maxNumOps) {
@@ -130,10 +124,10 @@ const _alignOps = (ops: number[][]): (number | null)[][] => {
             if (reg.length <= col) continue;
 
             // Should never be null (nulls are only padded to previous columns)
-            const opIdx: (number | null) = reg[col];
+            const opIdx: number | null = reg[col];
 
             // Get position of gate
-            const targetsPos: number[] = paddedOps.map(regOps => regOps.indexOf(opIdx));
+            const targetsPos: number[] = paddedOps.map((regOps) => regOps.indexOf(opIdx));
             const gatePos: number = Math.max(-1, ...targetsPos);
 
             // If current column is not desired gate position, pad with null
@@ -145,19 +139,19 @@ const _alignOps = (ops: number[][]): (number | null)[][] => {
         col++;
     }
     return paddedOps;
-}
+};
 
 /**
  * Given an array of column widths, calculate the middle x coord of each column.
  * This will be used to centre the gates within each column.
- * 
+ *
  * @param columnWidths Array of column widths where `columnWidths[i]` is the
  *                     width of the `i`th column.
- * 
+ *
  * @returns Object containing the middle x coords of each column (`columnsX`) and the width
  * of the corresponding SVG (`svgWidth`).
  */
-const _getColumnsX = (columnWidths: number[]): { columnsX: number[], svgWidth: number } => {
+const _getColumnsX = (columnWidths: number[]): { columnsX: number[]; svgWidth: number } => {
     const columnsX: number[] = new Array(columnWidths.length).fill(0);
     let x: number = startX;
     columnWidths.forEach((width, i) => {
@@ -170,10 +164,10 @@ const _getColumnsX = (columnWidths: number[]): { columnsX: number[], svgWidth: n
 /**
  * Maps operation to metadata (e.g. gate type, position, dimensions, text)
  * required to render the image.
- * 
+ *
  * @param op        Operation to be mapped into metadata format.
  * @param registers Array of registers.
- * 
+ *
  * @returns Metadata representation of given operation.
  */
 const _opToMetadata = (op: Operation | null, registers: RegisterMap): Metadata => {
@@ -188,20 +182,11 @@ const _opToMetadata = (op: Operation | null, registers: RegisterMap): Metadata =
 
     if (op == null) return metadata;
 
-    let {
-        gate,
-        displayArgs,
-        isMeasurement,
-        isControlled,
-        isAdjoint,
-        controls,
-        targets,
-        children
-    } = op;
+    const { gate, id, displayArgs, isMeasurement, isControlled, isAdjoint, controls, targets, children } = op;
 
     // Set y coords
-    metadata.controlsY = controls.map(reg => _getRegY(reg, registers));
-    metadata.targetsY = targets.map(reg => _getRegY(reg, registers));
+    metadata.controlsY = controls.map((reg) => _getRegY(reg, registers));
+    metadata.targetsY = targets.map((reg) => _getRegY(reg, registers));
 
     if (children != null && children.length > 0) {
         // Classically-controlled operations
@@ -233,7 +218,7 @@ const _opToMetadata = (op: Operation | null, registers: RegisterMap): Metadata =
     } else if (gate === 'SWAP') {
         metadata.type = GateType.Swap;
     } else if (isControlled) {
-        metadata.type = (gate === 'X') ? GateType.Cnot : GateType.ControlledUnitary;
+        metadata.type = gate === 'X' ? GateType.Cnot : GateType.ControlledUnitary;
         metadata.label = gate;
     } else {
         // Any other gate treated as a simple unitary gate
@@ -250,15 +235,18 @@ const _opToMetadata = (op: Operation | null, registers: RegisterMap): Metadata =
     // Set gate width
     metadata.width = getGateWidth(metadata);
 
+    // Set custom gate ID
+    metadata.id = id;
+
     return metadata;
 };
 
 /**
  * Compute the y coord of a given register.
- * 
+ *
  * @param reg       Register to compute y coord of.
  * @param registers Map of qubit IDs to RegisterMetadata.
- * 
+ *
  * @returns The y coord of give register.
  */
 const _getRegY = (reg: Register, registers: RegisterMap): number => {
@@ -270,9 +258,12 @@ const _getRegY = (reg: Register, registers: RegisterMap): number => {
             return y;
         case RegisterType.Classical:
             if (children == null) throw new Error(`ERROR: No classical registers found for qubit ID ${qId}.`);
-            if (cId == null) throw new Error(`ERROR: No ID defined for classical register associated with qubit ID ${qId}.`);
+            if (cId == null)
+                throw new Error(`ERROR: No ID defined for classical register associated with qubit ID ${qId}.`);
             if (children.length <= cId)
-                throw new Error(`ERROR: Classical register ID ${cId} invalid for qubit ID ${qId} with ${children.length} classical register(s).`);
+                throw new Error(
+                    `ERROR: Classical register ID ${cId} invalid for qubit ID ${qId} with ${children.length} classical register(s).`,
+                );
             return children[cId].y;
         default:
             throw new Error(`ERROR: Unknown register type ${type}.`);
@@ -281,30 +272,30 @@ const _getRegY = (reg: Register, registers: RegisterMap): number => {
 
 /**
  * Adds HTML class to metadata and its nested children.
- * 
+ *
  * @param metadata Metadata assigned to class.
  * @param cls      HTML class name.
  */
 const _addClass = (metadata: Metadata, cls: string): void => {
     metadata.htmlClass = cls;
     if (metadata.children != null) {
-        metadata.children[0].forEach(child => _addClass(child, cls));
-        metadata.children[1].forEach(child => _addClass(child, cls));
+        metadata.children[0].forEach((child) => _addClass(child, cls));
+        metadata.children[1].forEach((child) => _addClass(child, cls));
     }
 };
 
 /**
  * Updates the x coord of each metadata in the given 2D array of metadata and returns rightmost x coord.
- * 
+ *
  * @param opsMetadata  2D array of metadata.
  * @param columnWidths Array of column widths.
- * 
+ *
  * @returns Rightmost x coord.
  */
 const _fillMetadataX = (opsMetadata: Metadata[][], columnWidths: number[]): number => {
     let currX: number = startX;
 
-    const colStartX: number[] = columnWidths.map(width => {
+    const colStartX: number[] = columnWidths.map((width) => {
         const x: number = currX;
         currX += width + gatePadding * 2;
         return x;
@@ -312,36 +303,38 @@ const _fillMetadataX = (opsMetadata: Metadata[][], columnWidths: number[]): numb
 
     const endX: number = currX;
 
-    opsMetadata.forEach(regOps => regOps.forEach((metadata, col) => {
-        const x = colStartX[col];
-        if (metadata.type === GateType.ClassicalControlled) {
-            // Subtract startX offset from nested gates and add offset and padding
-            const offset: number = x - startX + controlBtnOffset + classicalBoxPadding;
+    opsMetadata.forEach((regOps) =>
+        regOps.forEach((metadata, col) => {
+            const x = colStartX[col];
+            if (metadata.type === GateType.ClassicalControlled) {
+                // Subtract startX offset from nested gates and add offset and padding
+                const offset: number = x - startX + controlBtnOffset + classicalBoxPadding;
 
-            // Offset each x coord in children gates
-            _offsetChildrenX(metadata.children, offset);
+                // Offset each x coord in children gates
+                _offsetChildrenX(metadata.children, offset);
 
-            // We don't use the centre x coord because we only care about the rightmost x for
-            // rendering the box around the group of nested gates
-            metadata.x = x;
-        } else {
-            // Get x coord of middle of each column (used for centering gates in a column)
-            metadata.x = x + columnWidths[col] / 2;
-        }
-    }));
+                // We don't use the centre x coord because we only care about the rightmost x for
+                // rendering the box around the group of nested gates
+                metadata.x = x;
+            } else {
+                // Get x coord of middle of each column (used for centering gates in a column)
+                metadata.x = x + columnWidths[col] / 2;
+            }
+        }),
+    );
 
     return endX;
 };
 
 /**
  * Offset x coords of nested children operations.
- * 
+ *
  * @param children 2D array of children metadata.
  * @param offset   x coord offset.
  */
-const _offsetChildrenX = (children: (Metadata[][] | undefined), offset: number): void => {
+const _offsetChildrenX = (children: Metadata[][] | undefined, offset: number): void => {
     if (children == null) return;
-    children.flat().forEach(child => {
+    children.flat().forEach((child) => {
         child.x += offset;
         _offsetChildrenX(child.children, offset);
     });

--- a/src/Kernel/client/ExecutionPathVisualizer/register.ts
+++ b/src/Kernel/client/ExecutionPathVisualizer/register.ts
@@ -3,8 +3,8 @@
  */
 export enum RegisterType {
     Qubit,
-    Classical
-};
+    Classical,
+}
 
 /**
  * Represents a register resource.
@@ -16,7 +16,7 @@ export interface Register {
     qId: number;
     /** Classical register ID (if classical register). */
     cId?: number;
-};
+}
 
 export interface RegisterMetadata {
     /** Type of register. */
@@ -25,8 +25,8 @@ export interface RegisterMetadata {
     y: number;
     /** Nested classical registers attached to quantum register. */
     children?: RegisterMetadata[];
-};
+}
 
 export interface RegisterMap {
-    [id: number]: RegisterMetadata
-};
+    [id: number]: RegisterMetadata;
+}

--- a/src/Kernel/client/ExecutionPathVisualizer/styles.ts
+++ b/src/Kernel/client/ExecutionPathVisualizer/styles.ts
@@ -23,39 +23,39 @@ export interface StyleConfig {
 }
 
 const defaultStyle: StyleConfig = {
-    lineStroke: "#000000",
+    lineStroke: '#000000',
     lineWidth: 1,
-    textColour: "#000000",
-    unitary: "#D9F1FA",
-    oplus: "#FFFFFF",
-    measure: "#FFDE86",
-    classicalUnknown: "#E5E5E5",
-    classicalZero: "#C40000",
-    classicalOne: "#4059BD",
+    textColour: '#000000',
+    unitary: '#D9F1FA',
+    oplus: '#FFFFFF',
+    measure: '#FFDE86',
+    classicalUnknown: '#E5E5E5',
+    classicalZero: '#C40000',
+    classicalOne: '#4059BD',
 };
 
 const blackAndWhiteStyle: StyleConfig = {
-    lineStroke: "#000000",
+    lineStroke: '#000000',
     lineWidth: 1,
-    textColour: "#000000",
-    unitary: "#FFFFFF",
-    oplus: "#FFFFFF",
-    measure: "#FFFFFF",
-    classicalUnknown: "#FFFFFF",
-    classicalZero: "#FFFFFF",
-    classicalOne: "#FFFFFF",
+    textColour: '#000000',
+    unitary: '#FFFFFF',
+    oplus: '#FFFFFF',
+    measure: '#FFFFFF',
+    classicalUnknown: '#FFFFFF',
+    classicalZero: '#FFFFFF',
+    classicalOne: '#FFFFFF',
 };
 
 const invertedStyle: StyleConfig = {
-    lineStroke: "#FFFFFF",
+    lineStroke: '#FFFFFF',
     lineWidth: 1,
-    textColour: "#FFFFFF",
-    unitary: "#000000",
-    oplus: "#000000",
-    measure: "#000000",
-    classicalUnknown: "#000000",
-    classicalZero: "#000000",
-    classicalOne: "#000000",
+    textColour: '#FFFFFF',
+    unitary: '#000000',
+    oplus: '#000000',
+    measure: '#000000',
+    classicalUnknown: '#000000',
+    classicalZero: '#000000',
+    classicalOne: '#000000',
 };
 
 /**
@@ -63,21 +63,21 @@ const invertedStyle: StyleConfig = {
  */
 export const STYLES: { [name: string]: StyleConfig } = {
     /** Default style with coloured gates. */
-    "Default": defaultStyle,
+    Default: defaultStyle,
     /** Black and white style. */
-    "BlackAndWhite": blackAndWhiteStyle,
+    BlackAndWhite: blackAndWhiteStyle,
     /** Inverted black and white style (for black backgrounds). */
-    "Inverted": invertedStyle,
+    Inverted: invertedStyle,
 };
 
 /**
  * CSS style script to be injected into visualization HTML string.
- * 
+ *
  * @param customStyle Custom style configuration.
- * 
+ *
  * @returns String containing CSS style script.
  */
-export const style = (customStyle: StyleConfig = {}) => {
+export const style = (customStyle: StyleConfig = {}): string => {
     const styleConfig = { ...defaultStyle, ...customStyle };
     return `
 <style>
@@ -111,7 +111,7 @@ export const style = (customStyle: StyleConfig = {}) => {
         stroke-width: ${styleConfig.lineWidth};
     }
     .register-classical {
-        stroke-width: ${styleConfig.lineWidth / 2};
+        stroke-width: ${(styleConfig.lineWidth || 0) / 2};
     }
     <!-- Classically controlled gates -->
     .hidden {
@@ -124,12 +124,12 @@ export const style = (customStyle: StyleConfig = {}) => {
     .classically-controlled-one .classical-container,
     .classically-controlled-one .classical-line {
         stroke: ${styleConfig.classicalOne};
-        stroke-width: ${styleConfig.lineWidth + 0.3};
+        stroke-width: ${(styleConfig.lineWidth || 0) + 0.3};
     }
     .classically-controlled-zero .classical-container,
     .classically-controlled-zero .classical-line {
         stroke: ${styleConfig.classicalZero};
-        stroke-width: ${styleConfig.lineWidth + 0.3};
+        stroke-width: ${(styleConfig.lineWidth || 0) + 0.3};
     }
     <!-- Control button -->
     .classically-controlled-btn {
@@ -155,5 +155,5 @@ export const style = (customStyle: StyleConfig = {}) => {
         stroke: none;
     }
 </style>
-`
+`;
 };

--- a/src/Kernel/client/ExecutionPathVisualizer/styles.ts
+++ b/src/Kernel/client/ExecutionPathVisualizer/styles.ts
@@ -20,6 +20,10 @@ export interface StyleConfig {
     classicalZero?: string;
     /** Measurement one primary colour. */
     classicalOne?: string;
+    /** Measurement zero text colour */
+    classicalZeroText?: string;
+    /** Measurement one text colour */
+    classicalOneText?: string;
 }
 
 const defaultStyle: StyleConfig = {
@@ -32,6 +36,8 @@ const defaultStyle: StyleConfig = {
     classicalUnknown: '#E5E5E5',
     classicalZero: '#C40000',
     classicalOne: '#4059BD',
+    classicalZeroText: '#FFFFFF',
+    classicalOneText: '#FFFFFF',
 };
 
 const blackAndWhiteStyle: StyleConfig = {
@@ -42,8 +48,10 @@ const blackAndWhiteStyle: StyleConfig = {
     oplus: '#FFFFFF',
     measure: '#FFFFFF',
     classicalUnknown: '#FFFFFF',
-    classicalZero: '#FFFFFF',
-    classicalOne: '#FFFFFF',
+    classicalZero: '#000000',
+    classicalOne: '#000000',
+    classicalZeroText: '#FFFFFF',
+    classicalOneText: '#FFFFFF',
 };
 
 const invertedStyle: StyleConfig = {
@@ -54,8 +62,10 @@ const invertedStyle: StyleConfig = {
     oplus: '#000000',
     measure: '#000000',
     classicalUnknown: '#000000',
-    classicalZero: '#000000',
-    classicalOne: '#000000',
+    classicalZero: '#FFFFFF',
+    classicalOne: '#FFFFFF',
+    classicalZeroText: '#000000',
+    classicalOneText: '#000000',
 };
 
 /**
@@ -88,7 +98,7 @@ export const style = (customStyle: StyleConfig = {}): string => {
         stroke-width: ${styleConfig.lineWidth};
     }
     text {
-        color: ${styleConfig.textColour};
+        fill: ${styleConfig.textColour};
         dominant-baseline: middle;
         text-anchor: middle;
         font-family: Arial;
@@ -145,14 +155,20 @@ export const style = (customStyle: StyleConfig = {}): string => {
         fill: ${styleConfig.classicalZero};
     }
     <!-- Control button text -->
+    .classically-controlled-text {
+        dominant-baseline: middle;
+        text-anchor: middle;
+        stroke: none;
+        font-family: Arial;
+    }
     .classically-controlled-unknown .classically-controlled-text {
         fill: ${styleConfig.textColour};
-        stroke: none;
     }
-    .classically-controlled-one .classically-controlled-text,
+    .classically-controlled-one .classically-controlled-text {
+        fill: ${styleConfig.classicalOneText};
+    }
     .classically-controlled-zero .classically-controlled-text {
-        color: white;
-        stroke: none;
+        fill: ${styleConfig.classicalZeroText};
     }
 </style>
 `;

--- a/src/Kernel/client/ExecutionPathVisualizer/utils.ts
+++ b/src/Kernel/client/ExecutionPathVisualizer/utils.ts
@@ -1,17 +1,11 @@
 import { Metadata } from './metadata';
-import {
-    GateType,
-    minGateWidth,
-    labelPadding,
-    labelFontSize,
-    argsFontSize,
-} from './constants';
+import { GateType, minGateWidth, labelPadding, labelFontSize, argsFontSize } from './constants';
 
 /**
  * Calculate the width of a gate, given its metadata.
- * 
+ *
  * @param metadata Metadata of a given gate.
- * 
+ *
  * @returns Width of given gate (in pixels).
  */
 const getGateWidth = ({ type, label, displayArgs, width }: Metadata): number => {
@@ -25,7 +19,7 @@ const getGateWidth = ({ type, label, displayArgs, width }: Metadata): number => 
             return minGateWidth;
         default:
             const labelWidth = _getStringWidth(label);
-            const argsWidth = (displayArgs != null) ? _getStringWidth(displayArgs, argsFontSize) : 0;
+            const argsWidth = displayArgs != null ? _getStringWidth(displayArgs, argsFontSize) : 0;
             const textWidth = Math.max(labelWidth, argsWidth) + labelPadding * 2;
             return Math.max(minGateWidth, textWidth);
     }
@@ -33,23 +27,20 @@ const getGateWidth = ({ type, label, displayArgs, width }: Metadata): number => 
 
 /**
  * Get the width of a string with font-size `fontSize` and font-family Arial.
- * 
+ *
  * @param text     Input string.
- * @param fontSize Font size of `text`. 
- * 
+ * @param fontSize Font size of `text`.
+ *
  * @returns Pixel width of given string.
  */
 const _getStringWidth = (text: string, fontSize: number = labelFontSize): number => {
-    var canvas: HTMLCanvasElement = document.createElement("canvas");
-    var context: CanvasRenderingContext2D | null = canvas.getContext("2d");
-    if (context == null) throw new Error("Null canvas");
-    
+    const canvas: HTMLCanvasElement = document.createElement('canvas');
+    const context: CanvasRenderingContext2D | null = canvas.getContext('2d');
+    if (context == null) throw new Error('Null canvas');
+
     context.font = `${fontSize}px Arial`;
-    var metrics: TextMetrics = context.measureText(text);
+    const metrics: TextMetrics = context.measureText(text);
     return metrics.width;
 };
 
-export {
-    getGateWidth,
-    _getStringWidth,
-};
+export { getGateWidth, _getStringWidth };

--- a/src/Kernel/client/__tests__/ExecutionPathVisualizerTests/__snapshots__/gateFormatter.test.ts.snap
+++ b/src/Kernel/client/__tests__/ExecutionPathVisualizerTests/__snapshots__/gateFormatter.test.ts.snap
@@ -5,8 +5,8 @@ exports[`Testing _classicalControlled No htmlClass 1`] = `
 <line class=\\"classical-line\\" x1=\\"95\\" x2=\\"120\\" y1=\\"180\\" y2=\\"180\\" stroke-dasharray=\\"8, 8\\"></line>
 <line class=\\"classical-line\\" x1=\\"95\\" x2=\\"95\\" y1=\\"175\\" y2=\\"180\\" stroke-dasharray=\\"8, 8\\"></line>
 <g class=\\"classically-controlled-btn classically-controlled\\" onClick=\\"toggleClassicalBtn('classically-controlled')\\">
-<circle class=\\"classically-controlled\\" cx=\\"95\\" cy=\\"160\\" r=\\"15\\" stroke=\\"black\\" stroke-width=\\"1\\"></circle>
-<text class=\\"classically-controlled classically-controlled-text\\" font-size=\\"14\\" font-family=\\"Arial\\" x=\\"95\\" y=\\"160\\" dominant-baseline=\\"middle\\" text-anchor=\\"middle\\" fill=\\"black\\">?</text>
+<circle class=\\"classically-controlled\\" cx=\\"95\\" cy=\\"160\\" r=\\"15\\"></circle>
+<text class=\\"classically-controlled classically-controlled-text\\" font-size=\\"14\\" x=\\"95\\" y=\\"160\\">?</text>
 </g>
 <g class=\\"classically-controlled-zero hidden\\">
 </g>
@@ -24,8 +24,8 @@ exports[`Testing _classicalControlled change padding 1`] = `
 <line class=\\"classical-line\\" x1=\\"95\\" x2=\\"120\\" y1=\\"180\\" y2=\\"180\\" stroke-dasharray=\\"8, 8\\"></line>
 <line class=\\"classical-line\\" x1=\\"95\\" x2=\\"95\\" y1=\\"175\\" y2=\\"180\\" stroke-dasharray=\\"8, 8\\"></line>
 <g class=\\"classically-controlled-btn classically-controlled-1\\" onClick=\\"toggleClassicalBtn('classically-controlled-1')\\">
-<circle class=\\"classically-controlled-1\\" cx=\\"95\\" cy=\\"160\\" r=\\"15\\" stroke=\\"black\\" stroke-width=\\"1\\"></circle>
-<text class=\\"classically-controlled-1 classically-controlled-text\\" font-size=\\"14\\" font-family=\\"Arial\\" x=\\"95\\" y=\\"160\\" dominant-baseline=\\"middle\\" text-anchor=\\"middle\\" fill=\\"black\\">?</text>
+<circle class=\\"classically-controlled-1\\" cx=\\"95\\" cy=\\"160\\" r=\\"15\\"></circle>
+<text class=\\"classically-controlled-1 classically-controlled-text\\" font-size=\\"14\\" x=\\"95\\" y=\\"160\\">?</text>
 </g>
 <g class=\\"classically-controlled-1-zero hidden\\">
 </g>
@@ -43,8 +43,8 @@ exports[`Testing _classicalControlled multiple 'zero'/'one' children 1`] = `
 <line class=\\"classical-line\\" x1=\\"95\\" x2=\\"120\\" y1=\\"180\\" y2=\\"180\\" stroke-dasharray=\\"8, 8\\"></line>
 <line class=\\"classical-line\\" x1=\\"95\\" x2=\\"95\\" y1=\\"175\\" y2=\\"180\\" stroke-dasharray=\\"8, 8\\"></line>
 <g class=\\"classically-controlled-btn classically-controlled-1\\" onClick=\\"toggleClassicalBtn('classically-controlled-1')\\">
-<circle class=\\"classically-controlled-1\\" cx=\\"95\\" cy=\\"160\\" r=\\"15\\" stroke=\\"black\\" stroke-width=\\"1\\"></circle>
-<text class=\\"classically-controlled-1 classically-controlled-text\\" font-size=\\"14\\" font-family=\\"Arial\\" x=\\"95\\" y=\\"160\\" dominant-baseline=\\"middle\\" text-anchor=\\"middle\\" fill=\\"black\\">?</text>
+<circle class=\\"classically-controlled-1\\" cx=\\"95\\" cy=\\"160\\" r=\\"15\\"></circle>
+<text class=\\"classically-controlled-1 classically-controlled-text\\" font-size=\\"14\\" x=\\"95\\" y=\\"160\\">?</text>
 </g>
 <g class=\\"classically-controlled-1-zero hidden\\">
 <g class=\\"gate\\">
@@ -72,8 +72,8 @@ exports[`Testing _classicalControlled nested children 1`] = `
 <line class=\\"classical-line\\" x1=\\"95\\" x2=\\"120\\" y1=\\"180\\" y2=\\"180\\" stroke-dasharray=\\"8, 8\\"></line>
 <line class=\\"classical-line\\" x1=\\"95\\" x2=\\"95\\" y1=\\"175\\" y2=\\"180\\" stroke-dasharray=\\"8, 8\\"></line>
 <g class=\\"classically-controlled-btn classically-controlled-1\\" onClick=\\"toggleClassicalBtn('classically-controlled-1')\\">
-<circle class=\\"classically-controlled-1\\" cx=\\"95\\" cy=\\"160\\" r=\\"15\\" stroke=\\"black\\" stroke-width=\\"1\\"></circle>
-<text class=\\"classically-controlled-1 classically-controlled-text\\" font-size=\\"14\\" font-family=\\"Arial\\" x=\\"95\\" y=\\"160\\" dominant-baseline=\\"middle\\" text-anchor=\\"middle\\" fill=\\"black\\">?</text>
+<circle class=\\"classically-controlled-1\\" cx=\\"95\\" cy=\\"160\\" r=\\"15\\"></circle>
+<text class=\\"classically-controlled-1 classically-controlled-text\\" font-size=\\"14\\" x=\\"95\\" y=\\"160\\">?</text>
 </g>
 <g class=\\"classically-controlled-1-zero hidden\\">
 </g>
@@ -86,8 +86,8 @@ exports[`Testing _classicalControlled nested children 1`] = `
 <line class=\\"classical-line\\" x1=\\"165\\" x2=\\"190\\" y1=\\"240\\" y2=\\"240\\" stroke-dasharray=\\"8, 8\\"></line>
 <line class=\\"classical-line\\" x1=\\"165\\" x2=\\"165\\" y1=\\"235\\" y2=\\"240\\" stroke-dasharray=\\"8, 8\\"></line>
 <g class=\\"classically-controlled-btn classically-controlled-1\\" onClick=\\"toggleClassicalBtn('classically-controlled-1')\\">
-<circle class=\\"classically-controlled-1\\" cx=\\"165\\" cy=\\"220\\" r=\\"15\\" stroke=\\"black\\" stroke-width=\\"1\\"></circle>
-<text class=\\"classically-controlled-1 classically-controlled-text\\" font-size=\\"14\\" font-family=\\"Arial\\" x=\\"165\\" y=\\"220\\" dominant-baseline=\\"middle\\" text-anchor=\\"middle\\" fill=\\"black\\">?</text>
+<circle class=\\"classically-controlled-1\\" cx=\\"165\\" cy=\\"220\\" r=\\"15\\"></circle>
+<text class=\\"classically-controlled-1 classically-controlled-text\\" font-size=\\"14\\" x=\\"165\\" y=\\"220\\">?</text>
 </g>
 <g class=\\"classically-controlled-1-zero hidden\\">
 </g>
@@ -110,8 +110,8 @@ exports[`Testing _classicalControlled one 'one' child 1`] = `
 <line class=\\"classical-line\\" x1=\\"95\\" x2=\\"120\\" y1=\\"180\\" y2=\\"180\\" stroke-dasharray=\\"8, 8\\"></line>
 <line class=\\"classical-line\\" x1=\\"95\\" x2=\\"95\\" y1=\\"175\\" y2=\\"180\\" stroke-dasharray=\\"8, 8\\"></line>
 <g class=\\"classically-controlled-btn classically-controlled-1\\" onClick=\\"toggleClassicalBtn('classically-controlled-1')\\">
-<circle class=\\"classically-controlled-1\\" cx=\\"95\\" cy=\\"160\\" r=\\"15\\" stroke=\\"black\\" stroke-width=\\"1\\"></circle>
-<text class=\\"classically-controlled-1 classically-controlled-text\\" font-size=\\"14\\" font-family=\\"Arial\\" x=\\"95\\" y=\\"160\\" dominant-baseline=\\"middle\\" text-anchor=\\"middle\\" fill=\\"black\\">?</text>
+<circle class=\\"classically-controlled-1\\" cx=\\"95\\" cy=\\"160\\" r=\\"15\\"></circle>
+<text class=\\"classically-controlled-1 classically-controlled-text\\" font-size=\\"14\\" x=\\"95\\" y=\\"160\\">?</text>
 </g>
 <g class=\\"classically-controlled-1-zero hidden\\">
 </g>
@@ -129,8 +129,8 @@ exports[`Testing _classicalControlled one 'zero' child 1`] = `
 <line class=\\"classical-line\\" x1=\\"95\\" x2=\\"120\\" y1=\\"180\\" y2=\\"180\\" stroke-dasharray=\\"8, 8\\"></line>
 <line class=\\"classical-line\\" x1=\\"95\\" x2=\\"95\\" y1=\\"175\\" y2=\\"180\\" stroke-dasharray=\\"8, 8\\"></line>
 <g class=\\"classically-controlled-btn classically-controlled-1\\" onClick=\\"toggleClassicalBtn('classically-controlled-1')\\">
-<circle class=\\"classically-controlled-1\\" cx=\\"95\\" cy=\\"160\\" r=\\"15\\" stroke=\\"black\\" stroke-width=\\"1\\"></circle>
-<text class=\\"classically-controlled-1 classically-controlled-text\\" font-size=\\"14\\" font-family=\\"Arial\\" x=\\"95\\" y=\\"160\\" dominant-baseline=\\"middle\\" text-anchor=\\"middle\\" fill=\\"black\\">?</text>
+<circle class=\\"classically-controlled-1\\" cx=\\"95\\" cy=\\"160\\" r=\\"15\\"></circle>
+<text class=\\"classically-controlled-1 classically-controlled-text\\" font-size=\\"14\\" x=\\"95\\" y=\\"160\\">?</text>
 </g>
 <g class=\\"classically-controlled-1-zero hidden\\">
 <g class=\\"gate\\">
@@ -332,8 +332,8 @@ exports[`Testing _formatGate classically controlled gate 1`] = `
 <line class=\\"classical-line\\" x1=\\"95\\" x2=\\"120\\" y1=\\"180\\" y2=\\"180\\" stroke-dasharray=\\"8, 8\\"></line>
 <line class=\\"classical-line\\" x1=\\"95\\" x2=\\"95\\" y1=\\"175\\" y2=\\"180\\" stroke-dasharray=\\"8, 8\\"></line>
 <g class=\\"classically-controlled-btn classically-controlled\\" onClick=\\"toggleClassicalBtn('classically-controlled')\\">
-<circle class=\\"classically-controlled\\" cx=\\"95\\" cy=\\"160\\" r=\\"15\\" stroke=\\"black\\" stroke-width=\\"1\\"></circle>
-<text class=\\"classically-controlled classically-controlled-text\\" font-size=\\"14\\" font-family=\\"Arial\\" x=\\"95\\" y=\\"160\\" dominant-baseline=\\"middle\\" text-anchor=\\"middle\\" fill=\\"black\\">?</text>
+<circle class=\\"classically-controlled\\" cx=\\"95\\" cy=\\"160\\" r=\\"15\\"></circle>
+<text class=\\"classically-controlled classically-controlled-text\\" font-size=\\"14\\" x=\\"95\\" y=\\"160\\">?</text>
 </g>
 <g class=\\"classically-controlled-zero hidden\\">
 </g>

--- a/src/Kernel/client/__tests__/ExecutionPathVisualizerTests/__snapshots__/gateFormatter.test.ts.snap
+++ b/src/Kernel/client/__tests__/ExecutionPathVisualizerTests/__snapshots__/gateFormatter.test.ts.snap
@@ -1,8 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Testing _classicalControlled No htmlClass 1`] = `
-"<g>
-<g class=\\"classically-controlled-group classically-controlled-unknown\\">
+"<g class=\\"classically-controlled-group classically-controlled-unknown\\">
 <line class=\\"classical-line\\" x1=\\"95\\" x2=\\"120\\" y1=\\"180\\" y2=\\"180\\" stroke-dasharray=\\"8, 8\\"></line>
 <line class=\\"classical-line\\" x1=\\"95\\" x2=\\"95\\" y1=\\"175\\" y2=\\"180\\" stroke-dasharray=\\"8, 8\\"></line>
 <g class=\\"classically-controlled-btn classically-controlled\\" onClick=\\"toggleClassicalBtn('classically-controlled')\\">
@@ -12,18 +11,16 @@ exports[`Testing _classicalControlled No htmlClass 1`] = `
 <g class=\\"classically-controlled-zero hidden\\">
 </g>
 <g class=\\"classically-controlled-one\\">
-<g>
+<g class=\\"gate\\">
 <rect class=\\"gate-unitary\\" x=\\"90\\" y=\\"20\\" width=\\"40\\" height=\\"40\\"></rect>
 <text font-size=\\"14\\" x=\\"110\\" y=\\"40\\">X</text>
 </g></g>
 <rect class=\\"classical-container\\" x=\\"120\\" y=\\"5\\" width=\\"80\\" height=\\"130\\" fill-opacity=\\"0\\" stroke-dasharray=\\"8, 8\\"></rect>
-</g>
 </g>"
 `;
 
 exports[`Testing _classicalControlled change padding 1`] = `
-"<g>
-<g class=\\"classically-controlled-1-group classically-controlled-unknown\\">
+"<g class=\\"classically-controlled-1-group classically-controlled-unknown\\">
 <line class=\\"classical-line\\" x1=\\"95\\" x2=\\"120\\" y1=\\"180\\" y2=\\"180\\" stroke-dasharray=\\"8, 8\\"></line>
 <line class=\\"classical-line\\" x1=\\"95\\" x2=\\"95\\" y1=\\"175\\" y2=\\"180\\" stroke-dasharray=\\"8, 8\\"></line>
 <g class=\\"classically-controlled-btn classically-controlled-1\\" onClick=\\"toggleClassicalBtn('classically-controlled-1')\\">
@@ -33,18 +30,16 @@ exports[`Testing _classicalControlled change padding 1`] = `
 <g class=\\"classically-controlled-1-zero hidden\\">
 </g>
 <g class=\\"classically-controlled-1-one\\">
-<g>
+<g class=\\"gate\\">
 <rect class=\\"gate-unitary\\" x=\\"90\\" y=\\"20\\" width=\\"40\\" height=\\"40\\"></rect>
 <text font-size=\\"14\\" x=\\"110\\" y=\\"40\\">X</text>
 </g></g>
 <rect class=\\"classical-container\\" x=\\"115\\" y=\\"0\\" width=\\"90\\" height=\\"140\\" fill-opacity=\\"0\\" stroke-dasharray=\\"8, 8\\"></rect>
-</g>
 </g>"
 `;
 
 exports[`Testing _classicalControlled multiple 'zero'/'one' children 1`] = `
-"<g>
-<g class=\\"classically-controlled-1-group classically-controlled-unknown\\">
+"<g class=\\"classically-controlled-1-group classically-controlled-unknown\\">
 <line class=\\"classical-line\\" x1=\\"95\\" x2=\\"120\\" y1=\\"180\\" y2=\\"180\\" stroke-dasharray=\\"8, 8\\"></line>
 <line class=\\"classical-line\\" x1=\\"95\\" x2=\\"95\\" y1=\\"175\\" y2=\\"180\\" stroke-dasharray=\\"8, 8\\"></line>
 <g class=\\"classically-controlled-btn classically-controlled-1\\" onClick=\\"toggleClassicalBtn('classically-controlled-1')\\">
@@ -52,32 +47,28 @@ exports[`Testing _classicalControlled multiple 'zero'/'one' children 1`] = `
 <text class=\\"classically-controlled-1 classically-controlled-text\\" font-size=\\"14\\" font-family=\\"Arial\\" x=\\"95\\" y=\\"160\\" dominant-baseline=\\"middle\\" text-anchor=\\"middle\\" fill=\\"black\\">?</text>
 </g>
 <g class=\\"classically-controlled-1-zero hidden\\">
-<g>
+<g class=\\"gate\\">
 <rect class=\\"gate-unitary\\" x=\\"90\\" y=\\"20\\" width=\\"40\\" height=\\"40\\"></rect>
 <text font-size=\\"14\\" x=\\"110\\" y=\\"40\\">X</text>
 </g></g>
 <g class=\\"classically-controlled-1-one\\">
-<g>
+<g class=\\"gate\\">
 <rect class=\\"gate-unitary\\" x=\\"90\\" y=\\"20\\" width=\\"40\\" height=\\"40\\"></rect>
 <text font-size=\\"14\\" x=\\"110\\" y=\\"40\\">X</text>
 </g>
-<g>
+<g class=\\"gate\\">
 <line x1=\\"170\\" x2=\\"170\\" y1=\\"40\\" y2=\\"100\\"></line>
 <circle class=\\"control-dot\\" cx=\\"170\\" cy=\\"100\\" r=\\"5\\"></circle>
-<g>
 <circle class=\\"oplus\\" cx=\\"170\\" cy=\\"40\\" r=\\"15\\"></circle>
 <line x1=\\"170\\" x2=\\"170\\" y1=\\"25\\" y2=\\"55\\"></line>
 <line x1=\\"155\\" x2=\\"185\\" y1=\\"40\\" y2=\\"40\\"></line>
-</g>
 </g></g>
 <rect class=\\"classical-container\\" x=\\"120\\" y=\\"5\\" width=\\"80\\" height=\\"130\\" fill-opacity=\\"0\\" stroke-dasharray=\\"8, 8\\"></rect>
-</g>
 </g>"
 `;
 
 exports[`Testing _classicalControlled nested children 1`] = `
-"<g>
-<g class=\\"classically-controlled-1-group classically-controlled-unknown\\">
+"<g class=\\"classically-controlled-1-group classically-controlled-unknown\\">
 <line class=\\"classical-line\\" x1=\\"95\\" x2=\\"120\\" y1=\\"180\\" y2=\\"180\\" stroke-dasharray=\\"8, 8\\"></line>
 <line class=\\"classical-line\\" x1=\\"95\\" x2=\\"95\\" y1=\\"175\\" y2=\\"180\\" stroke-dasharray=\\"8, 8\\"></line>
 <g class=\\"classically-controlled-btn classically-controlled-1\\" onClick=\\"toggleClassicalBtn('classically-controlled-1')\\">
@@ -87,11 +78,10 @@ exports[`Testing _classicalControlled nested children 1`] = `
 <g class=\\"classically-controlled-1-zero hidden\\">
 </g>
 <g class=\\"classically-controlled-1-one\\">
-<g>
+<g class=\\"gate\\">
 <rect class=\\"gate-unitary\\" x=\\"90\\" y=\\"20\\" width=\\"40\\" height=\\"40\\"></rect>
 <text font-size=\\"14\\" x=\\"110\\" y=\\"40\\">X</text>
 </g>
-<g>
 <g class=\\"classically-controlled-1-group classically-controlled-unknown\\">
 <line class=\\"classical-line\\" x1=\\"165\\" x2=\\"190\\" y1=\\"240\\" y2=\\"240\\" stroke-dasharray=\\"8, 8\\"></line>
 <line class=\\"classical-line\\" x1=\\"165\\" x2=\\"165\\" y1=\\"235\\" y2=\\"240\\" stroke-dasharray=\\"8, 8\\"></line>
@@ -102,26 +92,21 @@ exports[`Testing _classicalControlled nested children 1`] = `
 <g class=\\"classically-controlled-1-zero hidden\\">
 </g>
 <g class=\\"classically-controlled-1-one\\">
-<g>
+<g class=\\"gate\\">
 <line x1=\\"180\\" x2=\\"180\\" y1=\\"40\\" y2=\\"100\\"></line>
 <circle class=\\"control-dot\\" cx=\\"180\\" cy=\\"100\\" r=\\"5\\"></circle>
-<g>
 <circle class=\\"oplus\\" cx=\\"180\\" cy=\\"40\\" r=\\"15\\"></circle>
 <line x1=\\"180\\" x2=\\"180\\" y1=\\"25\\" y2=\\"55\\"></line>
 <line x1=\\"165\\" x2=\\"195\\" y1=\\"40\\" y2=\\"40\\"></line>
-</g>
 </g></g>
 <rect class=\\"classical-container\\" x=\\"190\\" y=\\"5\\" width=\\"20\\" height=\\"130\\" fill-opacity=\\"0\\" stroke-dasharray=\\"8, 8\\"></rect>
-</g>
 </g></g>
 <rect class=\\"classical-container\\" x=\\"120\\" y=\\"5\\" width=\\"100\\" height=\\"130\\" fill-opacity=\\"0\\" stroke-dasharray=\\"8, 8\\"></rect>
-</g>
 </g>"
 `;
 
 exports[`Testing _classicalControlled one 'one' child 1`] = `
-"<g>
-<g class=\\"classically-controlled-1-group classically-controlled-unknown\\">
+"<g class=\\"classically-controlled-1-group classically-controlled-unknown\\">
 <line class=\\"classical-line\\" x1=\\"95\\" x2=\\"120\\" y1=\\"180\\" y2=\\"180\\" stroke-dasharray=\\"8, 8\\"></line>
 <line class=\\"classical-line\\" x1=\\"95\\" x2=\\"95\\" y1=\\"175\\" y2=\\"180\\" stroke-dasharray=\\"8, 8\\"></line>
 <g class=\\"classically-controlled-btn classically-controlled-1\\" onClick=\\"toggleClassicalBtn('classically-controlled-1')\\">
@@ -131,18 +116,16 @@ exports[`Testing _classicalControlled one 'one' child 1`] = `
 <g class=\\"classically-controlled-1-zero hidden\\">
 </g>
 <g class=\\"classically-controlled-1-one\\">
-<g>
+<g class=\\"gate\\">
 <rect class=\\"gate-unitary\\" x=\\"90\\" y=\\"20\\" width=\\"40\\" height=\\"40\\"></rect>
 <text font-size=\\"14\\" x=\\"110\\" y=\\"40\\">X</text>
 </g></g>
 <rect class=\\"classical-container\\" x=\\"120\\" y=\\"5\\" width=\\"20\\" height=\\"130\\" fill-opacity=\\"0\\" stroke-dasharray=\\"8, 8\\"></rect>
-</g>
 </g>"
 `;
 
 exports[`Testing _classicalControlled one 'zero' child 1`] = `
-"<g>
-<g class=\\"classically-controlled-1-group classically-controlled-unknown\\">
+"<g class=\\"classically-controlled-1-group classically-controlled-unknown\\">
 <line class=\\"classical-line\\" x1=\\"95\\" x2=\\"120\\" y1=\\"180\\" y2=\\"180\\" stroke-dasharray=\\"8, 8\\"></line>
 <line class=\\"classical-line\\" x1=\\"95\\" x2=\\"95\\" y1=\\"175\\" y2=\\"180\\" stroke-dasharray=\\"8, 8\\"></line>
 <g class=\\"classically-controlled-btn classically-controlled-1\\" onClick=\\"toggleClassicalBtn('classically-controlled-1')\\">
@@ -150,194 +133,159 @@ exports[`Testing _classicalControlled one 'zero' child 1`] = `
 <text class=\\"classically-controlled-1 classically-controlled-text\\" font-size=\\"14\\" font-family=\\"Arial\\" x=\\"95\\" y=\\"160\\" dominant-baseline=\\"middle\\" text-anchor=\\"middle\\" fill=\\"black\\">?</text>
 </g>
 <g class=\\"classically-controlled-1-zero hidden\\">
-<g>
+<g class=\\"gate\\">
 <rect class=\\"gate-unitary\\" x=\\"90\\" y=\\"20\\" width=\\"40\\" height=\\"40\\"></rect>
 <text font-size=\\"14\\" x=\\"110\\" y=\\"40\\">X</text>
 </g></g>
 <g class=\\"classically-controlled-1-one\\">
 </g>
 <rect class=\\"classical-container\\" x=\\"120\\" y=\\"5\\" width=\\"20\\" height=\\"130\\" fill-opacity=\\"0\\" stroke-dasharray=\\"8, 8\\"></rect>
-</g>
 </g>"
 `;
 
 exports[`Testing _controlledGate CNOT gate 1`] = `
-"<g>
+"<g class=\\"gate\\">
 <line x1=\\"80\\" x2=\\"80\\" y1=\\"40\\" y2=\\"100\\"></line>
 <circle class=\\"control-dot\\" cx=\\"80\\" cy=\\"40\\" r=\\"5\\"></circle>
-<g>
 <circle class=\\"oplus\\" cx=\\"80\\" cy=\\"100\\" r=\\"15\\"></circle>
 <line x1=\\"80\\" x2=\\"80\\" y1=\\"85\\" y2=\\"115\\"></line>
 <line x1=\\"65\\" x2=\\"95\\" y1=\\"100\\" y2=\\"100\\"></line>
-</g>
 </g>"
 `;
 
 exports[`Testing _controlledGate CNOT gate 2`] = `
-"<g>
+"<g class=\\"gate\\">
 <line x1=\\"80\\" x2=\\"80\\" y1=\\"40\\" y2=\\"100\\"></line>
 <circle class=\\"control-dot\\" cx=\\"80\\" cy=\\"100\\" r=\\"5\\"></circle>
-<g>
 <circle class=\\"oplus\\" cx=\\"80\\" cy=\\"40\\" r=\\"15\\"></circle>
 <line x1=\\"80\\" x2=\\"80\\" y1=\\"25\\" y2=\\"55\\"></line>
 <line x1=\\"65\\" x2=\\"95\\" y1=\\"40\\" y2=\\"40\\"></line>
-</g>
 </g>"
 `;
 
 exports[`Testing _controlledGate Controlled U gate with 1 control + 1 target 1`] = `
-"<g>
+"<g class=\\"gate\\">
 <line x1=\\"80\\" x2=\\"80\\" y1=\\"40\\" y2=\\"100\\"></line>
 <circle class=\\"control-dot\\" cx=\\"80\\" cy=\\"40\\" r=\\"5\\"></circle>
-<g>
 <rect class=\\"gate-unitary\\" x=\\"57.5\\" y=\\"80\\" width=\\"45\\" height=\\"40\\"></rect>
 <text font-size=\\"14\\" x=\\"80\\" y=\\"100\\">Foo</text>
-</g>
 </g>"
 `;
 
 exports[`Testing _controlledGate Controlled U gate with 1 control + 1 target 2`] = `
-"<g>
+"<g class=\\"gate\\">
 <line x1=\\"80\\" x2=\\"80\\" y1=\\"40\\" y2=\\"100\\"></line>
 <circle class=\\"control-dot\\" cx=\\"80\\" cy=\\"100\\" r=\\"5\\"></circle>
-<g>
 <rect class=\\"gate-unitary\\" x=\\"57.5\\" y=\\"20\\" width=\\"45\\" height=\\"40\\"></rect>
 <text font-size=\\"14\\" x=\\"80\\" y=\\"40\\">Foo</text>
-</g>
 </g>"
 `;
 
 exports[`Testing _controlledGate Controlled U gate with 1 control + 2 targets 1`] = `
-"<g>
+"<g class=\\"gate\\">
 <line x1=\\"80\\" x2=\\"80\\" y1=\\"40\\" y2=\\"160\\"></line>
 <circle class=\\"control-dot\\" cx=\\"80\\" cy=\\"160\\" r=\\"5\\"></circle>
-<g>
 <rect class=\\"gate-unitary\\" x=\\"57.5\\" y=\\"20\\" width=\\"45\\" height=\\"100\\"></rect>
 <text font-size=\\"14\\" x=\\"80\\" y=\\"70\\">Foo</text>
-</g>
 </g>"
 `;
 
 exports[`Testing _controlledGate Controlled U gate with 1 control + 2 targets 2`] = `
-"<g>
+"<g class=\\"gate\\">
 <line x1=\\"80\\" x2=\\"80\\" y1=\\"40\\" y2=\\"160\\"></line>
 <circle class=\\"control-dot\\" cx=\\"80\\" cy=\\"40\\" r=\\"5\\"></circle>
-<g>
 <rect class=\\"gate-unitary\\" x=\\"57.5\\" y=\\"80\\" width=\\"45\\" height=\\"100\\"></rect>
 <text font-size=\\"14\\" x=\\"80\\" y=\\"130\\">Foo</text>
-</g>
 </g>"
 `;
 
 exports[`Testing _controlledGate Controlled U gate with 1 control + 2 targets 3`] = `
-"<g>
+"<g class=\\"gate\\">
 <line x1=\\"80\\" x2=\\"80\\" y1=\\"40\\" y2=\\"160\\"></line>
 <circle class=\\"control-dot\\" cx=\\"80\\" cy=\\"100\\" r=\\"5\\"></circle>
-<g>
 <rect class=\\"gate-unitary\\" x=\\"57.5\\" y=\\"20\\" width=\\"45\\" height=\\"40\\"></rect>
 <text font-size=\\"14\\" x=\\"80\\" y=\\"40\\">Foo</text>
-</g>
-<g>
 <rect class=\\"gate-unitary\\" x=\\"57.5\\" y=\\"140\\" width=\\"45\\" height=\\"40\\"></rect>
 <text font-size=\\"14\\" x=\\"80\\" y=\\"160\\">Foo</text>
-</g>
 </g>"
 `;
 
 exports[`Testing _controlledGate Controlled U gate with 2 controls + 2 targets 1`] = `
-"<g>
+"<g class=\\"gate\\">
 <line x1=\\"80\\" x2=\\"80\\" y1=\\"40\\" y2=\\"220\\"></line>
 <circle class=\\"control-dot\\" cx=\\"80\\" cy=\\"160\\" r=\\"5\\"></circle>
 <circle class=\\"control-dot\\" cx=\\"80\\" cy=\\"220\\" r=\\"5\\"></circle>
-<g>
 <rect class=\\"gate-unitary\\" x=\\"57.5\\" y=\\"20\\" width=\\"45\\" height=\\"100\\"></rect>
 <text font-size=\\"14\\" x=\\"80\\" y=\\"70\\">Foo</text>
-</g>
 </g>"
 `;
 
 exports[`Testing _controlledGate Controlled U gate with 2 controls + 2 targets 2`] = `
-"<g>
+"<g class=\\"gate\\">
 <line x1=\\"80\\" x2=\\"80\\" y1=\\"40\\" y2=\\"220\\"></line>
 <circle class=\\"control-dot\\" cx=\\"80\\" cy=\\"40\\" r=\\"5\\"></circle>
 <circle class=\\"control-dot\\" cx=\\"80\\" cy=\\"100\\" r=\\"5\\"></circle>
-<g>
 <rect class=\\"gate-unitary\\" x=\\"57.5\\" y=\\"140\\" width=\\"45\\" height=\\"100\\"></rect>
 <text font-size=\\"14\\" x=\\"80\\" y=\\"190\\">Foo</text>
-</g>
 </g>"
 `;
 
 exports[`Testing _controlledGate Controlled U gate with 2 controls + 2 targets 3`] = `
-"<g>
+"<g class=\\"gate\\">
 <line x1=\\"80\\" x2=\\"80\\" y1=\\"40\\" y2=\\"220\\"></line>
 <circle class=\\"control-dot\\" cx=\\"80\\" cy=\\"100\\" r=\\"5\\"></circle>
 <circle class=\\"control-dot\\" cx=\\"80\\" cy=\\"160\\" r=\\"5\\"></circle>
-<g>
 <rect class=\\"gate-unitary\\" x=\\"57.5\\" y=\\"20\\" width=\\"45\\" height=\\"40\\"></rect>
 <text font-size=\\"14\\" x=\\"80\\" y=\\"40\\">Foo</text>
-</g>
-<g>
 <rect class=\\"gate-unitary\\" x=\\"57.5\\" y=\\"200\\" width=\\"45\\" height=\\"40\\"></rect>
 <text font-size=\\"14\\" x=\\"80\\" y=\\"220\\">Foo</text>
-</g>
 </g>"
 `;
 
 exports[`Testing _controlledGate Controlled U gate with 2 controls + 2 targets 4`] = `
-"<g>
+"<g class=\\"gate\\">
 <line x1=\\"80\\" x2=\\"80\\" y1=\\"40\\" y2=\\"220\\"></line>
 <circle class=\\"control-dot\\" cx=\\"80\\" cy=\\"100\\" r=\\"5\\"></circle>
 <circle class=\\"control-dot\\" cx=\\"80\\" cy=\\"220\\" r=\\"5\\"></circle>
-<g>
 <rect class=\\"gate-unitary\\" x=\\"57.5\\" y=\\"20\\" width=\\"45\\" height=\\"40\\"></rect>
 <text font-size=\\"14\\" x=\\"80\\" y=\\"40\\">Foo</text>
-</g>
-<g>
 <rect class=\\"gate-unitary\\" x=\\"57.5\\" y=\\"140\\" width=\\"45\\" height=\\"40\\"></rect>
 <text font-size=\\"14\\" x=\\"80\\" y=\\"160\\">Foo</text>
-</g>
 </g>"
 `;
 
 exports[`Testing _controlledGate Controlled U gate with multiple controls + 1 target 1`] = `
-"<g>
+"<g class=\\"gate\\">
 <line x1=\\"80\\" x2=\\"80\\" y1=\\"40\\" y2=\\"160\\"></line>
 <circle class=\\"control-dot\\" cx=\\"80\\" cy=\\"40\\" r=\\"5\\"></circle>
 <circle class=\\"control-dot\\" cx=\\"80\\" cy=\\"100\\" r=\\"5\\"></circle>
-<g>
 <rect class=\\"gate-unitary\\" x=\\"57.5\\" y=\\"140\\" width=\\"45\\" height=\\"40\\"></rect>
 <text font-size=\\"14\\" x=\\"80\\" y=\\"160\\">Foo</text>
-</g>
 </g>"
 `;
 
 exports[`Testing _controlledGate Controlled U gate with multiple controls + 1 target 2`] = `
-"<g>
+"<g class=\\"gate\\">
 <line x1=\\"80\\" x2=\\"80\\" y1=\\"40\\" y2=\\"160\\"></line>
 <circle class=\\"control-dot\\" cx=\\"80\\" cy=\\"100\\" r=\\"5\\"></circle>
 <circle class=\\"control-dot\\" cx=\\"80\\" cy=\\"160\\" r=\\"5\\"></circle>
-<g>
 <rect class=\\"gate-unitary\\" x=\\"57.5\\" y=\\"20\\" width=\\"45\\" height=\\"40\\"></rect>
 <text font-size=\\"14\\" x=\\"80\\" y=\\"40\\">Foo</text>
-</g>
 </g>"
 `;
 
 exports[`Testing _controlledGate Controlled U gate with multiple controls + 1 target 3`] = `
-"<g>
+"<g class=\\"gate\\">
 <line x1=\\"80\\" x2=\\"80\\" y1=\\"40\\" y2=\\"160\\"></line>
 <circle class=\\"control-dot\\" cx=\\"80\\" cy=\\"40\\" r=\\"5\\"></circle>
 <circle class=\\"control-dot\\" cx=\\"80\\" cy=\\"160\\" r=\\"5\\"></circle>
-<g>
 <rect class=\\"gate-unitary\\" x=\\"57.5\\" y=\\"80\\" width=\\"45\\" height=\\"40\\"></rect>
 <text font-size=\\"14\\" x=\\"80\\" y=\\"100\\">Foo</text>
-</g>
 </g>"
 `;
 
 exports[`Testing _controlledGate SWAP gate 1`] = `
-"<g>
+"<g class=\\"gate\\">
 <line x1=\\"80\\" x2=\\"80\\" y1=\\"40\\" y2=\\"160\\"></line>
 <circle class=\\"control-dot\\" cx=\\"80\\" cy=\\"40\\" r=\\"5\\"></circle>
 <line x1=\\"72\\" x2=\\"88\\" y1=\\"92\\" y2=\\"108\\"></line>
@@ -348,7 +296,7 @@ exports[`Testing _controlledGate SWAP gate 1`] = `
 `;
 
 exports[`Testing _controlledGate SWAP gate 2`] = `
-"<g>
+"<g class=\\"gate\\">
 <line x1=\\"80\\" x2=\\"80\\" y1=\\"40\\" y2=\\"160\\"></line>
 <circle class=\\"control-dot\\" cx=\\"80\\" cy=\\"160\\" r=\\"5\\"></circle>
 <line x1=\\"72\\" x2=\\"88\\" y1=\\"32\\" y2=\\"48\\"></line>
@@ -359,7 +307,7 @@ exports[`Testing _controlledGate SWAP gate 2`] = `
 `;
 
 exports[`Testing _controlledGate SWAP gate 3`] = `
-"<g>
+"<g class=\\"gate\\">
 <line x1=\\"80\\" x2=\\"80\\" y1=\\"40\\" y2=\\"160\\"></line>
 <circle class=\\"control-dot\\" cx=\\"80\\" cy=\\"100\\" r=\\"5\\"></circle>
 <line x1=\\"72\\" x2=\\"88\\" y1=\\"32\\" y2=\\"48\\"></line>
@@ -370,20 +318,17 @@ exports[`Testing _controlledGate SWAP gate 3`] = `
 `;
 
 exports[`Testing _formatGate CNOT gate 1`] = `
-"<g>
+"<g class=\\"gate\\">
 <line x1=\\"80\\" x2=\\"80\\" y1=\\"40\\" y2=\\"100\\"></line>
 <circle class=\\"control-dot\\" cx=\\"80\\" cy=\\"40\\" r=\\"5\\"></circle>
-<g>
 <circle class=\\"oplus\\" cx=\\"80\\" cy=\\"100\\" r=\\"15\\"></circle>
 <line x1=\\"80\\" x2=\\"80\\" y1=\\"85\\" y2=\\"115\\"></line>
 <line x1=\\"65\\" x2=\\"95\\" y1=\\"100\\" y2=\\"100\\"></line>
-</g>
 </g>"
 `;
 
 exports[`Testing _formatGate classically controlled gate 1`] = `
-"<g>
-<g class=\\"classically-controlled-group classically-controlled-unknown\\">
+"<g class=\\"classically-controlled-group classically-controlled-unknown\\">
 <line class=\\"classical-line\\" x1=\\"95\\" x2=\\"120\\" y1=\\"180\\" y2=\\"180\\" stroke-dasharray=\\"8, 8\\"></line>
 <line class=\\"classical-line\\" x1=\\"95\\" x2=\\"95\\" y1=\\"175\\" y2=\\"180\\" stroke-dasharray=\\"8, 8\\"></line>
 <g class=\\"classically-controlled-btn classically-controlled\\" onClick=\\"toggleClassicalBtn('classically-controlled')\\">
@@ -395,12 +340,11 @@ exports[`Testing _formatGate classically controlled gate 1`] = `
 <g class=\\"classically-controlled-one\\">
 </g>
 <rect class=\\"classical-container\\" x=\\"120\\" y=\\"5\\" width=\\"0\\" height=\\"130\\" fill-opacity=\\"0\\" stroke-dasharray=\\"8, 8\\"></rect>
-</g>
 </g>"
 `;
 
 exports[`Testing _formatGate controlled swap gate 1`] = `
-"<g>
+"<g class=\\"gate\\">
 <line x1=\\"80\\" x2=\\"80\\" y1=\\"40\\" y2=\\"160\\"></line>
 <circle class=\\"control-dot\\" cx=\\"80\\" cy=\\"40\\" r=\\"5\\"></circle>
 <line x1=\\"72\\" x2=\\"88\\" y1=\\"92\\" y2=\\"108\\"></line>
@@ -411,30 +355,26 @@ exports[`Testing _formatGate controlled swap gate 1`] = `
 `;
 
 exports[`Testing _formatGate controlled unitary gate 1`] = `
-"<g>
+"<g class=\\"gate\\">
 <line x1=\\"80\\" x2=\\"80\\" y1=\\"40\\" y2=\\"100\\"></line>
 <circle class=\\"control-dot\\" cx=\\"80\\" cy=\\"40\\" r=\\"5\\"></circle>
-<g>
 <rect class=\\"gate-unitary\\" x=\\"60\\" y=\\"80\\" width=\\"40\\" height=\\"40\\"></rect>
 <text font-size=\\"14\\" x=\\"80\\" y=\\"100\\">U</text>
-</g>
 </g>"
 `;
 
 exports[`Testing _formatGate controlled unitary gate with arguments 1`] = `
-"<g>
+"<g class=\\"gate\\">
 <line x1=\\"80\\" x2=\\"80\\" y1=\\"40\\" y2=\\"100\\"></line>
 <circle class=\\"control-dot\\" cx=\\"80\\" cy=\\"40\\" r=\\"5\\"></circle>
-<g>
 <rect class=\\"gate-unitary\\" x=\\"41.5\\" y=\\"80\\" width=\\"77\\" height=\\"40\\"></rect>
 <text font-size=\\"14\\" x=\\"80\\" y=\\"93\\">U</text>
 <text font-size=\\"12\\" x=\\"80\\" y=\\"108\\">('foo', 'bar')</text>
-</g>
 </g>"
 `;
 
 exports[`Testing _formatGate measure gate 1`] = `
-"<g>
+"<g class=\\"gate\\">
 <rect class=\\"gate-measure\\" x=\\"60\\" y=\\"20\\" width=\\"40\\" height=\\"40\\"></rect>
 <path class=\\"arc-measure\\" d=\\"M 95 42 A 15 12 0 0 0 65 42\\"></path>
 <line x1=\\"80\\" x2=\\"92\\" y1=\\"48\\" y2=\\"28\\"></line>
@@ -442,32 +382,30 @@ exports[`Testing _formatGate measure gate 1`] = `
 `;
 
 exports[`Testing _formatGate multi-qubit unitary gate 1`] = `
-"<g>
+"<g class=\\"gate\\">
 <rect class=\\"gate-unitary\\" x=\\"60\\" y=\\"20\\" width=\\"40\\" height=\\"100\\"></rect>
 <text font-size=\\"14\\" x=\\"80\\" y=\\"70\\">U</text>
 </g>"
 `;
 
 exports[`Testing _formatGate multi-qubit unitary gate with arguments 1`] = `
-"<g>
+"<g class=\\"gate\\">
 <line x1=\\"80\\" x2=\\"80\\" y1=\\"40\\" y2=\\"100\\"></line>
-<g>
 <rect class=\\"gate-unitary\\" x=\\"41.5\\" y=\\"20\\" width=\\"77\\" height=\\"100\\"></rect>
 <text font-size=\\"14\\" x=\\"80\\" y=\\"63\\">U</text>
 <text font-size=\\"12\\" x=\\"80\\" y=\\"78\\">('foo', 'bar')</text>
-</g>
 </g>"
 `;
 
 exports[`Testing _formatGate single-qubit unitary gate 1`] = `
-"<g>
+"<g class=\\"gate\\">
 <rect class=\\"gate-unitary\\" x=\\"60\\" y=\\"20\\" width=\\"40\\" height=\\"40\\"></rect>
 <text font-size=\\"14\\" x=\\"80\\" y=\\"40\\">H</text>
 </g>"
 `;
 
 exports[`Testing _formatGate single-qubit unitary gate with arguments 1`] = `
-"<g>
+"<g class=\\"gate\\">
 <rect class=\\"gate-unitary\\" x=\\"54\\" y=\\"20\\" width=\\"52\\" height=\\"40\\"></rect>
 <text font-size=\\"14\\" x=\\"80\\" y=\\"33\\">Ry</text>
 <text font-size=\\"12\\" x=\\"80\\" y=\\"48\\">(0.25)</text>
@@ -475,177 +413,130 @@ exports[`Testing _formatGate single-qubit unitary gate with arguments 1`] = `
 `;
 
 exports[`Testing _formatGate swap gate 1`] = `
-"<g>
+"<g class=\\"gate\\">
 <line x1=\\"72\\" x2=\\"88\\" y1=\\"32\\" y2=\\"48\\"></line>
-<line x1=\\"72\\" x2=\\"88\\" y1=\\"48\\" y2=\\"32\\"></line>
-<line x1=\\"72\\" x2=\\"88\\" y1=\\"92\\" y2=\\"108\\"></line>
+<line x1=\\"72\\" x2=\\"88\\" y1=\\"48\\" y2=\\"32\\"></line>,<line x1=\\"72\\" x2=\\"88\\" y1=\\"92\\" y2=\\"108\\"></line>
 <line x1=\\"72\\" x2=\\"88\\" y1=\\"108\\" y2=\\"92\\"></line>
 <line x1=\\"80\\" x2=\\"80\\" y1=\\"40\\" y2=\\"100\\"></line>
 </g>"
 `;
 
 exports[`Testing _measure 1 qubit + 1 classical registers 1`] = `
-"<g>
-<rect class=\\"gate-measure\\" x=\\"60\\" y=\\"20\\" width=\\"40\\" height=\\"40\\"></rect>
+"<rect class=\\"gate-measure\\" x=\\"60\\" y=\\"20\\" width=\\"40\\" height=\\"40\\"></rect>
 <path class=\\"arc-measure\\" d=\\"M 95 42 A 15 12 0 0 0 65 42\\"></path>
-<line x1=\\"80\\" x2=\\"92\\" y1=\\"48\\" y2=\\"28\\"></line>
-</g>"
+<line x1=\\"80\\" x2=\\"92\\" y1=\\"48\\" y2=\\"28\\"></line>"
 `;
 
 exports[`Testing _measure 2 qubit + 1 classical registers 1`] = `
-"<g>
-<rect class=\\"gate-measure\\" x=\\"60\\" y=\\"20\\" width=\\"40\\" height=\\"40\\"></rect>
+"<rect class=\\"gate-measure\\" x=\\"60\\" y=\\"20\\" width=\\"40\\" height=\\"40\\"></rect>
 <path class=\\"arc-measure\\" d=\\"M 95 42 A 15 12 0 0 0 65 42\\"></path>
-<line x1=\\"80\\" x2=\\"92\\" y1=\\"48\\" y2=\\"28\\"></line>
-</g>"
+<line x1=\\"80\\" x2=\\"92\\" y1=\\"48\\" y2=\\"28\\"></line>"
 `;
 
 exports[`Testing _measure 2 qubit + 2 classical registers 1`] = `
-"<g>
-<rect class=\\"gate-measure\\" x=\\"60\\" y=\\"20\\" width=\\"40\\" height=\\"40\\"></rect>
+"<rect class=\\"gate-measure\\" x=\\"60\\" y=\\"20\\" width=\\"40\\" height=\\"40\\"></rect>
 <path class=\\"arc-measure\\" d=\\"M 95 42 A 15 12 0 0 0 65 42\\"></path>
-<line x1=\\"80\\" x2=\\"92\\" y1=\\"48\\" y2=\\"28\\"></line>
-</g>"
+<line x1=\\"80\\" x2=\\"92\\" y1=\\"48\\" y2=\\"28\\"></line>"
 `;
 
 exports[`Testing _measure 2 qubit + 2 classical registers 2`] = `
-"<g>
-<rect class=\\"gate-measure\\" x=\\"60\\" y=\\"80\\" width=\\"40\\" height=\\"40\\"></rect>
+"<rect class=\\"gate-measure\\" x=\\"60\\" y=\\"80\\" width=\\"40\\" height=\\"40\\"></rect>
 <path class=\\"arc-measure\\" d=\\"M 95 102 A 15 12 0 0 0 65 102\\"></path>
-<line x1=\\"80\\" x2=\\"92\\" y1=\\"108\\" y2=\\"88\\"></line>
-</g>"
+<line x1=\\"80\\" x2=\\"92\\" y1=\\"108\\" y2=\\"88\\"></line>"
 `;
 
 exports[`Testing _swap Adjacent swap 1`] = `
-"<g>
-<line x1=\\"72\\" x2=\\"88\\" y1=\\"32\\" y2=\\"48\\"></line>
-<line x1=\\"72\\" x2=\\"88\\" y1=\\"48\\" y2=\\"32\\"></line>
-<line x1=\\"72\\" x2=\\"88\\" y1=\\"92\\" y2=\\"108\\"></line>
+"<line x1=\\"72\\" x2=\\"88\\" y1=\\"32\\" y2=\\"48\\"></line>
+<line x1=\\"72\\" x2=\\"88\\" y1=\\"48\\" y2=\\"32\\"></line>,<line x1=\\"72\\" x2=\\"88\\" y1=\\"92\\" y2=\\"108\\"></line>
 <line x1=\\"72\\" x2=\\"88\\" y1=\\"108\\" y2=\\"92\\"></line>
-<line x1=\\"80\\" x2=\\"80\\" y1=\\"40\\" y2=\\"100\\"></line>
-</g>"
+<line x1=\\"80\\" x2=\\"80\\" y1=\\"40\\" y2=\\"100\\"></line>"
 `;
 
 exports[`Testing _swap Adjacent swap 2`] = `
-"<g>
-<line x1=\\"72\\" x2=\\"88\\" y1=\\"92\\" y2=\\"108\\"></line>
-<line x1=\\"72\\" x2=\\"88\\" y1=\\"108\\" y2=\\"92\\"></line>
-<line x1=\\"72\\" x2=\\"88\\" y1=\\"32\\" y2=\\"48\\"></line>
+"<line x1=\\"72\\" x2=\\"88\\" y1=\\"92\\" y2=\\"108\\"></line>
+<line x1=\\"72\\" x2=\\"88\\" y1=\\"108\\" y2=\\"92\\"></line>,<line x1=\\"72\\" x2=\\"88\\" y1=\\"32\\" y2=\\"48\\"></line>
 <line x1=\\"72\\" x2=\\"88\\" y1=\\"48\\" y2=\\"32\\"></line>
-<line x1=\\"80\\" x2=\\"80\\" y1=\\"100\\" y2=\\"40\\"></line>
-</g>"
+<line x1=\\"80\\" x2=\\"80\\" y1=\\"100\\" y2=\\"40\\"></line>"
 `;
 
 exports[`Testing _swap Non-adjacent swap 1`] = `
-"<g>
-<line x1=\\"72\\" x2=\\"88\\" y1=\\"32\\" y2=\\"48\\"></line>
-<line x1=\\"72\\" x2=\\"88\\" y1=\\"48\\" y2=\\"32\\"></line>
-<line x1=\\"72\\" x2=\\"88\\" y1=\\"152\\" y2=\\"168\\"></line>
+"<line x1=\\"72\\" x2=\\"88\\" y1=\\"32\\" y2=\\"48\\"></line>
+<line x1=\\"72\\" x2=\\"88\\" y1=\\"48\\" y2=\\"32\\"></line>,<line x1=\\"72\\" x2=\\"88\\" y1=\\"152\\" y2=\\"168\\"></line>
 <line x1=\\"72\\" x2=\\"88\\" y1=\\"168\\" y2=\\"152\\"></line>
-<line x1=\\"80\\" x2=\\"80\\" y1=\\"40\\" y2=\\"160\\"></line>
-</g>"
+<line x1=\\"80\\" x2=\\"80\\" y1=\\"40\\" y2=\\"160\\"></line>"
 `;
 
 exports[`Testing _swap Non-adjacent swap 2`] = `
-"<g>
-<line x1=\\"72\\" x2=\\"88\\" y1=\\"152\\" y2=\\"168\\"></line>
-<line x1=\\"72\\" x2=\\"88\\" y1=\\"168\\" y2=\\"152\\"></line>
-<line x1=\\"72\\" x2=\\"88\\" y1=\\"32\\" y2=\\"48\\"></line>
+"<line x1=\\"72\\" x2=\\"88\\" y1=\\"152\\" y2=\\"168\\"></line>
+<line x1=\\"72\\" x2=\\"88\\" y1=\\"168\\" y2=\\"152\\"></line>,<line x1=\\"72\\" x2=\\"88\\" y1=\\"32\\" y2=\\"48\\"></line>
 <line x1=\\"72\\" x2=\\"88\\" y1=\\"48\\" y2=\\"32\\"></line>
-<line x1=\\"80\\" x2=\\"80\\" y1=\\"160\\" y2=\\"40\\"></line>
-</g>"
+<line x1=\\"80\\" x2=\\"80\\" y1=\\"160\\" y2=\\"40\\"></line>"
 `;
 
 exports[`Testing _unitary Multiqubit unitary on consecutive registers 1`] = `
-"<g>
-<rect class=\\"gate-unitary\\" x=\\"60\\" y=\\"20\\" width=\\"40\\" height=\\"100\\"></rect>
-<text font-size=\\"14\\" x=\\"80\\" y=\\"70\\">ZZ</text>
-</g>"
+"<rect class=\\"gate-unitary\\" x=\\"60\\" y=\\"20\\" width=\\"40\\" height=\\"100\\"></rect>
+<text font-size=\\"14\\" x=\\"80\\" y=\\"70\\">ZZ</text>"
 `;
 
 exports[`Testing _unitary Multiqubit unitary on consecutive registers 2`] = `
-"<g>
-<rect class=\\"gate-unitary\\" x=\\"60\\" y=\\"20\\" width=\\"40\\" height=\\"160\\"></rect>
-<text font-size=\\"14\\" x=\\"80\\" y=\\"100\\">ZZZ</text>
-</g>"
+"<rect class=\\"gate-unitary\\" x=\\"60\\" y=\\"20\\" width=\\"40\\" height=\\"160\\"></rect>
+<text font-size=\\"14\\" x=\\"80\\" y=\\"100\\">ZZZ</text>"
 `;
 
 exports[`Testing _unitary Multiqubit unitary on non-consecutive registers 1`] = `
 "<line x1=\\"80\\" x2=\\"80\\" y1=\\"40\\" y2=\\"160\\" stroke-dasharray=\\"8, 8\\"></line>
-<g>
 <rect class=\\"gate-unitary\\" x=\\"60\\" y=\\"20\\" width=\\"40\\" height=\\"40\\"></rect>
 <text font-size=\\"14\\" x=\\"80\\" y=\\"40\\">ZZ</text>
-</g>
-<g>
 <rect class=\\"gate-unitary\\" x=\\"60\\" y=\\"140\\" width=\\"40\\" height=\\"40\\"></rect>
-<text font-size=\\"14\\" x=\\"80\\" y=\\"160\\">ZZ</text>
-</g>"
+<text font-size=\\"14\\" x=\\"80\\" y=\\"160\\">ZZ</text>"
 `;
 
 exports[`Testing _unitary Multiqubit unitary on non-consecutive registers 2`] = `
 "<line x1=\\"80\\" x2=\\"80\\" y1=\\"40\\" y2=\\"220\\" stroke-dasharray=\\"8, 8\\"></line>
-<g>
 <rect class=\\"gate-unitary\\" x=\\"60\\" y=\\"20\\" width=\\"40\\" height=\\"40\\"></rect>
 <text font-size=\\"14\\" x=\\"80\\" y=\\"40\\">ZZZ</text>
-</g>
-<g>
 <rect class=\\"gate-unitary\\" x=\\"60\\" y=\\"140\\" width=\\"40\\" height=\\"100\\"></rect>
-<text font-size=\\"14\\" x=\\"80\\" y=\\"190\\">ZZZ</text>
-</g>"
+<text font-size=\\"14\\" x=\\"80\\" y=\\"190\\">ZZZ</text>"
 `;
 
 exports[`Testing _unitary Multiqubit unitary on non-consecutive registers 3`] = `
-"<g>
-<rect class=\\"gate-unitary\\" x=\\"60\\" y=\\"20\\" width=\\"40\\" height=\\"40\\"></rect>
+"<rect class=\\"gate-unitary\\" x=\\"60\\" y=\\"20\\" width=\\"40\\" height=\\"40\\"></rect>
 <text font-size=\\"14\\" x=\\"80\\" y=\\"40\\">ZZ</text>
-</g>
-<g>
 <rect class=\\"gate-unitary\\" x=\\"60\\" y=\\"140\\" width=\\"40\\" height=\\"40\\"></rect>
-<text font-size=\\"14\\" x=\\"80\\" y=\\"160\\">ZZ</text>
-</g>"
+<text font-size=\\"14\\" x=\\"80\\" y=\\"160\\">ZZ</text>"
 `;
 
 exports[`Testing _unitary Multiqubit unitary on non-consecutive registers 4`] = `
-"<g>
-<rect class=\\"gate-unitary\\" x=\\"60\\" y=\\"20\\" width=\\"40\\" height=\\"40\\"></rect>
+"<rect class=\\"gate-unitary\\" x=\\"60\\" y=\\"20\\" width=\\"40\\" height=\\"40\\"></rect>
 <text font-size=\\"14\\" x=\\"80\\" y=\\"40\\">ZZZ</text>
-</g>
-<g>
 <rect class=\\"gate-unitary\\" x=\\"60\\" y=\\"140\\" width=\\"40\\" height=\\"100\\"></rect>
-<text font-size=\\"14\\" x=\\"80\\" y=\\"190\\">ZZZ</text>
-</g>"
+<text font-size=\\"14\\" x=\\"80\\" y=\\"190\\">ZZZ</text>"
 `;
 
 exports[`Testing _unitary Single qubit unitary 1`] = `
-"<g>
-<rect class=\\"gate-unitary\\" x=\\"60\\" y=\\"20\\" width=\\"40\\" height=\\"40\\"></rect>
-<text font-size=\\"14\\" x=\\"80\\" y=\\"40\\">H</text>
-</g>"
+"<rect class=\\"gate-unitary\\" x=\\"60\\" y=\\"20\\" width=\\"40\\" height=\\"40\\"></rect>
+<text font-size=\\"14\\" x=\\"80\\" y=\\"40\\">H</text>"
 `;
 
 exports[`Testing formatGates Multiple gates 1`] = `
-"<g>
+"<g class=\\"gate\\">
 <line x1=\\"80\\" x2=\\"80\\" y1=\\"40\\" y2=\\"100\\"></line>
 <circle class=\\"control-dot\\" cx=\\"80\\" cy=\\"100\\" r=\\"5\\"></circle>
-<g>
 <circle class=\\"oplus\\" cx=\\"80\\" cy=\\"40\\" r=\\"15\\"></circle>
 <line x1=\\"80\\" x2=\\"80\\" y1=\\"25\\" y2=\\"55\\"></line>
 <line x1=\\"65\\" x2=\\"95\\" y1=\\"40\\" y2=\\"40\\"></line>
 </g>
-</g>
-<g>
+<g class=\\"gate\\">
 <line x1=\\"80\\" x2=\\"80\\" y1=\\"100\\" y2=\\"160\\"></line>
 <circle class=\\"control-dot\\" cx=\\"80\\" cy=\\"100\\" r=\\"5\\"></circle>
-<g>
 <rect class=\\"gate-unitary\\" x=\\"60\\" y=\\"140\\" width=\\"40\\" height=\\"40\\"></rect>
 <text font-size=\\"14\\" x=\\"80\\" y=\\"160\\">X</text>
 </g>
-</g>
-<g>
+<g class=\\"gate\\">
 <rect class=\\"gate-unitary\\" x=\\"60\\" y=\\"140\\" width=\\"40\\" height=\\"40\\"></rect>
 <text font-size=\\"14\\" x=\\"80\\" y=\\"160\\">X</text>
 </g>
-<g>
+<g class=\\"gate\\">
 <rect class=\\"gate-measure\\" x=\\"60\\" y=\\"20\\" width=\\"40\\" height=\\"40\\"></rect>
 <path class=\\"arc-measure\\" d=\\"M 95 42 A 15 12 0 0 0 65 42\\"></path>
 <line x1=\\"80\\" x2=\\"92\\" y1=\\"48\\" y2=\\"28\\"></line>
@@ -653,13 +544,11 @@ exports[`Testing formatGates Multiple gates 1`] = `
 `;
 
 exports[`Testing formatGates Single gate 1`] = `
-"<g>
+"<g class=\\"gate\\">
 <line x1=\\"80\\" x2=\\"80\\" y1=\\"40\\" y2=\\"100\\"></line>
 <circle class=\\"control-dot\\" cx=\\"80\\" cy=\\"40\\" r=\\"5\\"></circle>
-<g>
 <circle class=\\"oplus\\" cx=\\"80\\" cy=\\"100\\" r=\\"15\\"></circle>
 <line x1=\\"80\\" x2=\\"80\\" y1=\\"85\\" y2=\\"115\\"></line>
 <line x1=\\"65\\" x2=\\"95\\" y1=\\"100\\" y2=\\"100\\"></line>
-</g>
 </g>"
 `;

--- a/src/Kernel/client/__tests__/ExecutionPathVisualizerTests/gateFormatter.test.ts
+++ b/src/Kernel/client/__tests__/ExecutionPathVisualizerTests/gateFormatter.test.ts
@@ -5,19 +5,12 @@ import {
     _unitary,
     _swap,
     _controlledGate,
-    _classicalControlled
-} from "../../ExecutionPathVisualizer/formatters/gateFormatter";
-import { Metadata } from "../../ExecutionPathVisualizer/metadata";
-import {
-    GateType,
-    startX,
-    startY,
-    registerHeight,
-    minGateWidth,
-    gatePadding,
-} from "../../ExecutionPathVisualizer/constants";
+    _classicalControlled,
+} from '../../ExecutionPathVisualizer/formatters/gateFormatter';
+import { Metadata } from '../../ExecutionPathVisualizer/metadata';
+import { GateType, startX, startY, registerHeight, minGateWidth, gatePadding } from '../../ExecutionPathVisualizer/constants';
 
-describe("Testing _classicalControlled", () => {
+describe('Testing _classicalControlled', () => {
     test("one 'zero' child", () => {
         const metadata: Metadata = {
             type: GateType.ClassicalControlled,
@@ -27,17 +20,19 @@ describe("Testing _classicalControlled", () => {
             width: minGateWidth + gatePadding * 2,
             label: 'if',
             children: [
-                [{
-                    type: GateType.Unitary,
-                    x: startX + minGateWidth / 2 + gatePadding,
-                    label: 'X',
-                    controlsY: [],
-                    targetsY: [startY],
-                    width: minGateWidth
-                }],
-                []
+                [
+                    {
+                        type: GateType.Unitary,
+                        x: startX + minGateWidth / 2 + gatePadding,
+                        label: 'X',
+                        controlsY: [],
+                        targetsY: [startY],
+                        width: minGateWidth,
+                    },
+                ],
+                [],
             ],
-            htmlClass: 'classically-controlled-1'
+            htmlClass: 'classically-controlled-1',
         };
         expect(_classicalControlled(metadata)).toMatchSnapshot();
     });
@@ -51,16 +46,18 @@ describe("Testing _classicalControlled", () => {
             label: 'if',
             children: [
                 [],
-                [{
-                    type: GateType.Unitary,
-                    x: startX + minGateWidth / 2 + gatePadding,
-                    label: 'X',
-                    controlsY: [],
-                    targetsY: [startY],
-                    width: minGateWidth
-                }]
+                [
+                    {
+                        type: GateType.Unitary,
+                        x: startX + minGateWidth / 2 + gatePadding,
+                        label: 'X',
+                        controlsY: [],
+                        targetsY: [startY],
+                        width: minGateWidth,
+                    },
+                ],
             ],
-            htmlClass: 'classically-controlled-1'
+            htmlClass: 'classically-controlled-1',
         };
         expect(_classicalControlled(metadata)).toMatchSnapshot();
     });
@@ -74,14 +71,6 @@ describe("Testing _classicalControlled", () => {
             label: 'if',
             htmlClass: 'classically-controlled-1',
             children: [
-                [{
-                    type: GateType.Unitary,
-                    x: startX + minGateWidth / 2 + gatePadding,
-                    label: 'X',
-                    controlsY: [],
-                    targetsY: [startY],
-                    width: minGateWidth
-                }],
                 [
                     {
                         type: GateType.Unitary,
@@ -89,7 +78,17 @@ describe("Testing _classicalControlled", () => {
                         label: 'X',
                         controlsY: [],
                         targetsY: [startY],
-                        width: minGateWidth
+                        width: minGateWidth,
+                    },
+                ],
+                [
+                    {
+                        type: GateType.Unitary,
+                        x: startX + minGateWidth / 2 + gatePadding,
+                        label: 'X',
+                        controlsY: [],
+                        targetsY: [startY],
+                        width: minGateWidth,
                     },
                     {
                         type: GateType.Cnot,
@@ -97,14 +96,14 @@ describe("Testing _classicalControlled", () => {
                         label: 'X',
                         controlsY: [startY + registerHeight],
                         targetsY: [startY],
-                        width: minGateWidth
-                    }
-                ]
+                        width: minGateWidth,
+                    },
+                ],
             ],
         };
         expect(_classicalControlled(metadata)).toMatchSnapshot();
     });
-    test("nested children", () => {
+    test('nested children', () => {
         const metadata: Metadata = {
             type: GateType.ClassicalControlled,
             x: startX,
@@ -122,7 +121,7 @@ describe("Testing _classicalControlled", () => {
                         label: 'X',
                         controlsY: [],
                         targetsY: [startY],
-                        width: minGateWidth
+                        width: minGateWidth,
                     },
                     {
                         type: GateType.ClassicalControlled,
@@ -134,22 +133,24 @@ describe("Testing _classicalControlled", () => {
                         htmlClass: 'classically-controlled-1',
                         children: [
                             [],
-                            [{
-                                type: GateType.Cnot,
-                                x: startX + minGateWidth + gatePadding * 4 + minGateWidth / 2,
-                                label: 'X',
-                                controlsY: [startY + registerHeight],
-                                targetsY: [startY],
-                                width: minGateWidth
-                            }]
-                        ]
-                    }
-                ]
+                            [
+                                {
+                                    type: GateType.Cnot,
+                                    x: startX + minGateWidth + gatePadding * 4 + minGateWidth / 2,
+                                    label: 'X',
+                                    controlsY: [startY + registerHeight],
+                                    targetsY: [startY],
+                                    width: minGateWidth,
+                                },
+                            ],
+                        ],
+                    },
+                ],
             ],
         };
         expect(_classicalControlled(metadata)).toMatchSnapshot();
     });
-    test("No htmlClass", () => {
+    test('No htmlClass', () => {
         const metadata: Metadata = {
             type: GateType.ClassicalControlled,
             x: startX,
@@ -159,19 +160,21 @@ describe("Testing _classicalControlled", () => {
             label: 'if',
             children: [
                 [],
-                [{
-                    type: GateType.Unitary,
-                    x: startX + minGateWidth / 2 + gatePadding,
-                    label: 'X',
-                    controlsY: [],
-                    targetsY: [startY],
-                    width: minGateWidth
-                }]
+                [
+                    {
+                        type: GateType.Unitary,
+                        x: startX + minGateWidth / 2 + gatePadding,
+                        label: 'X',
+                        controlsY: [],
+                        targetsY: [startY],
+                        width: minGateWidth,
+                    },
+                ],
             ],
         };
         expect(_classicalControlled(metadata)).toMatchSnapshot();
     });
-    test("change padding", () => {
+    test('change padding', () => {
         const metadata: Metadata = {
             type: GateType.ClassicalControlled,
             x: startX,
@@ -181,30 +184,32 @@ describe("Testing _classicalControlled", () => {
             label: 'if',
             children: [
                 [],
-                [{
-                    type: GateType.Unitary,
-                    x: startX + minGateWidth / 2 + gatePadding,
-                    label: 'X',
-                    controlsY: [],
-                    targetsY: [startY],
-                    width: minGateWidth
-                }]
+                [
+                    {
+                        type: GateType.Unitary,
+                        x: startX + minGateWidth / 2 + gatePadding,
+                        label: 'X',
+                        controlsY: [],
+                        targetsY: [startY],
+                        width: minGateWidth,
+                    },
+                ],
             ],
-            htmlClass: 'classically-controlled-1'
+            htmlClass: 'classically-controlled-1',
         };
         expect(_classicalControlled(metadata, 20)).toMatchSnapshot();
     });
 });
 
-describe("Testing _controlledGate", () => {
-    test("CNOT gate", () => {
+describe('Testing _controlledGate', () => {
+    test('CNOT gate', () => {
         const metadata: Metadata = {
             type: GateType.Cnot,
             label: 'X',
             x: startX,
             controlsY: [startY],
             targetsY: [startY + registerHeight],
-            width: minGateWidth
+            width: minGateWidth,
         };
         let svg: string = _controlledGate(metadata);
         expect(svg).toMatchSnapshot();
@@ -215,14 +220,14 @@ describe("Testing _controlledGate", () => {
         svg = _controlledGate(metadata);
         expect(svg).toMatchSnapshot();
     });
-    test("SWAP gate", () => {
+    test('SWAP gate', () => {
         const metadata: Metadata = {
             type: GateType.Swap,
             label: '',
             x: startX,
             controlsY: [startY],
             targetsY: [startY + registerHeight, startY + registerHeight * 2],
-            width: minGateWidth
+            width: minGateWidth,
         };
         // Control on top
         let svg: string = _controlledGate(metadata);
@@ -240,14 +245,14 @@ describe("Testing _controlledGate", () => {
         svg = _controlledGate(metadata);
         expect(svg).toMatchSnapshot();
     });
-    test("Controlled U gate with 1 control + 1 target", () => {
+    test('Controlled U gate with 1 control + 1 target', () => {
         const metadata: Metadata = {
             type: GateType.ControlledUnitary,
             label: 'Foo',
             x: startX,
             controlsY: [startY],
             targetsY: [startY + registerHeight],
-            width: 45
+            width: 45,
         };
         let svg: string = _controlledGate(metadata);
         expect(svg).toMatchSnapshot();
@@ -258,14 +263,14 @@ describe("Testing _controlledGate", () => {
         svg = _controlledGate(metadata);
         expect(svg).toMatchSnapshot();
     });
-    test("Controlled U gate with multiple controls + 1 target", () => {
+    test('Controlled U gate with multiple controls + 1 target', () => {
         const metadata: Metadata = {
             type: GateType.ControlledUnitary,
             label: 'Foo',
             x: startX,
             controlsY: [startY, startY + registerHeight],
             targetsY: [startY + registerHeight * 2],
-            width: 45
+            width: 45,
         };
         // Target on bottom
         let svg: string = _controlledGate(metadata);
@@ -283,14 +288,14 @@ describe("Testing _controlledGate", () => {
         svg = _controlledGate(metadata);
         expect(svg).toMatchSnapshot();
     });
-    test("Controlled U gate with 1 control + 2 targets", () => {
+    test('Controlled U gate with 1 control + 2 targets', () => {
         const metadata: Metadata = {
             type: GateType.ControlledUnitary,
             label: 'Foo',
             x: startX,
             controlsY: [startY + registerHeight * 2],
             targetsY: [startY, startY + registerHeight],
-            width: 45
+            width: 45,
         };
         // Control on bottom
         let svg: string = _controlledGate(metadata);
@@ -308,14 +313,14 @@ describe("Testing _controlledGate", () => {
         svg = _controlledGate(metadata);
         expect(svg).toMatchSnapshot();
     });
-    test("Controlled U gate with 2 controls + 2 targets", () => {
+    test('Controlled U gate with 2 controls + 2 targets', () => {
         const metadata: Metadata = {
             type: GateType.ControlledUnitary,
             label: 'Foo',
             x: startX,
             controlsY: [startY + registerHeight * 2, startY + registerHeight * 3],
             targetsY: [startY, startY + registerHeight],
-            width: 45
+            width: 45,
         };
         // Controls on bottom
         let svg: string = _controlledGate(metadata);
@@ -339,29 +344,28 @@ describe("Testing _controlledGate", () => {
         svg = _controlledGate(metadata);
         expect(svg).toMatchSnapshot();
     });
-    test("Invalid gate", () => {
+    test('Invalid gate', () => {
         const metadata: Metadata = {
             type: GateType.Measure,
             label: 'X',
             x: startX,
             controlsY: [startY],
             targetsY: [startY + registerHeight],
-            width: minGateWidth
+            width: minGateWidth,
         };
-        expect(() => _controlledGate(metadata))
-            .toThrowError(`ERROR: Unrecognized gate: X of type ${GateType.Measure}`);
+        expect(() => _controlledGate(metadata)).toThrowError(`ERROR: Unrecognized gate: X of type ${GateType.Measure}`);
     });
 });
 
-describe("Testing _swap", () => {
-    test("Adjacent swap", () => {
+describe('Testing _swap', () => {
+    test('Adjacent swap', () => {
         let svg: string = _swap(startX, [startY, startY + registerHeight]);
         expect(svg).toMatchSnapshot();
         // Flip target and control
         svg = _swap(startX, [startY + registerHeight, startY]);
         expect(svg).toMatchSnapshot();
     });
-    test("Non-adjacent swap", () => {
+    test('Non-adjacent swap', () => {
         let svg: string = _swap(startX, [startY, startY + registerHeight * 2]);
         expect(svg).toMatchSnapshot();
         // Flip target and control
@@ -370,57 +374,56 @@ describe("Testing _swap", () => {
     });
 });
 
-describe("Testing _unitary", () => {
-    test("Single qubit unitary", () => {
+describe('Testing _unitary', () => {
+    test('Single qubit unitary', () => {
         expect(_unitary('H', startX, [startY], minGateWidth)).toMatchSnapshot();
     });
-    test("Multiqubit unitary on consecutive registers", () => {
+    test('Multiqubit unitary on consecutive registers', () => {
         let svg: string = _unitary('ZZ', startX, [startY, startY + registerHeight], minGateWidth);
         expect(svg).toMatchSnapshot();
-        svg = _unitary('ZZZ', startX,
-            [startY, startY + registerHeight, startY + registerHeight * 2], minGateWidth);
+        svg = _unitary('ZZZ', startX, [startY, startY + registerHeight, startY + registerHeight * 2], minGateWidth);
         expect(svg).toMatchSnapshot();
     });
-    test("Multiqubit unitary on non-consecutive registers", () => {
+    test('Multiqubit unitary on non-consecutive registers', () => {
         // Dashed line between unitaries
         let svg: string = _unitary('ZZ', startX, [startY, startY + registerHeight * 2], minGateWidth);
         expect(svg).toMatchSnapshot();
-        svg = _unitary('ZZZ', startX,
-            [startY, startY + registerHeight * 2, startY + registerHeight * 3], minGateWidth);
+        svg = _unitary('ZZZ', startX, [startY, startY + registerHeight * 2, startY + registerHeight * 3], minGateWidth);
         expect(svg).toMatchSnapshot();
         // Solid line
         svg = _unitary('ZZ', startX, [startY, startY + registerHeight * 2], minGateWidth, undefined, false);
         expect(svg).toMatchSnapshot();
-        svg = _unitary('ZZZ', startX,
+        svg = _unitary(
+            'ZZZ',
+            startX,
             [startY, startY + registerHeight * 2, startY + registerHeight * 3],
-            minGateWidth, undefined, false);
+            minGateWidth,
+            undefined,
+            false,
+        );
         expect(svg).toMatchSnapshot();
     });
-    test("No y coords", () => {
+    test('No y coords', () => {
         const svg: string = _unitary('ZZ', startX, [], minGateWidth);
-        expect(svg).toStrictEqual("");
+        expect(svg).toStrictEqual('');
     });
 });
 
-describe("Testing _measure", () => {
-    test("1 qubit + 1 classical registers", () => {
-        expect(_measure(startX, startY, startY + registerHeight))
-            .toMatchSnapshot();
+describe('Testing _measure', () => {
+    test('1 qubit + 1 classical registers', () => {
+        expect(_measure(startX, startY)).toMatchSnapshot();
     });
-    test("2 qubit + 1 classical registers", () => {
-        expect(_measure(startX, startY, startY + registerHeight * 2))
-            .toMatchSnapshot();
+    test('2 qubit + 1 classical registers', () => {
+        expect(_measure(startX, startY)).toMatchSnapshot();
     });
-    test("2 qubit + 2 classical registers", () => {
-        expect(_measure(startX, startY, startY + registerHeight * 3))
-            .toMatchSnapshot();
-        expect(_measure(startX, startY + registerHeight, startY + registerHeight * 3))
-            .toMatchSnapshot();
+    test('2 qubit + 2 classical registers', () => {
+        expect(_measure(startX, startY)).toMatchSnapshot();
+        expect(_measure(startX, startY + registerHeight)).toMatchSnapshot();
     });
 });
 
-describe("Testing _formatGate", () => {
-    test("measure gate", () => {
+describe('Testing _formatGate', () => {
+    test('measure gate', () => {
         const metadata: Metadata = {
             type: GateType.Measure,
             x: startX,
@@ -431,7 +434,7 @@ describe("Testing _formatGate", () => {
         };
         expect(_formatGate(metadata)).toMatchSnapshot();
     });
-    test("single-qubit unitary gate", () => {
+    test('single-qubit unitary gate', () => {
         const metadata: Metadata = {
             type: GateType.Unitary,
             x: startX,
@@ -442,7 +445,7 @@ describe("Testing _formatGate", () => {
         };
         expect(_formatGate(metadata)).toMatchSnapshot();
     });
-    test("single-qubit unitary gate with arguments", () => {
+    test('single-qubit unitary gate with arguments', () => {
         const metadata: Metadata = {
             type: GateType.Unitary,
             x: startX,
@@ -454,7 +457,7 @@ describe("Testing _formatGate", () => {
         };
         expect(_formatGate(metadata)).toMatchSnapshot();
     });
-    test("multi-qubit unitary gate", () => {
+    test('multi-qubit unitary gate', () => {
         const metadata: Metadata = {
             type: GateType.Unitary,
             x: startX,
@@ -465,8 +468,8 @@ describe("Testing _formatGate", () => {
         };
         expect(_formatGate(metadata)).toMatchSnapshot();
     });
-    
-    test("multi-qubit unitary gate with arguments", () => {
+
+    test('multi-qubit unitary gate with arguments', () => {
         const metadata: Metadata = {
             type: GateType.ControlledUnitary,
             x: startX,
@@ -478,7 +481,7 @@ describe("Testing _formatGate", () => {
         };
         expect(_formatGate(metadata)).toMatchSnapshot();
     });
-    test("swap gate", () => {
+    test('swap gate', () => {
         const metadata: Metadata = {
             type: GateType.Swap,
             x: startX,
@@ -489,7 +492,7 @@ describe("Testing _formatGate", () => {
         };
         expect(_formatGate(metadata)).toMatchSnapshot();
     });
-    test("controlled swap gate", () => {
+    test('controlled swap gate', () => {
         const metadata: Metadata = {
             type: GateType.Swap,
             x: startX,
@@ -500,7 +503,7 @@ describe("Testing _formatGate", () => {
         };
         expect(_formatGate(metadata)).toMatchSnapshot();
     });
-    test("CNOT gate", () => {
+    test('CNOT gate', () => {
         const metadata: Metadata = {
             type: GateType.Cnot,
             x: startX,
@@ -511,7 +514,7 @@ describe("Testing _formatGate", () => {
         };
         expect(_formatGate(metadata)).toMatchSnapshot();
     });
-    test("controlled unitary gate", () => {
+    test('controlled unitary gate', () => {
         const metadata: Metadata = {
             type: GateType.ControlledUnitary,
             x: startX,
@@ -522,7 +525,7 @@ describe("Testing _formatGate", () => {
         };
         expect(_formatGate(metadata)).toMatchSnapshot();
     });
-    test("controlled unitary gate with arguments", () => {
+    test('controlled unitary gate with arguments', () => {
         const metadata: Metadata = {
             type: GateType.ControlledUnitary,
             x: startX,
@@ -534,7 +537,7 @@ describe("Testing _formatGate", () => {
         };
         expect(_formatGate(metadata)).toMatchSnapshot();
     });
-    test("classically controlled gate", () => {
+    test('classically controlled gate', () => {
         const metadata: Metadata = {
             type: GateType.ClassicalControlled,
             x: startX,
@@ -545,7 +548,7 @@ describe("Testing _formatGate", () => {
         };
         expect(_formatGate(metadata)).toMatchSnapshot();
     });
-    test("Invalid gate", () => {
+    test('Invalid gate', () => {
         const metadata: Metadata = {
             type: GateType.Invalid,
             x: startX,
@@ -554,13 +557,12 @@ describe("Testing _formatGate", () => {
             label: 'Foo',
             width: 48,
         };
-        expect(() => _formatGate(metadata))
-            .toThrowError(`ERROR: unknown gate (Foo) of type ${GateType.Invalid}.`);
+        expect(() => _formatGate(metadata)).toThrowError(`ERROR: unknown gate (Foo) of type ${GateType.Invalid}.`);
     });
 });
 
-describe("Testing formatGates", () => {
-    test("Single gate", () => {
+describe('Testing formatGates', () => {
+    test('Single gate', () => {
         const gates: Metadata[] = [
             {
                 type: GateType.Cnot,
@@ -573,7 +575,7 @@ describe("Testing formatGates", () => {
         ];
         expect(formatGates(gates)).toMatchSnapshot();
     });
-    test("Single null gate", () => {
+    test('Single null gate', () => {
         const gates: Metadata[] = [
             {
                 type: GateType.Invalid,
@@ -586,7 +588,7 @@ describe("Testing formatGates", () => {
         ];
         expect(() => formatGates(gates)).toThrowError(`ERROR: unknown gate () of type ${GateType.Invalid}.`);
     });
-    test("Multiple gates", () => {
+    test('Multiple gates', () => {
         const gates: Metadata[] = [
             {
                 type: GateType.Cnot,
@@ -623,7 +625,7 @@ describe("Testing formatGates", () => {
         ];
         expect(formatGates(gates)).toMatchSnapshot();
     });
-    test("Multiple gates with invalid gate", () => {
+    test('Multiple gates with invalid gate', () => {
         const gates: Metadata[] = [
             {
                 type: GateType.Unitary,
@@ -658,7 +660,6 @@ describe("Testing formatGates", () => {
                 width: minGateWidth,
             },
         ];
-        expect(() => formatGates(gates))
-            .toThrowError(`ERROR: unknown gate () of type ${GateType.Invalid}.`);
+        expect(() => formatGates(gates)).toThrowError(`ERROR: unknown gate () of type ${GateType.Invalid}.`);
     });
 });

--- a/src/Kernel/client/__tests__/ExecutionPathVisualizerTests/inputFormatter.test.ts
+++ b/src/Kernel/client/__tests__/ExecutionPathVisualizerTests/inputFormatter.test.ts
@@ -1,18 +1,18 @@
-import { Qubit } from "../../ExecutionPathVisualizer/executionPath";
-import { RegisterMap, RegisterType } from "../../ExecutionPathVisualizer/register";
-import { formatInputs, _qubitInput } from "../../ExecutionPathVisualizer/formatters/inputFormatter";
-import { startY, registerHeight, classicalRegHeight } from "../../ExecutionPathVisualizer/constants";
+import { Qubit } from '../../ExecutionPathVisualizer/executionPath';
+import { RegisterMap, RegisterType } from '../../ExecutionPathVisualizer/register';
+import { formatInputs, _qubitInput } from '../../ExecutionPathVisualizer/formatters/inputFormatter';
+import { startY, registerHeight, classicalRegHeight } from '../../ExecutionPathVisualizer/constants';
 
-describe("Testing _qubitInput", () => {
-    test("classical register", () => {
+describe('Testing _qubitInput', () => {
+    test('classical register', () => {
         expect(_qubitInput(20)).toMatchSnapshot();
         expect(_qubitInput(50)).toMatchSnapshot();
         expect(_qubitInput(0)).toMatchSnapshot();
     });
 });
 
-describe("Testing formatInputs", () => {
-    test("1 quantum register", () => {
+describe('Testing formatInputs', () => {
+    test('1 quantum register', () => {
         const inputs: Qubit[] = [{ id: 0 }];
         const expectedRegs: RegisterMap = { 0: { type: RegisterType.Qubit, y: startY } };
         const { qubitWires, registers } = formatInputs(inputs);
@@ -20,7 +20,7 @@ describe("Testing formatInputs", () => {
         expect(registers).toEqual(expectedRegs);
         expect(registers).toEqual(expectedRegs);
     });
-    test("Multiple quantum registers", () => {
+    test('Multiple quantum registers', () => {
         const inputs: Qubit[] = [{ id: 0 }, { id: 1 }, { id: 2 }];
         const expectedRegs: RegisterMap = {
             0: { type: RegisterType.Qubit, y: startY },
@@ -32,13 +32,13 @@ describe("Testing formatInputs", () => {
         expect(registers).toEqual(expectedRegs);
         expect(registers).toEqual(expectedRegs);
     });
-    test("Quantum and classical registers", () => {
+    test('Quantum and classical registers', () => {
         let inputs: Qubit[] = [{ id: 0, numChildren: 1 }, { id: 1 }, { id: 2 }];
         let expectedRegs: RegisterMap = {
             0: {
                 type: RegisterType.Qubit,
                 y: startY,
-                children: [{ type: RegisterType.Classical, y: startY + classicalRegHeight }]
+                children: [{ type: RegisterType.Classical, y: startY + classicalRegHeight }],
             },
             1: { type: RegisterType.Qubit, y: startY + classicalRegHeight * 2 },
             2: { type: RegisterType.Qubit, y: startY + registerHeight + classicalRegHeight * 2 },
@@ -57,14 +57,12 @@ describe("Testing formatInputs", () => {
                 children: [
                     { type: RegisterType.Classical, y: startY + registerHeight + classicalRegHeight },
                     { type: RegisterType.Classical, y: startY + registerHeight + classicalRegHeight * 2 },
-                ]
+                ],
             },
             2: {
                 type: RegisterType.Qubit,
                 y: startY + registerHeight + classicalRegHeight * 3,
-                children: [
-                    { type: RegisterType.Classical, y: startY + registerHeight + classicalRegHeight * 4 },
-                ]
+                children: [{ type: RegisterType.Classical, y: startY + registerHeight + classicalRegHeight * 4 }],
             },
         };
         ({ qubitWires, registers } = formatInputs(inputs));
@@ -72,7 +70,7 @@ describe("Testing formatInputs", () => {
         expect(registers).toEqual(expectedRegs);
         expect(registers).toEqual(expectedRegs);
     });
-    test("Skip quantum registers", () => {
+    test('Skip quantum registers', () => {
         const inputs: Qubit[] = [{ id: 0 }, { id: 2 }];
         const expectedRegs: RegisterMap = {
             0: { type: RegisterType.Qubit, y: startY },

--- a/src/Kernel/client/__tests__/ExecutionPathVisualizerTests/process.test.ts
+++ b/src/Kernel/client/__tests__/ExecutionPathVisualizerTests/process.test.ts
@@ -1,6 +1,6 @@
-import { Operation } from "../../ExecutionPathVisualizer/executionPath";
-import { RegisterMap, RegisterType, Register } from "../../ExecutionPathVisualizer/register";
-import { Metadata } from "../../ExecutionPathVisualizer/metadata";
+import { Operation } from '../../ExecutionPathVisualizer/executionPath';
+import { RegisterMap, RegisterType, Register } from '../../ExecutionPathVisualizer/register';
+import { Metadata } from '../../ExecutionPathVisualizer/metadata';
 import {
     processOperations,
     _groupOperations,
@@ -11,7 +11,7 @@ import {
     _addClass,
     _fillMetadataX,
     _offsetChildrenX,
-} from "../../ExecutionPathVisualizer/process";
+} from '../../ExecutionPathVisualizer/process';
 import {
     GateType,
     minGateWidth,
@@ -21,258 +21,762 @@ import {
     gatePadding,
     classicalRegHeight,
     controlBtnOffset,
-    classicalBoxPadding
-} from "../../ExecutionPathVisualizer/constants";
-import { _getStringWidth } from "../../ExecutionPathVisualizer/utils";
+    classicalBoxPadding,
+} from '../../ExecutionPathVisualizer/constants';
 
-describe("Testing _groupOperations", () => {
+describe('Testing _groupOperations', () => {
     const registers: RegisterMap = {
         0: { type: RegisterType.Qubit, y: startY },
         1: { type: RegisterType.Qubit, y: startY + registerHeight },
         2: { type: RegisterType.Qubit, y: startY + registerHeight * 2 },
         3: { type: RegisterType.Qubit, y: startY + registerHeight * 3 },
     };
-    test("single qubit gates on 1 qubit register", () => {
+    test('single qubit gates on 1 qubit register', () => {
         const operations: Operation[] = [
-            { gate: "X", isMeasurement: false, isControlled: false, isAdjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
-            { gate: "Y", isMeasurement: false, isControlled: false, isAdjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
-            { gate: "Z", isMeasurement: false, isControlled: false, isAdjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
+            {
+                gate: 'X',
+                isMeasurement: false,
+                isControlled: false,
+                isAdjoint: false,
+                controls: [],
+                targets: [{ type: RegisterType.Qubit, qId: 0 }],
+            },
+            {
+                gate: 'Y',
+                isMeasurement: false,
+                isControlled: false,
+                isAdjoint: false,
+                controls: [],
+                targets: [{ type: RegisterType.Qubit, qId: 0 }],
+            },
+            {
+                gate: 'Z',
+                isMeasurement: false,
+                isControlled: false,
+                isAdjoint: false,
+                controls: [],
+                targets: [{ type: RegisterType.Qubit, qId: 0 }],
+            },
         ];
         expect(_groupOperations(operations, registers)).toEqual([[0, 1, 2], [], [], []]);
     });
-    test("single qubit gates on multiple qubit registers", () => {
+    test('single qubit gates on multiple qubit registers', () => {
         const operations: Operation[] = [
-            { gate: "X", isMeasurement: false, isControlled: false, isAdjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
-            { gate: "Y", isMeasurement: false, isControlled: false, isAdjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 1 }] },
-            { gate: "Z", isMeasurement: false, isControlled: false, isAdjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 2 }] },
-            { gate: "H", isMeasurement: false, isControlled: false, isAdjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
-            { gate: "T", isMeasurement: false, isControlled: false, isAdjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 1 }] },
+            {
+                gate: 'X',
+                isMeasurement: false,
+                isControlled: false,
+                isAdjoint: false,
+                controls: [],
+                targets: [{ type: RegisterType.Qubit, qId: 0 }],
+            },
+            {
+                gate: 'Y',
+                isMeasurement: false,
+                isControlled: false,
+                isAdjoint: false,
+                controls: [],
+                targets: [{ type: RegisterType.Qubit, qId: 1 }],
+            },
+            {
+                gate: 'Z',
+                isMeasurement: false,
+                isControlled: false,
+                isAdjoint: false,
+                controls: [],
+                targets: [{ type: RegisterType.Qubit, qId: 2 }],
+            },
+            {
+                gate: 'H',
+                isMeasurement: false,
+                isControlled: false,
+                isAdjoint: false,
+                controls: [],
+                targets: [{ type: RegisterType.Qubit, qId: 0 }],
+            },
+            {
+                gate: 'T',
+                isMeasurement: false,
+                isControlled: false,
+                isAdjoint: false,
+                controls: [],
+                targets: [{ type: RegisterType.Qubit, qId: 1 }],
+            },
         ];
         expect(_groupOperations(operations, registers)).toEqual([[0, 3], [1, 4], [2], []]);
     });
-    test("single and multiple qubit(s) gates", () => {
+    test('single and multiple qubit(s) gates', () => {
         let operations: Operation[] = [
-            { gate: "X", isMeasurement: false, isControlled: false, isAdjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
-            { gate: "Y", isMeasurement: false, isControlled: true, isAdjoint: false, controls: [{ type: RegisterType.Qubit, qId: 0 }], targets: [{ type: RegisterType.Qubit, qId: 1 }] },
-            { gate: "Z", isMeasurement: false, isControlled: false, isAdjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
+            {
+                gate: 'X',
+                isMeasurement: false,
+                isControlled: false,
+                isAdjoint: false,
+                controls: [],
+                targets: [{ type: RegisterType.Qubit, qId: 0 }],
+            },
+            {
+                gate: 'Y',
+                isMeasurement: false,
+                isControlled: true,
+                isAdjoint: false,
+                controls: [{ type: RegisterType.Qubit, qId: 0 }],
+                targets: [{ type: RegisterType.Qubit, qId: 1 }],
+            },
+            {
+                gate: 'Z',
+                isMeasurement: false,
+                isControlled: false,
+                isAdjoint: false,
+                controls: [],
+                targets: [{ type: RegisterType.Qubit, qId: 0 }],
+            },
         ];
         expect(_groupOperations(operations, registers)).toEqual([[0, 1, 2], [1], [], []]);
         operations = [
-            { gate: "X", isMeasurement: false, isControlled: false, isAdjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
-            { gate: "Y", isMeasurement: false, isControlled: true, isAdjoint: false, controls: [{ type: RegisterType.Qubit, qId: 1 }], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
-            { gate: "Z", isMeasurement: false, isControlled: false, isAdjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
+            {
+                gate: 'X',
+                isMeasurement: false,
+                isControlled: false,
+                isAdjoint: false,
+                controls: [],
+                targets: [{ type: RegisterType.Qubit, qId: 0 }],
+            },
+            {
+                gate: 'Y',
+                isMeasurement: false,
+                isControlled: true,
+                isAdjoint: false,
+                controls: [{ type: RegisterType.Qubit, qId: 1 }],
+                targets: [{ type: RegisterType.Qubit, qId: 0 }],
+            },
+            {
+                gate: 'Z',
+                isMeasurement: false,
+                isControlled: false,
+                isAdjoint: false,
+                controls: [],
+                targets: [{ type: RegisterType.Qubit, qId: 0 }],
+            },
         ];
         expect(_groupOperations(operations, registers)).toEqual([[0, 1, 2], [1], [], []]);
         operations = [
-            { gate: "X", isMeasurement: false, isControlled: false, isAdjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
-            { gate: "Z", isMeasurement: false, isControlled: false, isAdjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
-            { gate: "Y", isMeasurement: false, isControlled: true, isAdjoint: false, controls: [{ type: RegisterType.Qubit, qId: 1 }], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
+            {
+                gate: 'X',
+                isMeasurement: false,
+                isControlled: false,
+                isAdjoint: false,
+                controls: [],
+                targets: [{ type: RegisterType.Qubit, qId: 0 }],
+            },
+            {
+                gate: 'Z',
+                isMeasurement: false,
+                isControlled: false,
+                isAdjoint: false,
+                controls: [],
+                targets: [{ type: RegisterType.Qubit, qId: 0 }],
+            },
+            {
+                gate: 'Y',
+                isMeasurement: false,
+                isControlled: true,
+                isAdjoint: false,
+                controls: [{ type: RegisterType.Qubit, qId: 1 }],
+                targets: [{ type: RegisterType.Qubit, qId: 0 }],
+            },
         ];
         expect(_groupOperations(operations, registers)).toEqual([[0, 1, 2], [2], [], []]);
         operations = [
-            { gate: "Y", isMeasurement: false, isControlled: true, isAdjoint: false, controls: [{ type: RegisterType.Qubit, qId: 1 }], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
-            { gate: "X", isMeasurement: false, isControlled: false, isAdjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
-            { gate: "Z", isMeasurement: false, isControlled: false, isAdjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
+            {
+                gate: 'Y',
+                isMeasurement: false,
+                isControlled: true,
+                isAdjoint: false,
+                controls: [{ type: RegisterType.Qubit, qId: 1 }],
+                targets: [{ type: RegisterType.Qubit, qId: 0 }],
+            },
+            {
+                gate: 'X',
+                isMeasurement: false,
+                isControlled: false,
+                isAdjoint: false,
+                controls: [],
+                targets: [{ type: RegisterType.Qubit, qId: 0 }],
+            },
+            {
+                gate: 'Z',
+                isMeasurement: false,
+                isControlled: false,
+                isAdjoint: false,
+                controls: [],
+                targets: [{ type: RegisterType.Qubit, qId: 0 }],
+            },
         ];
         expect(_groupOperations(operations, registers)).toEqual([[0, 1, 2], [0], [], []]);
         operations = [
-            { gate: "Y", isMeasurement: false, isControlled: true, isAdjoint: false, controls: [{ type: RegisterType.Qubit, qId: 1 }], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
-            { gate: "X", isMeasurement: false, isControlled: false, isAdjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
-            { gate: "Z", isMeasurement: false, isControlled: false, isAdjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 1 }] },
+            {
+                gate: 'Y',
+                isMeasurement: false,
+                isControlled: true,
+                isAdjoint: false,
+                controls: [{ type: RegisterType.Qubit, qId: 1 }],
+                targets: [{ type: RegisterType.Qubit, qId: 0 }],
+            },
+            {
+                gate: 'X',
+                isMeasurement: false,
+                isControlled: false,
+                isAdjoint: false,
+                controls: [],
+                targets: [{ type: RegisterType.Qubit, qId: 0 }],
+            },
+            {
+                gate: 'Z',
+                isMeasurement: false,
+                isControlled: false,
+                isAdjoint: false,
+                controls: [],
+                targets: [{ type: RegisterType.Qubit, qId: 1 }],
+            },
         ];
         expect(_groupOperations(operations, registers)).toEqual([[0, 1], [0, 2], [], []]);
     });
-    test("multiple qubit gates in ladder format", () => {
+    test('multiple qubit gates in ladder format', () => {
         const operations: Operation[] = [
-            { gate: "X", isMeasurement: false, isControlled: true, isAdjoint: false, controls: [{ type: RegisterType.Qubit, qId: 1 }], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
-            { gate: "Y", isMeasurement: false, isControlled: true, isAdjoint: false, controls: [{ type: RegisterType.Qubit, qId: 1 }], targets: [{ type: RegisterType.Qubit, qId: 2 }] },
-            { gate: "Z", isMeasurement: false, isControlled: true, isAdjoint: false, controls: [{ type: RegisterType.Qubit, qId: 2 }], targets: [{ type: RegisterType.Qubit, qId: 3 }] },
-            { gate: "H", isMeasurement: false, isControlled: true, isAdjoint: false, controls: [{ type: RegisterType.Qubit, qId: 2 }], targets: [{ type: RegisterType.Qubit, qId: 3 }] },
-            { gate: "T", isMeasurement: false, isControlled: true, isAdjoint: false, controls: [{ type: RegisterType.Qubit, qId: 2 }], targets: [{ type: RegisterType.Qubit, qId: 1 }] },
-            { gate: "X", isMeasurement: false, isControlled: true, isAdjoint: false, controls: [{ type: RegisterType.Qubit, qId: 0 }], targets: [{ type: RegisterType.Qubit, qId: 1 }] },
+            {
+                gate: 'X',
+                isMeasurement: false,
+                isControlled: true,
+                isAdjoint: false,
+                controls: [{ type: RegisterType.Qubit, qId: 1 }],
+                targets: [{ type: RegisterType.Qubit, qId: 0 }],
+            },
+            {
+                gate: 'Y',
+                isMeasurement: false,
+                isControlled: true,
+                isAdjoint: false,
+                controls: [{ type: RegisterType.Qubit, qId: 1 }],
+                targets: [{ type: RegisterType.Qubit, qId: 2 }],
+            },
+            {
+                gate: 'Z',
+                isMeasurement: false,
+                isControlled: true,
+                isAdjoint: false,
+                controls: [{ type: RegisterType.Qubit, qId: 2 }],
+                targets: [{ type: RegisterType.Qubit, qId: 3 }],
+            },
+            {
+                gate: 'H',
+                isMeasurement: false,
+                isControlled: true,
+                isAdjoint: false,
+                controls: [{ type: RegisterType.Qubit, qId: 2 }],
+                targets: [{ type: RegisterType.Qubit, qId: 3 }],
+            },
+            {
+                gate: 'T',
+                isMeasurement: false,
+                isControlled: true,
+                isAdjoint: false,
+                controls: [{ type: RegisterType.Qubit, qId: 2 }],
+                targets: [{ type: RegisterType.Qubit, qId: 1 }],
+            },
+            {
+                gate: 'X',
+                isMeasurement: false,
+                isControlled: true,
+                isAdjoint: false,
+                controls: [{ type: RegisterType.Qubit, qId: 0 }],
+                targets: [{ type: RegisterType.Qubit, qId: 1 }],
+            },
         ];
-        expect(_groupOperations(operations, registers)).toEqual([[0, 5], [0, 1, 4, 5], [1, 2, 3, 4], [2, 3]]);
-
+        expect(_groupOperations(operations, registers)).toEqual([
+            [0, 5],
+            [0, 1, 4, 5],
+            [1, 2, 3, 4],
+            [2, 3],
+        ]);
     });
-    test("multiple qubit gates in ladder format with single qubit gate", () => {
-        let numRegs: number = 4;
+    test('multiple qubit gates in ladder format with single qubit gate', () => {
         let operations: Operation[] = [
-            { gate: "X", isMeasurement: false, isControlled: true, isAdjoint: false, controls: [{ type: RegisterType.Qubit, qId: 1 }], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
-            { gate: "Y", isMeasurement: false, isControlled: false, isAdjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 1 }] },
-            { gate: "Y", isMeasurement: false, isControlled: true, isAdjoint: false, controls: [{ type: RegisterType.Qubit, qId: 1 }], targets: [{ type: RegisterType.Qubit, qId: 2 }] },
-            { gate: "Z", isMeasurement: false, isControlled: true, isAdjoint: false, controls: [{ type: RegisterType.Qubit, qId: 2 }], targets: [{ type: RegisterType.Qubit, qId: 3 }] },
-            { gate: "Z", isMeasurement: false, isControlled: false, isAdjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 2 }] },
-            { gate: "H", isMeasurement: false, isControlled: true, isAdjoint: false, controls: [{ type: RegisterType.Qubit, qId: 2 }], targets: [{ type: RegisterType.Qubit, qId: 3 }] },
-            { gate: "T", isMeasurement: false, isControlled: true, isAdjoint: false, controls: [{ type: RegisterType.Qubit, qId: 2 }], targets: [{ type: RegisterType.Qubit, qId: 1 }] },
-            { gate: "Y", isMeasurement: false, isControlled: false, isAdjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 1 }] },
-            { gate: "X", isMeasurement: false, isControlled: true, isAdjoint: false, controls: [{ type: RegisterType.Qubit, qId: 0 }], targets: [{ type: RegisterType.Qubit, qId: 1 }] },
+            {
+                gate: 'X',
+                isMeasurement: false,
+                isControlled: true,
+                isAdjoint: false,
+                controls: [{ type: RegisterType.Qubit, qId: 1 }],
+                targets: [{ type: RegisterType.Qubit, qId: 0 }],
+            },
+            {
+                gate: 'Y',
+                isMeasurement: false,
+                isControlled: false,
+                isAdjoint: false,
+                controls: [],
+                targets: [{ type: RegisterType.Qubit, qId: 1 }],
+            },
+            {
+                gate: 'Y',
+                isMeasurement: false,
+                isControlled: true,
+                isAdjoint: false,
+                controls: [{ type: RegisterType.Qubit, qId: 1 }],
+                targets: [{ type: RegisterType.Qubit, qId: 2 }],
+            },
+            {
+                gate: 'Z',
+                isMeasurement: false,
+                isControlled: true,
+                isAdjoint: false,
+                controls: [{ type: RegisterType.Qubit, qId: 2 }],
+                targets: [{ type: RegisterType.Qubit, qId: 3 }],
+            },
+            {
+                gate: 'Z',
+                isMeasurement: false,
+                isControlled: false,
+                isAdjoint: false,
+                controls: [],
+                targets: [{ type: RegisterType.Qubit, qId: 2 }],
+            },
+            {
+                gate: 'H',
+                isMeasurement: false,
+                isControlled: true,
+                isAdjoint: false,
+                controls: [{ type: RegisterType.Qubit, qId: 2 }],
+                targets: [{ type: RegisterType.Qubit, qId: 3 }],
+            },
+            {
+                gate: 'T',
+                isMeasurement: false,
+                isControlled: true,
+                isAdjoint: false,
+                controls: [{ type: RegisterType.Qubit, qId: 2 }],
+                targets: [{ type: RegisterType.Qubit, qId: 1 }],
+            },
+            {
+                gate: 'Y',
+                isMeasurement: false,
+                isControlled: false,
+                isAdjoint: false,
+                controls: [],
+                targets: [{ type: RegisterType.Qubit, qId: 1 }],
+            },
+            {
+                gate: 'X',
+                isMeasurement: false,
+                isControlled: true,
+                isAdjoint: false,
+                controls: [{ type: RegisterType.Qubit, qId: 0 }],
+                targets: [{ type: RegisterType.Qubit, qId: 1 }],
+            },
         ];
-        expect(_groupOperations(operations, registers)).toEqual([[0, 8], [0, 1, 2, 6, 7, 8], [2, 3, 4, 5, 6], [3, 5]]);
+        expect(_groupOperations(operations, registers)).toEqual([
+            [0, 8],
+            [0, 1, 2, 6, 7, 8],
+            [2, 3, 4, 5, 6],
+            [3, 5],
+        ]);
 
-        numRegs = 3;
         operations = [
-            { gate: "X", isMeasurement: false, isControlled: true, isAdjoint: false, controls: [{ type: RegisterType.Qubit, qId: 1 }], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
-            { gate: "Y", isMeasurement: false, isControlled: false, isAdjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 1 }] },
-            { gate: "Y", isMeasurement: false, isControlled: true, isAdjoint: false, controls: [{ type: RegisterType.Qubit, qId: 1 }], targets: [{ type: RegisterType.Qubit, qId: 2 }] },
-            { gate: "Z", isMeasurement: false, isControlled: false, isAdjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 2 }] },
-            { gate: "T", isMeasurement: false, isControlled: true, isAdjoint: false, controls: [{ type: RegisterType.Qubit, qId: 2 }], targets: [{ type: RegisterType.Qubit, qId: 1 }] },
-            { gate: "Y", isMeasurement: false, isControlled: false, isAdjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 1 }] },
-            { gate: "H", isMeasurement: false, isControlled: false, isAdjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
-            { gate: "H", isMeasurement: false, isControlled: false, isAdjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
-            { gate: "H", isMeasurement: false, isControlled: false, isAdjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
-            { gate: "H", isMeasurement: false, isControlled: false, isAdjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
-            { gate: "X", isMeasurement: false, isControlled: true, isAdjoint: false, controls: [{ type: RegisterType.Qubit, qId: 0 }], targets: [{ type: RegisterType.Qubit, qId: 1 }] },
+            {
+                gate: 'X',
+                isMeasurement: false,
+                isControlled: true,
+                isAdjoint: false,
+                controls: [{ type: RegisterType.Qubit, qId: 1 }],
+                targets: [{ type: RegisterType.Qubit, qId: 0 }],
+            },
+            {
+                gate: 'Y',
+                isMeasurement: false,
+                isControlled: false,
+                isAdjoint: false,
+                controls: [],
+                targets: [{ type: RegisterType.Qubit, qId: 1 }],
+            },
+            {
+                gate: 'Y',
+                isMeasurement: false,
+                isControlled: true,
+                isAdjoint: false,
+                controls: [{ type: RegisterType.Qubit, qId: 1 }],
+                targets: [{ type: RegisterType.Qubit, qId: 2 }],
+            },
+            {
+                gate: 'Z',
+                isMeasurement: false,
+                isControlled: false,
+                isAdjoint: false,
+                controls: [],
+                targets: [{ type: RegisterType.Qubit, qId: 2 }],
+            },
+            {
+                gate: 'T',
+                isMeasurement: false,
+                isControlled: true,
+                isAdjoint: false,
+                controls: [{ type: RegisterType.Qubit, qId: 2 }],
+                targets: [{ type: RegisterType.Qubit, qId: 1 }],
+            },
+            {
+                gate: 'Y',
+                isMeasurement: false,
+                isControlled: false,
+                isAdjoint: false,
+                controls: [],
+                targets: [{ type: RegisterType.Qubit, qId: 1 }],
+            },
+            {
+                gate: 'H',
+                isMeasurement: false,
+                isControlled: false,
+                isAdjoint: false,
+                controls: [],
+                targets: [{ type: RegisterType.Qubit, qId: 0 }],
+            },
+            {
+                gate: 'H',
+                isMeasurement: false,
+                isControlled: false,
+                isAdjoint: false,
+                controls: [],
+                targets: [{ type: RegisterType.Qubit, qId: 0 }],
+            },
+            {
+                gate: 'H',
+                isMeasurement: false,
+                isControlled: false,
+                isAdjoint: false,
+                controls: [],
+                targets: [{ type: RegisterType.Qubit, qId: 0 }],
+            },
+            {
+                gate: 'H',
+                isMeasurement: false,
+                isControlled: false,
+                isAdjoint: false,
+                controls: [],
+                targets: [{ type: RegisterType.Qubit, qId: 0 }],
+            },
+            {
+                gate: 'X',
+                isMeasurement: false,
+                isControlled: true,
+                isAdjoint: false,
+                controls: [{ type: RegisterType.Qubit, qId: 0 }],
+                targets: [{ type: RegisterType.Qubit, qId: 1 }],
+            },
         ];
-        expect(_groupOperations(operations, registers)).toEqual([[0, 6, 7, 8, 9, 10], [0, 1, 2, 4, 5, 10], [2, 3, 4], []]);
+        expect(_groupOperations(operations, registers)).toEqual([
+            [0, 6, 7, 8, 9, 10],
+            [0, 1, 2, 4, 5, 10],
+            [2, 3, 4],
+            [],
+        ]);
     });
-    test("interleaved multiqubit gates", () => {
+    test('interleaved multiqubit gates', () => {
         let operations: Operation[] = [
-            { gate: "X", isMeasurement: false, isControlled: true, isAdjoint: false, controls: [{ type: RegisterType.Qubit, qId: 1 }], targets: [{ type: RegisterType.Qubit, qId: 3 }] },
-            { gate: "X", isMeasurement: false, isControlled: true, isAdjoint: false, controls: [{ type: RegisterType.Qubit, qId: 0 }], targets: [{ type: RegisterType.Qubit, qId: 2 }] },
+            {
+                gate: 'X',
+                isMeasurement: false,
+                isControlled: true,
+                isAdjoint: false,
+                controls: [{ type: RegisterType.Qubit, qId: 1 }],
+                targets: [{ type: RegisterType.Qubit, qId: 3 }],
+            },
+            {
+                gate: 'X',
+                isMeasurement: false,
+                isControlled: true,
+                isAdjoint: false,
+                controls: [{ type: RegisterType.Qubit, qId: 0 }],
+                targets: [{ type: RegisterType.Qubit, qId: 2 }],
+            },
         ];
         expect(_groupOperations(operations, registers)).toEqual([[1], [0, 1], [0, 1], [0]]);
         operations = [
-            { gate: "X", isMeasurement: false, isControlled: true, isAdjoint: false, controls: [{ type: RegisterType.Qubit, qId: 0 }, { type: RegisterType.Qubit, qId: 1 }], targets: [{ type: RegisterType.Qubit, qId: 3 }] },
-            { gate: "X", isMeasurement: false, isControlled: true, isAdjoint: false, controls: [{ type: RegisterType.Qubit, qId: 0 }], targets: [{ type: RegisterType.Qubit, qId: 2 }, { type: RegisterType.Qubit, qId: 3 }] },
+            {
+                gate: 'X',
+                isMeasurement: false,
+                isControlled: true,
+                isAdjoint: false,
+                controls: [
+                    { type: RegisterType.Qubit, qId: 0 },
+                    { type: RegisterType.Qubit, qId: 1 },
+                ],
+                targets: [{ type: RegisterType.Qubit, qId: 3 }],
+            },
+            {
+                gate: 'X',
+                isMeasurement: false,
+                isControlled: true,
+                isAdjoint: false,
+                controls: [{ type: RegisterType.Qubit, qId: 0 }],
+                targets: [
+                    { type: RegisterType.Qubit, qId: 2 },
+                    { type: RegisterType.Qubit, qId: 3 },
+                ],
+            },
         ];
-        expect(_groupOperations(operations, registers)).toEqual([[0, 1], [0, 1], [0, 1], [0, 1]]);
+        expect(_groupOperations(operations, registers)).toEqual([
+            [0, 1],
+            [0, 1],
+            [0, 1],
+            [0, 1],
+        ]);
         operations = [
-            { gate: "Foo", isMeasurement: false, isControlled: false, isAdjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 0 }, { type: RegisterType.Qubit, qId: 2 }, { type: RegisterType.Qubit, qId: 3 }] },
-            { gate: "Bar", isMeasurement: false, isControlled: false, isAdjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 0 }, { type: RegisterType.Qubit, qId: 1 }, { type: RegisterType.Qubit, qId: 2 }] },
+            {
+                gate: 'Foo',
+                isMeasurement: false,
+                isControlled: false,
+                isAdjoint: false,
+                controls: [],
+                targets: [
+                    { type: RegisterType.Qubit, qId: 0 },
+                    { type: RegisterType.Qubit, qId: 2 },
+                    { type: RegisterType.Qubit, qId: 3 },
+                ],
+            },
+            {
+                gate: 'Bar',
+                isMeasurement: false,
+                isControlled: false,
+                isAdjoint: false,
+                controls: [],
+                targets: [
+                    { type: RegisterType.Qubit, qId: 0 },
+                    { type: RegisterType.Qubit, qId: 1 },
+                    { type: RegisterType.Qubit, qId: 2 },
+                ],
+            },
         ];
         expect(_groupOperations(operations, registers)).toEqual([[0, 1], [0, 1], [0, 1], [0]]);
     });
-    test("classical control gates", () => {
+    test('classical control gates', () => {
         const registers: RegisterMap = {
             0: { type: RegisterType.Qubit, y: startY },
             1: {
                 type: RegisterType.Qubit,
                 y: startY + registerHeight,
-                children: [{ type: RegisterType.Classical, y: startY + registerHeight + classicalRegHeight }]
+                children: [{ type: RegisterType.Classical, y: startY + registerHeight + classicalRegHeight }],
             },
             2: {
                 type: RegisterType.Qubit,
                 y: startY + registerHeight + classicalRegHeight * 2,
-                children: [{ type: RegisterType.Classical, y: startY + registerHeight + classicalRegHeight * 3 }]
+                children: [{ type: RegisterType.Classical, y: startY + registerHeight + classicalRegHeight * 3 }],
             },
             3: { type: RegisterType.Qubit, y: startY + registerHeight + classicalRegHeight * 4 },
-        }
+        };
         let operations: Operation[] = [
-            { gate: "X", isMeasurement: false, isControlled: true, isAdjoint: false, controls: [{ type: RegisterType.Classical, qId: 2, cId: 0 }], targets: [{ type: RegisterType.Qubit, qId: 1 }] },
-            { gate: "X", isMeasurement: false, isControlled: false, isAdjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
+            {
+                gate: 'X',
+                isMeasurement: false,
+                isControlled: true,
+                isAdjoint: false,
+                controls: [{ type: RegisterType.Classical, qId: 2, cId: 0 }],
+                targets: [{ type: RegisterType.Qubit, qId: 1 }],
+            },
+            {
+                gate: 'X',
+                isMeasurement: false,
+                isControlled: false,
+                isAdjoint: false,
+                controls: [],
+                targets: [{ type: RegisterType.Qubit, qId: 0 }],
+            },
         ];
         expect(_groupOperations(operations, registers)).toEqual([[0, 1], [0], [0], [0]]);
         operations = [
-            { gate: "X", isMeasurement: false, isControlled: true, isAdjoint: false, controls: [{ type: RegisterType.Classical, qId: 2, cId: 0 }], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
-            { gate: "X", isMeasurement: false, isControlled: false, isAdjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 1 }] },
+            {
+                gate: 'X',
+                isMeasurement: false,
+                isControlled: true,
+                isAdjoint: false,
+                controls: [{ type: RegisterType.Classical, qId: 2, cId: 0 }],
+                targets: [{ type: RegisterType.Qubit, qId: 0 }],
+            },
+            {
+                gate: 'X',
+                isMeasurement: false,
+                isControlled: false,
+                isAdjoint: false,
+                controls: [],
+                targets: [{ type: RegisterType.Qubit, qId: 1 }],
+            },
         ];
         expect(_groupOperations(operations, registers)).toEqual([[0], [0, 1], [0], [0]]);
         operations = [
-            { gate: "X", isMeasurement: false, isControlled: false, isAdjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 1 }] },
-            { gate: "X", isMeasurement: false, isControlled: true, isAdjoint: false, controls: [{ type: RegisterType.Classical, qId: 1, cId: 0 }], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
+            {
+                gate: 'X',
+                isMeasurement: false,
+                isControlled: false,
+                isAdjoint: false,
+                controls: [],
+                targets: [{ type: RegisterType.Qubit, qId: 1 }],
+            },
+            {
+                gate: 'X',
+                isMeasurement: false,
+                isControlled: true,
+                isAdjoint: false,
+                controls: [{ type: RegisterType.Classical, qId: 1, cId: 0 }],
+                targets: [{ type: RegisterType.Qubit, qId: 0 }],
+            },
         ];
         expect(_groupOperations(operations, registers)).toEqual([[1], [0, 1], [1], [1]]);
     });
-    test("skipped registers", () => {
+    test('skipped registers', () => {
         let operations: Operation[] = [
-            { gate: "X", isMeasurement: false, isControlled: false, isAdjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
-            { gate: "Z", isMeasurement: false, isControlled: false, isAdjoint: false, controls: [], targets: [{ type: RegisterType.Qubit, qId: 2 }] },
+            {
+                gate: 'X',
+                isMeasurement: false,
+                isControlled: false,
+                isAdjoint: false,
+                controls: [],
+                targets: [{ type: RegisterType.Qubit, qId: 0 }],
+            },
+            {
+                gate: 'Z',
+                isMeasurement: false,
+                isControlled: false,
+                isAdjoint: false,
+                controls: [],
+                targets: [{ type: RegisterType.Qubit, qId: 2 }],
+            },
         ];
         expect(_groupOperations(operations, registers)).toEqual([[0], [], [1], []]);
         operations = [
-            { gate: "X", isMeasurement: false, isControlled: true, isAdjoint: false, controls: [{ type: RegisterType.Qubit, qId: 1 }], targets: [{ type: RegisterType.Qubit, qId: 0 }] },
-            { gate: "Z", isMeasurement: false, isControlled: true, isAdjoint: false, controls: [{ type: RegisterType.Qubit, qId: 1 }], targets: [{ type: RegisterType.Qubit, qId: 2 }] },
+            {
+                gate: 'X',
+                isMeasurement: false,
+                isControlled: true,
+                isAdjoint: false,
+                controls: [{ type: RegisterType.Qubit, qId: 1 }],
+                targets: [{ type: RegisterType.Qubit, qId: 0 }],
+            },
+            {
+                gate: 'Z',
+                isMeasurement: false,
+                isControlled: true,
+                isAdjoint: false,
+                controls: [{ type: RegisterType.Qubit, qId: 1 }],
+                targets: [{ type: RegisterType.Qubit, qId: 2 }],
+            },
         ];
         expect(_groupOperations(operations, registers)).toEqual([[0], [0, 1], [1], []]);
     });
-    test("no qubits", () => {
+    test('no qubits', () => {
         const operations: Operation[] = [
-            { gate: "NoOp1", isMeasurement: false, isControlled: false, isAdjoint: false, controls: [], targets: [] },
-            { gate: "NoOp2", isMeasurement: false, isControlled: false, isAdjoint: false, controls: [], targets: [] },
+            { gate: 'NoOp1', isMeasurement: false, isControlled: false, isAdjoint: false, controls: [], targets: [] },
+            { gate: 'NoOp2', isMeasurement: false, isControlled: false, isAdjoint: false, controls: [], targets: [] },
         ];
         expect(_groupOperations(operations, registers)).toEqual([[], [], [], []]);
     });
-    test("empty arguments", () => {
+    test('empty arguments', () => {
         expect(_groupOperations([], {})).toEqual([]);
     });
 });
 
-describe("Testing _alignOps", () => {
-    test("single qubit gates", () => {
-        const ops: number[][] = [[0, 2, 5, 6], [1, 3, 4]];
+describe('Testing _alignOps', () => {
+    test('single qubit gates', () => {
+        const ops: number[][] = [
+            [0, 2, 5, 6],
+            [1, 3, 4],
+        ];
         expect(_alignOps(ops)).toEqual(ops);
     });
-    test("correct ordering of single qubit gate after multiqubit gate", () => {
-        const ops: number[][] = [[0, 1, 3], [1, 2]];
-        expect(_alignOps(ops)).toEqual([[0, 1, 3], [null, 1, 2]]);
+    test('correct ordering of single qubit gate after multiqubit gate', () => {
+        const ops: number[][] = [
+            [0, 1, 3],
+            [1, 2],
+        ];
+        expect(_alignOps(ops)).toEqual([
+            [0, 1, 3],
+            [null, 1, 2],
+        ]);
     });
-    test("padding of multiqubit register after single qubit gate", () => {
+    test('padding of multiqubit register after single qubit gate', () => {
         const ops: number[][] = [[1], [0, 1]];
-        expect(_alignOps(ops)).toEqual([[null, 1], [0, 1]]);
+        expect(_alignOps(ops)).toEqual([
+            [null, 1],
+            [0, 1],
+        ]);
     });
-    test("no padding of single qubit gate after multiqubit gate on different registers", () => {
+    test('no padding of single qubit gate after multiqubit gate on different registers', () => {
         const ops: number[][] = [[0, 3], [2], [1, 2]];
-        expect(_alignOps(ops)).toEqual([[0, 3], [null, 2], [1, 2]]);
+        expect(_alignOps(ops)).toEqual([
+            [0, 3],
+            [null, 2],
+            [1, 2],
+        ]);
     });
-    test("ladder of cnots", () => {
-        const ops: number[][] = [[0, 4], [0, 1, 3, 4], [1, 2, 3]];
-        expect(_alignOps(ops)).toEqual([[0, null, null, null, 4], [0, 1, null, 3, 4], [null, 1, 2, 3]]);
+    test('ladder of cnots', () => {
+        const ops: number[][] = [
+            [0, 4],
+            [0, 1, 3, 4],
+            [1, 2, 3],
+        ];
+        expect(_alignOps(ops)).toEqual([
+            [0, null, null, null, 4],
+            [0, 1, null, 3, 4],
+            [null, 1, 2, 3],
+        ]);
     });
-    test("interleaved multiqubit gates", () => {
+    test('interleaved multiqubit gates', () => {
         let ops: number[][] = [[0], [0, 1], [0, 1], [1]];
         expect(_alignOps(ops)).toEqual([[0], [0, 1], [0, 1], [null, 1]]);
         ops = [[0], [0], [0, 1], [1], [1], [1]];
         expect(_alignOps(ops)).toEqual([[0], [0], [0, 1], [null, 1], [null, 1], [null, 1]]);
     });
-    test("skipped registers", () => {
+    test('skipped registers', () => {
         let ops: number[][] = [[0], [], [1], []];
         expect(_alignOps(ops)).toEqual([[0], [], [1], []]);
         ops = [[0], [], [1, 2], [2]];
         expect(_alignOps(ops)).toEqual([[0], [], [1, 2], [null, 2]]);
     });
-    test("no ops", () => {
+    test('no ops', () => {
         expect(_alignOps([])).toEqual([]);
     });
 });
 
-describe("Testing _getColumnsX", () => {
-    test("0 columns", () =>
-        expect(_getColumnsX([])).toEqual({ columnsX: [], svgWidth: startX }));
-    test("1 column", () => {
-        expect(_getColumnsX([minGateWidth]))
-            .toEqual({
-                columnsX: [startX + minGateWidth / 2],
-                svgWidth: startX + minGateWidth + gatePadding * 2
-            });
-        expect(_getColumnsX([100]))
-            .toEqual({
-                columnsX: [startX + 100 / 2],
-                svgWidth: startX + 100 + gatePadding * 2
-            });
+describe('Testing _getColumnsX', () => {
+    test('0 columns', () => expect(_getColumnsX([])).toEqual({ columnsX: [], svgWidth: startX }));
+    test('1 column', () => {
+        expect(_getColumnsX([minGateWidth])).toEqual({
+            columnsX: [startX + minGateWidth / 2],
+            svgWidth: startX + minGateWidth + gatePadding * 2,
+        });
+        expect(_getColumnsX([100])).toEqual({
+            columnsX: [startX + 100 / 2],
+            svgWidth: startX + 100 + gatePadding * 2,
+        });
     });
-    test("2 columns", () => {
-        expect(_getColumnsX([10, 10]))
-            .toEqual({
-                columnsX: [startX + 5, startX + 15 + gatePadding * 2],
-                svgWidth: startX + 20 + gatePadding * 4
-            });
-        expect(_getColumnsX([20, 10]))
-            .toEqual({
-                columnsX: [startX + 10, startX + 25 + gatePadding * 2],
-                svgWidth: startX + 30 + gatePadding * 4
-            });
+    test('2 columns', () => {
+        expect(_getColumnsX([10, 10])).toEqual({
+            columnsX: [startX + 5, startX + 15 + gatePadding * 2],
+            svgWidth: startX + 20 + gatePadding * 4,
+        });
+        expect(_getColumnsX([20, 10])).toEqual({
+            columnsX: [startX + 10, startX + 25 + gatePadding * 2],
+            svgWidth: startX + 30 + gatePadding * 4,
+        });
     });
 });
 
-describe("Testing _opToMetadata", () => {
-    test("single qubit gate", () => {
+describe('Testing _opToMetadata', () => {
+    test('single qubit gate', () => {
         const op: Operation = {
-            gate: "X",
+            gate: 'X',
             isMeasurement: false,
             isControlled: false,
             isAdjoint: false,
             controls: [],
-            targets: [{ type: RegisterType.Qubit, qId: 1 }]
+            targets: [{ type: RegisterType.Qubit, qId: 1 }],
         };
         const registers: RegisterMap = {
             0: { type: RegisterType.Qubit, y: startY },
@@ -284,18 +788,18 @@ describe("Testing _opToMetadata", () => {
             controlsY: [],
             targetsY: [startY + registerHeight],
             label: 'X',
-            width: minGateWidth
+            width: minGateWidth,
         };
         expect(_opToMetadata(op, registers)).toEqual(metadata);
     });
-    test("isAdjoint gate", () => {
+    test('isAdjoint gate', () => {
         const op: Operation = {
-            gate: "Foo",
+            gate: 'Foo',
             isMeasurement: false,
             isControlled: false,
             isAdjoint: true,
             controls: [],
-            targets: [{ type: RegisterType.Qubit, qId: 1 }]
+            targets: [{ type: RegisterType.Qubit, qId: 1 }],
         };
         const registers: RegisterMap = {
             0: { type: RegisterType.Qubit, y: startY },
@@ -307,21 +811,25 @@ describe("Testing _opToMetadata", () => {
             controlsY: [],
             targetsY: [startY + registerHeight],
             label: "Foo'",
-            width: 48
+            width: 48,
         };
         expect(_opToMetadata(op, registers)).toEqual(metadata);
     });
-    test("measure gate", () => {
+    test('measure gate', () => {
         const op: Operation = {
-            gate: "M",
+            gate: 'M',
             isMeasurement: true,
             isControlled: false,
             isAdjoint: false,
             controls: [{ type: RegisterType.Qubit, qId: 0 }],
-            targets: [{ type: RegisterType.Classical, qId: 0, cId: 0 }]
+            targets: [{ type: RegisterType.Classical, qId: 0, cId: 0 }],
         };
         const registers: RegisterMap = {
-            0: { type: RegisterType.Qubit, y: startY, children: [{ type: RegisterType.Classical, y: startY + classicalRegHeight }] },
+            0: {
+                type: RegisterType.Qubit,
+                y: startY,
+                children: [{ type: RegisterType.Classical, y: startY + classicalRegHeight }],
+            },
         };
         const metadata: Metadata = {
             type: GateType.Measure,
@@ -329,21 +837,21 @@ describe("Testing _opToMetadata", () => {
             controlsY: [startY],
             targetsY: [startY + classicalRegHeight],
             label: '',
-            width: minGateWidth
+            width: minGateWidth,
         };
         expect(_opToMetadata(op, registers)).toEqual(metadata);
     });
-    test("swap gate", () => {
+    test('swap gate', () => {
         const op: Operation = {
-            gate: "SWAP",
+            gate: 'SWAP',
             isMeasurement: false,
             isControlled: false,
             isAdjoint: false,
             controls: [],
             targets: [
                 { type: RegisterType.Qubit, qId: 0 },
-                { type: RegisterType.Qubit, qId: 1 }
-            ]
+                { type: RegisterType.Qubit, qId: 1 },
+            ],
         };
         const registers: RegisterMap = {
             0: { type: RegisterType.Qubit, y: startY },
@@ -355,21 +863,21 @@ describe("Testing _opToMetadata", () => {
             controlsY: [],
             targetsY: [startY, startY + registerHeight],
             label: '',
-            width: minGateWidth
+            width: minGateWidth,
         };
         expect(_opToMetadata(op, registers)).toEqual(metadata);
     });
-    test("isControlled swap gate", () => {
+    test('isControlled swap gate', () => {
         const op: Operation = {
-            gate: "SWAP",
+            gate: 'SWAP',
             isMeasurement: false,
             isControlled: false,
             isAdjoint: false,
             controls: [{ type: RegisterType.Qubit, qId: 0 }],
             targets: [
                 { type: RegisterType.Qubit, qId: 1 },
-                { type: RegisterType.Qubit, qId: 2 }
-            ]
+                { type: RegisterType.Qubit, qId: 2 },
+            ],
         };
         const registers: RegisterMap = {
             0: { type: RegisterType.Qubit, y: startY },
@@ -382,18 +890,18 @@ describe("Testing _opToMetadata", () => {
             controlsY: [startY],
             targetsY: [startY + registerHeight, startY + registerHeight * 2],
             label: '',
-            width: minGateWidth
+            width: minGateWidth,
         };
         expect(_opToMetadata(op, registers)).toEqual(metadata);
     });
-    test("single qubit unitary gate", () => {
+    test('single qubit unitary gate', () => {
         const op: Operation = {
-            gate: "X",
+            gate: 'X',
             isMeasurement: false,
             isControlled: false,
             isAdjoint: false,
             controls: [],
-            targets: [{ type: RegisterType.Qubit, qId: 0 }]
+            targets: [{ type: RegisterType.Qubit, qId: 0 }],
         };
         const registers: RegisterMap = {
             0: { type: RegisterType.Qubit, y: startY },
@@ -404,26 +912,26 @@ describe("Testing _opToMetadata", () => {
             controlsY: [],
             targetsY: [startY],
             label: 'X',
-            width: minGateWidth
+            width: minGateWidth,
         };
         expect(_opToMetadata(op, registers)).toEqual(metadata);
     });
-    test("multiqubit unitary gate", () => {
+    test('multiqubit unitary gate', () => {
         const registers: RegisterMap = {
             0: { type: RegisterType.Qubit, y: startY },
             1: { type: RegisterType.Qubit, y: startY + registerHeight },
             2: { type: RegisterType.Qubit, y: startY + registerHeight * 2 },
         };
         let op: Operation = {
-            gate: "ZZ",
+            gate: 'ZZ',
             isMeasurement: false,
             isControlled: false,
             isAdjoint: false,
             controls: [],
             targets: [
                 { type: RegisterType.Qubit, qId: 0 },
-                { type: RegisterType.Qubit, qId: 1 }
-            ]
+                { type: RegisterType.Qubit, qId: 1 },
+            ],
         };
         let metadata: Metadata = {
             type: GateType.Unitary,
@@ -431,11 +939,11 @@ describe("Testing _opToMetadata", () => {
             controlsY: [],
             targetsY: [startY, startY + registerHeight],
             label: 'ZZ',
-            width: minGateWidth
+            width: minGateWidth,
         };
         expect(_opToMetadata(op, registers)).toEqual(metadata);
         op = {
-            gate: "XX",
+            gate: 'XX',
             isMeasurement: false,
             isControlled: false,
             isAdjoint: false,
@@ -443,7 +951,7 @@ describe("Testing _opToMetadata", () => {
             targets: [
                 { type: RegisterType.Qubit, qId: 1 },
                 { type: RegisterType.Qubit, qId: 2 },
-            ]
+            ],
         };
         metadata = {
             type: GateType.Unitary,
@@ -451,11 +959,11 @@ describe("Testing _opToMetadata", () => {
             controlsY: [],
             targetsY: [startY + registerHeight, startY + registerHeight * 2],
             label: 'XX',
-            width: minGateWidth
+            width: minGateWidth,
         };
         expect(_opToMetadata(op, registers)).toEqual(metadata);
     });
-    test("isControlled unitary gates", () => {
+    test('isControlled unitary gates', () => {
         const registers: RegisterMap = {
             0: { type: RegisterType.Qubit, y: startY },
             1: { type: RegisterType.Qubit, y: startY + registerHeight },
@@ -463,12 +971,12 @@ describe("Testing _opToMetadata", () => {
             3: { type: RegisterType.Qubit, y: startY + registerHeight * 3 },
         };
         let op: Operation = {
-            gate: "ZZ",
+            gate: 'ZZ',
             isMeasurement: false,
             isControlled: true,
             isAdjoint: false,
             controls: [{ type: RegisterType.Qubit, qId: 1 }],
-            targets: [{ type: RegisterType.Qubit, qId: 0 }]
+            targets: [{ type: RegisterType.Qubit, qId: 0 }],
         };
         let metadata: Metadata = {
             type: GateType.ControlledUnitary,
@@ -476,11 +984,11 @@ describe("Testing _opToMetadata", () => {
             controlsY: [startY + registerHeight],
             targetsY: [startY],
             label: 'ZZ',
-            width: minGateWidth
+            width: minGateWidth,
         };
         expect(_opToMetadata(op, registers)).toEqual(metadata);
         op = {
-            gate: "XX",
+            gate: 'XX',
             isMeasurement: false,
             isControlled: true,
             isAdjoint: false,
@@ -488,7 +996,7 @@ describe("Testing _opToMetadata", () => {
             targets: [
                 { type: RegisterType.Qubit, qId: 1 },
                 { type: RegisterType.Qubit, qId: 2 },
-            ]
+            ],
         };
         metadata = {
             type: GateType.ControlledUnitary,
@@ -496,11 +1004,11 @@ describe("Testing _opToMetadata", () => {
             controlsY: [startY],
             targetsY: [startY + registerHeight, startY + registerHeight * 2],
             label: 'XX',
-            width: minGateWidth
+            width: minGateWidth,
         };
         expect(_opToMetadata(op, registers)).toEqual(metadata);
         op = {
-            gate: "Foo",
+            gate: 'Foo',
             isMeasurement: false,
             isControlled: true,
             isAdjoint: false,
@@ -511,7 +1019,7 @@ describe("Testing _opToMetadata", () => {
             targets: [
                 { type: RegisterType.Qubit, qId: 0 },
                 { type: RegisterType.Qubit, qId: 1 },
-            ]
+            ],
         };
         metadata = {
             type: GateType.ControlledUnitary,
@@ -519,85 +1027,85 @@ describe("Testing _opToMetadata", () => {
             x: 0,
             controlsY: [startY + registerHeight * 2, startY + registerHeight * 3],
             targetsY: [startY, startY + registerHeight],
-            width: 45
+            width: 45,
         };
         expect(_opToMetadata(op, registers)).toEqual(metadata);
     });
-    test("single-qubit unitary gates with arguments", () => {
+    test('single-qubit unitary gates with arguments', () => {
         const registers: RegisterMap = {
             0: { type: RegisterType.Qubit, y: startY },
             1: { type: RegisterType.Qubit, y: startY + registerHeight },
         };
         let op: Operation = {
-            gate: "RX",
-            displayArgs: "(0.25)",
+            gate: 'RX',
+            displayArgs: '(0.25)',
             isMeasurement: false,
             isControlled: false,
             isAdjoint: false,
             controls: [],
-            targets: [{ type: RegisterType.Qubit, qId: 0 }]
+            targets: [{ type: RegisterType.Qubit, qId: 0 }],
         };
         let metadata: Metadata = {
             type: GateType.Unitary,
             x: 0,
             controlsY: [],
             targetsY: [startY],
-            label: "RX",
-            displayArgs: "(0.25)",
-            width: 52
+            label: 'RX',
+            displayArgs: '(0.25)',
+            width: 52,
         };
         expect(_opToMetadata(op, registers)).toEqual(metadata);
 
         // Test long argument
         op = {
-            gate: "RX",
+            gate: 'RX',
             displayArgs: "(0.25, 1.0, 'foobar', (3.14, 6.67))",
             isMeasurement: false,
             isControlled: false,
             isAdjoint: false,
             controls: [],
-            targets: [{ type: RegisterType.Qubit, qId: 0 }]
+            targets: [{ type: RegisterType.Qubit, qId: 0 }],
         };
         metadata = {
             type: GateType.Unitary,
             x: 0,
             controlsY: [],
             targetsY: [startY],
-            label: "RX",
+            label: 'RX',
             displayArgs: "(0.25, 1.0, 'foobar', (3.14, 6.67))",
-            width: 188
+            width: 188,
         };
         expect(_opToMetadata(op, registers)).toEqual(metadata);
 
         // Test isControlled
         op = {
-            gate: "RX",
-            displayArgs: "(0.25)",
+            gate: 'RX',
+            displayArgs: '(0.25)',
             isMeasurement: false,
             isControlled: true,
             isAdjoint: false,
             controls: [{ type: RegisterType.Qubit, qId: 1 }],
-            targets: [{ type: RegisterType.Qubit, qId: 0 }]
+            targets: [{ type: RegisterType.Qubit, qId: 0 }],
         };
         metadata = {
             type: GateType.ControlledUnitary,
             x: 0,
             controlsY: [startY + registerHeight],
             targetsY: [startY],
-            label: "RX",
-            displayArgs: "(0.25)",
-            width: 52
+            label: 'RX',
+            displayArgs: '(0.25)',
+            width: 52,
         };
         expect(_opToMetadata(op, registers)).toEqual(metadata);
     });
-    test("multi-qubit unitary gates with arguments", () => {
+    test('multi-qubit unitary gates with arguments', () => {
         const registers: RegisterMap = {
             0: { type: RegisterType.Qubit, y: startY },
             1: { type: RegisterType.Qubit, y: startY + registerHeight },
             2: { type: RegisterType.Qubit, y: startY + registerHeight * 2 },
         };
         let op: Operation = {
-            gate: "U",
+            gate: 'U',
             displayArgs: "('foo', 'bar')",
             isMeasurement: false,
             isControlled: false,
@@ -606,22 +1114,22 @@ describe("Testing _opToMetadata", () => {
             targets: [
                 { type: RegisterType.Qubit, qId: 0 },
                 { type: RegisterType.Qubit, qId: 1 },
-            ]
+            ],
         };
         let metadata: Metadata = {
             type: GateType.Unitary,
             x: 0,
             controlsY: [],
             targetsY: [startY, startY + registerHeight],
-            label: "U",
+            label: 'U',
             displayArgs: "('foo', 'bar')",
-            width: 77
+            width: 77,
         };
         expect(_opToMetadata(op, registers)).toEqual(metadata);
 
         // Test long argument
         op = {
-            gate: "U",
+            gate: 'U',
             displayArgs: "(0.25, 1.0, 'foobar', (3.14, 6.67))",
             isMeasurement: false,
             isControlled: false,
@@ -630,22 +1138,22 @@ describe("Testing _opToMetadata", () => {
             targets: [
                 { type: RegisterType.Qubit, qId: 0 },
                 { type: RegisterType.Qubit, qId: 1 },
-            ]
+            ],
         };
         metadata = {
             type: GateType.Unitary,
             x: 0,
             controlsY: [],
             targetsY: [startY, startY + registerHeight],
-            label: "U",
+            label: 'U',
             displayArgs: "(0.25, 1.0, 'foobar', (3.14, 6.67))",
-            width: 188
+            width: 188,
         };
         expect(_opToMetadata(op, registers)).toEqual(metadata);
 
         // Test isControlled
         op = {
-            gate: "U",
+            gate: 'U',
             displayArgs: "('foo', 'bar')",
             isMeasurement: false,
             isControlled: true,
@@ -654,22 +1162,22 @@ describe("Testing _opToMetadata", () => {
             targets: [
                 { type: RegisterType.Qubit, qId: 0 },
                 { type: RegisterType.Qubit, qId: 2 },
-            ]
+            ],
         };
         metadata = {
             type: GateType.ControlledUnitary,
             x: 0,
             controlsY: [startY + registerHeight],
             targetsY: [startY, startY + registerHeight * 2],
-            label: "U",
+            label: 'U',
             displayArgs: "('foo', 'bar')",
-            width: 77
+            width: 77,
         };
         expect(_opToMetadata(op, registers)).toEqual(metadata);
     });
-    test("classically isControlled gates", () => {
+    test('classically isControlled gates', () => {
         const op: Operation = {
-            gate: "X",
+            gate: 'X',
             isMeasurement: false,
             isControlled: true,
             isAdjoint: false,
@@ -679,26 +1187,34 @@ describe("Testing _opToMetadata", () => {
                 { type: RegisterType.Qubit, qId: 1 },
             ],
             children: [
-                [{
-                    gate: "X",
-                    isMeasurement: false,
-                    isControlled: false,
-                    isAdjoint: false,
-                    controls: [],
-                    targets: [{ type: RegisterType.Qubit, qId: 0 }]
-                }],
-                [{
-                    gate: "H",
-                    isMeasurement: false,
-                    isControlled: false,
-                    isAdjoint: false,
-                    controls: [],
-                    targets: [{ type: RegisterType.Qubit, qId: 1 }]
-                }]
-            ]
+                [
+                    {
+                        gate: 'X',
+                        isMeasurement: false,
+                        isControlled: false,
+                        isAdjoint: false,
+                        controls: [],
+                        targets: [{ type: RegisterType.Qubit, qId: 0 }],
+                    },
+                ],
+                [
+                    {
+                        gate: 'H',
+                        isMeasurement: false,
+                        isControlled: false,
+                        isAdjoint: false,
+                        controls: [],
+                        targets: [{ type: RegisterType.Qubit, qId: 1 }],
+                    },
+                ],
+            ],
         };
         const registers: RegisterMap = {
-            0: { type: RegisterType.Qubit, y: startY, children: [{ type: RegisterType.Classical, y: startY + classicalRegHeight }] },
+            0: {
+                type: RegisterType.Qubit,
+                y: startY,
+                children: [{ type: RegisterType.Classical, y: startY + classicalRegHeight }],
+            },
             1: { type: RegisterType.Qubit, y: startY + classicalRegHeight * 2 },
         };
         const metadata: Metadata = {
@@ -709,71 +1225,73 @@ describe("Testing _opToMetadata", () => {
             label: '',
             width: minGateWidth + controlBtnOffset + classicalBoxPadding * 2,
             children: [
-                [{
-                    type: GateType.Unitary,
-                    x: startX + minGateWidth / 2,
-                    controlsY: [],
-                    targetsY: [startY],
-                    label: 'X',
-                    width: minGateWidth
-                }],
-                [{
-                    type: GateType.Unitary,
-                    x: startX + minGateWidth / 2,
-                    controlsY: [],
-                    targetsY: [startY + classicalRegHeight * 2],
-                    label: 'H',
-                    width: minGateWidth
-                }]
-            ]
+                [
+                    {
+                        type: GateType.Unitary,
+                        x: startX + minGateWidth / 2,
+                        controlsY: [],
+                        targetsY: [startY],
+                        label: 'X',
+                        width: minGateWidth,
+                    },
+                ],
+                [
+                    {
+                        type: GateType.Unitary,
+                        x: startX + minGateWidth / 2,
+                        controlsY: [],
+                        targetsY: [startY + classicalRegHeight * 2],
+                        label: 'H',
+                        width: minGateWidth,
+                    },
+                ],
+            ],
         };
         expect(_opToMetadata(op, registers)).toEqual(metadata);
     });
-    test("no render on null", () => {
+    test('no render on null', () => {
         const metadata: Metadata = {
             type: GateType.Invalid,
             x: 0,
             controlsY: [],
             targetsY: [],
             label: '',
-            width: minGateWidth
+            width: minGateWidth,
         };
         expect(_opToMetadata(null, [])).toEqual(metadata);
     });
-    test("Invalid register", () => {
+    test('Invalid register', () => {
         let op: Operation = {
-            gate: "X",
+            gate: 'X',
             isMeasurement: false,
             isControlled: false,
             isAdjoint: false,
             controls: [],
-            targets: [{ type: RegisterType.Qubit, qId: 1 }]
+            targets: [{ type: RegisterType.Qubit, qId: 1 }],
         };
         const registers: RegisterMap = {
             0: { type: RegisterType.Qubit, y: startY },
         };
-        expect(() => _opToMetadata(op, registers))
-            .toThrowError('ERROR: Qubit register with ID 1 not found.');
+        expect(() => _opToMetadata(op, registers)).toThrowError('ERROR: Qubit register with ID 1 not found.');
 
         op = {
-            gate: "X",
+            gate: 'X',
             isMeasurement: false,
             isControlled: false,
             isAdjoint: false,
             controls: [{ type: RegisterType.Classical, qId: 0, cId: 2 }],
-            targets: []
+            targets: [],
         };
-        expect(() => _opToMetadata(op, registers))
-            .toThrowError('ERROR: No classical registers found for qubit ID 0.');
+        expect(() => _opToMetadata(op, registers)).toThrowError('ERROR: No classical registers found for qubit ID 0.');
     });
-    test("skipped registers", () => {
+    test('skipped registers', () => {
         const op: Operation = {
-            gate: "X",
+            gate: 'X',
             isMeasurement: false,
             isControlled: false,
             isAdjoint: false,
             controls: [],
-            targets: [{ type: RegisterType.Qubit, qId: 2 }]
+            targets: [{ type: RegisterType.Qubit, qId: 2 }],
         };
         const registers: RegisterMap = {
             0: { type: RegisterType.Qubit, y: startY },
@@ -784,53 +1302,57 @@ describe("Testing _opToMetadata", () => {
             x: 0,
             controlsY: [],
             targetsY: [startY + registerHeight],
-            label: "X",
-            width: minGateWidth
+            label: 'X',
+            width: minGateWidth,
         };
         expect(_opToMetadata(op, registers)).toEqual(metadata);
     });
 });
 
-describe("Testing _getRegY", () => {
+describe('Testing _getRegY', () => {
     const registers: RegisterMap = {
         0: {
             type: RegisterType.Qubit,
             y: startY,
-            children: [{ type: RegisterType.Classical, y: startY + classicalRegHeight }]
-        }
+            children: [{ type: RegisterType.Classical, y: startY + classicalRegHeight }],
+        },
     };
-    test("quantum register", () => {
+    test('quantum register', () => {
         const reg: Register = { type: RegisterType.Qubit, qId: 0 };
         expect(_getRegY(reg, registers)).toEqual(startY);
     });
-    test("classical register", () => {
+    test('classical register', () => {
         const reg: Register = { type: RegisterType.Classical, qId: 0, cId: 0 };
         expect(_getRegY(reg, registers)).toEqual(startY + classicalRegHeight);
     });
-    test("No children", () => {
+    test('No children', () => {
         const registers: RegisterMap = {
-            0: { type: RegisterType.Qubit, y: startY }
+            0: { type: RegisterType.Qubit, y: startY },
         };
         const reg: Register = { type: RegisterType.Classical, qId: 0, cId: 0 };
-        expect(() => _getRegY(reg, registers)).toThrowError("ERROR: No classical registers found for qubit ID 0.");
+        expect(() => _getRegY(reg, registers)).toThrowError('ERROR: No classical registers found for qubit ID 0.');
     });
-    test("Null cId", () => {
+    test('Null cId', () => {
         const reg: Register = { type: RegisterType.Classical, qId: 0 };
-        expect(() => _getRegY(reg, registers)).toThrowError("ERROR: No ID defined for classical register associated with qubit ID 0.");
+        expect(() => _getRegY(reg, registers)).toThrowError(
+            'ERROR: No ID defined for classical register associated with qubit ID 0.',
+        );
     });
-    test("Invalid cId", () => {
+    test('Invalid cId', () => {
         const reg: Register = { type: RegisterType.Classical, qId: 0, cId: 1 };
-        expect(() => _getRegY(reg, registers)).toThrowError("ERROR: Classical register ID 1 invalid for qubit ID 0 with 1 classical register(s).");
+        expect(() => _getRegY(reg, registers)).toThrowError(
+            'ERROR: Classical register ID 1 invalid for qubit ID 0 with 1 classical register(s).',
+        );
     });
-    test("Invalid register type", () => {
+    test('Invalid register type', () => {
         const reg: Register = { type: 2, qId: 0, cId: 1 };
-        expect(() => _getRegY(reg, registers)).toThrowError("ERROR: Unknown register type 2.");
+        expect(() => _getRegY(reg, registers)).toThrowError('ERROR: Unknown register type 2.');
     });
 });
 
-describe("Testing _addClass", () => {
-    test("No children", () => {
-        const cls: string = 'classname';
+describe('Testing _addClass', () => {
+    test('No children', () => {
+        const cls = 'classname';
         const metadata: Metadata = {
             type: GateType.Unitary,
             x: 0,
@@ -854,8 +1376,8 @@ describe("Testing _addClass", () => {
         _addClass(metadata, cls);
         expect(metadata).toEqual(expected);
     });
-    test("Undefined children", () => {
-        const cls: string = 'classname';
+    test('Undefined children', () => {
+        const cls = 'classname';
         const metadata: Metadata = {
             type: GateType.Unitary,
             x: 0,
@@ -876,28 +1398,35 @@ describe("Testing _addClass", () => {
         _addClass(metadata, cls);
         expect(metadata).toEqual(expected);
     });
-    test("depth-1 children", () => {
-        const cls: string = 'classname';
+    test('depth-1 children', () => {
+        const cls = 'classname';
         const metadata: Metadata = {
             type: GateType.Unitary,
             x: 0,
             controlsY: [],
             targetsY: [],
-            children: [[{
-                type: GateType.Unitary,
-                x: 0,
-                controlsY: [],
-                targetsY: [],
-                label: 'X',
-                width: minGateWidth,
-            }], [{
-                type: GateType.Unitary,
-                x: 0,
-                controlsY: [],
-                targetsY: [],
-                label: 'X',
-                width: minGateWidth,
-            }]],
+            children: [
+                [
+                    {
+                        type: GateType.Unitary,
+                        x: 0,
+                        controlsY: [],
+                        targetsY: [],
+                        label: 'X',
+                        width: minGateWidth,
+                    },
+                ],
+                [
+                    {
+                        type: GateType.Unitary,
+                        x: 0,
+                        controlsY: [],
+                        targetsY: [],
+                        label: 'X',
+                        width: minGateWidth,
+                    },
+                ],
+            ],
             label: 'X',
             width: minGateWidth,
         };
@@ -906,23 +1435,30 @@ describe("Testing _addClass", () => {
             x: 0,
             controlsY: [],
             targetsY: [],
-            children: [[{
-                type: GateType.Unitary,
-                x: 0,
-                controlsY: [],
-                targetsY: [],
-                label: 'X',
-                width: minGateWidth,
-                htmlClass: 'classname',
-            }], [{
-                type: GateType.Unitary,
-                x: 0,
-                controlsY: [],
-                targetsY: [],
-                label: 'X',
-                width: minGateWidth,
-                htmlClass: 'classname',
-            }]],
+            children: [
+                [
+                    {
+                        type: GateType.Unitary,
+                        x: 0,
+                        controlsY: [],
+                        targetsY: [],
+                        label: 'X',
+                        width: minGateWidth,
+                        htmlClass: 'classname',
+                    },
+                ],
+                [
+                    {
+                        type: GateType.Unitary,
+                        x: 0,
+                        controlsY: [],
+                        targetsY: [],
+                        label: 'X',
+                        width: minGateWidth,
+                        htmlClass: 'classname',
+                    },
+                ],
+            ],
             label: 'X',
             width: minGateWidth,
             htmlClass: 'classname',
@@ -931,43 +1467,57 @@ describe("Testing _addClass", () => {
         _addClass(metadata, cls);
         expect(metadata).toEqual(expected);
     });
-    test("depth-2 children", () => {
-        const cls: string = 'classname';
+    test('depth-2 children', () => {
+        const cls = 'classname';
         const metadata: Metadata = {
             type: GateType.Unitary,
             x: 0,
             controlsY: [],
             targetsY: [],
-            children: [[{
-                type: GateType.Unitary,
-                x: 0,
-                controlsY: [],
-                targetsY: [],
-                children: [[{
-                    type: GateType.Unitary,
-                    x: 0,
-                    controlsY: [],
-                    targetsY: [],
-                    label: 'X',
-                    width: minGateWidth,
-                }], [{
-                    type: GateType.Unitary,
-                    x: 0,
-                    controlsY: [],
-                    targetsY: [],
-                    label: 'X',
-                    width: minGateWidth,
-                }]],
-                label: 'X',
-                width: minGateWidth,
-            }], [{
-                type: GateType.Unitary,
-                x: 0,
-                controlsY: [],
-                targetsY: [],
-                label: 'X',
-                width: minGateWidth,
-            }]],
+            children: [
+                [
+                    {
+                        type: GateType.Unitary,
+                        x: 0,
+                        controlsY: [],
+                        targetsY: [],
+                        children: [
+                            [
+                                {
+                                    type: GateType.Unitary,
+                                    x: 0,
+                                    controlsY: [],
+                                    targetsY: [],
+                                    label: 'X',
+                                    width: minGateWidth,
+                                },
+                            ],
+                            [
+                                {
+                                    type: GateType.Unitary,
+                                    x: 0,
+                                    controlsY: [],
+                                    targetsY: [],
+                                    label: 'X',
+                                    width: minGateWidth,
+                                },
+                            ],
+                        ],
+                        label: 'X',
+                        width: minGateWidth,
+                    },
+                ],
+                [
+                    {
+                        type: GateType.Unitary,
+                        x: 0,
+                        controlsY: [],
+                        targetsY: [],
+                        label: 'X',
+                        width: minGateWidth,
+                    },
+                ],
+            ],
             label: 'X',
             width: minGateWidth,
         };
@@ -976,40 +1526,54 @@ describe("Testing _addClass", () => {
             x: 0,
             controlsY: [],
             targetsY: [],
-            children: [[{
-                type: GateType.Unitary,
-                x: 0,
-                controlsY: [],
-                targetsY: [],
-                children: [[{
-                    type: GateType.Unitary,
-                    x: 0,
-                    controlsY: [],
-                    targetsY: [],
-                    label: 'X',
-                    width: minGateWidth,
-                    htmlClass: 'classname',
-                }], [{
-                    type: GateType.Unitary,
-                    x: 0,
-                    controlsY: [],
-                    targetsY: [],
-                    label: 'X',
-                    width: minGateWidth,
-                    htmlClass: 'classname',
-                }]],
-                label: 'X',
-                width: minGateWidth,
-                htmlClass: 'classname',
-            }], [{
-                type: GateType.Unitary,
-                x: 0,
-                controlsY: [],
-                targetsY: [],
-                label: 'X',
-                width: minGateWidth,
-                htmlClass: 'classname',
-            }]],
+            children: [
+                [
+                    {
+                        type: GateType.Unitary,
+                        x: 0,
+                        controlsY: [],
+                        targetsY: [],
+                        children: [
+                            [
+                                {
+                                    type: GateType.Unitary,
+                                    x: 0,
+                                    controlsY: [],
+                                    targetsY: [],
+                                    label: 'X',
+                                    width: minGateWidth,
+                                    htmlClass: 'classname',
+                                },
+                            ],
+                            [
+                                {
+                                    type: GateType.Unitary,
+                                    x: 0,
+                                    controlsY: [],
+                                    targetsY: [],
+                                    label: 'X',
+                                    width: minGateWidth,
+                                    htmlClass: 'classname',
+                                },
+                            ],
+                        ],
+                        label: 'X',
+                        width: minGateWidth,
+                        htmlClass: 'classname',
+                    },
+                ],
+                [
+                    {
+                        type: GateType.Unitary,
+                        x: 0,
+                        controlsY: [],
+                        targetsY: [],
+                        label: 'X',
+                        width: minGateWidth,
+                        htmlClass: 'classname',
+                    },
+                ],
+            ],
             label: 'X',
             width: minGateWidth,
             htmlClass: 'classname',
@@ -1020,179 +1584,235 @@ describe("Testing _addClass", () => {
     });
 });
 
-describe("Testing _offsetChildrenX", () => {
-    const offset: number = 50;
-    test("no grandchildren", () => {
-        const children: Metadata[][] = [[{
-            type: GateType.Unitary,
-            x: 0,
-            controlsY: [],
-            targetsY: [],
-            width: minGateWidth,
-            label: 'X',
-        }]];
-        const expected: Metadata[][] = [[{
-            type: GateType.Unitary,
-            x: 50,
-            controlsY: [],
-            targetsY: [],
-            width: minGateWidth,
-            label: 'X',
-        }]];
+describe('Testing _offsetChildrenX', () => {
+    const offset = 50;
+    test('no grandchildren', () => {
+        const children: Metadata[][] = [
+            [
+                {
+                    type: GateType.Unitary,
+                    x: 0,
+                    controlsY: [],
+                    targetsY: [],
+                    width: minGateWidth,
+                    label: 'X',
+                },
+            ],
+        ];
+        const expected: Metadata[][] = [
+            [
+                {
+                    type: GateType.Unitary,
+                    x: 50,
+                    controlsY: [],
+                    targetsY: [],
+                    width: minGateWidth,
+                    label: 'X',
+                },
+            ],
+        ];
         _offsetChildrenX(children, offset);
         expect(children).toEqual(expected);
     });
-    test("has grandchildren", () => {
-        const children: Metadata[][] = [[{
-            type: GateType.Unitary,
-            x: 0,
-            controlsY: [],
-            targetsY: [],
-            width: minGateWidth,
-            label: 'X',
-            children: [[{
-                type: GateType.Unitary,
-                x: 0,
-                controlsY: [],
-                targetsY: [],
-                width: minGateWidth,
-                label: 'X',
-            }], []]
-        }]];
-        const expected: Metadata[][] = [[{
-            type: GateType.Unitary,
-            x: 50,
-            controlsY: [],
-            targetsY: [],
-            width: minGateWidth,
-            label: 'X',
-            children: [[{
-                type: GateType.Unitary,
-                x: 50,
-                controlsY: [],
-                targetsY: [],
-                width: minGateWidth,
-                label: 'X',
-            }], []]
-        }]];
+    test('has grandchildren', () => {
+        const children: Metadata[][] = [
+            [
+                {
+                    type: GateType.Unitary,
+                    x: 0,
+                    controlsY: [],
+                    targetsY: [],
+                    width: minGateWidth,
+                    label: 'X',
+                    children: [
+                        [
+                            {
+                                type: GateType.Unitary,
+                                x: 0,
+                                controlsY: [],
+                                targetsY: [],
+                                width: minGateWidth,
+                                label: 'X',
+                            },
+                        ],
+                        [],
+                    ],
+                },
+            ],
+        ];
+        const expected: Metadata[][] = [
+            [
+                {
+                    type: GateType.Unitary,
+                    x: 50,
+                    controlsY: [],
+                    targetsY: [],
+                    width: minGateWidth,
+                    label: 'X',
+                    children: [
+                        [
+                            {
+                                type: GateType.Unitary,
+                                x: 50,
+                                controlsY: [],
+                                targetsY: [],
+                                width: minGateWidth,
+                                label: 'X',
+                            },
+                        ],
+                        [],
+                    ],
+                },
+            ],
+        ];
         _offsetChildrenX(children, offset);
         expect(children).toEqual(expected);
     });
-    test("undefined child", () => {
+    test('undefined child', () => {
         expect(() => _offsetChildrenX(undefined, offset)).not.toThrow();
     });
 });
 
-describe("Testing _fillMetadataX", () => {
-    test("Non-classically-isControlled gate", () => {
+describe('Testing _fillMetadataX', () => {
+    test('Non-classically-isControlled gate', () => {
         const columnWidths: number[] = Array(1).fill(minGateWidth);
         const expectedEndX = startX + minGateWidth + gatePadding * 2;
         const opsMetadata: Metadata[][] = [
-            [{
-                type: GateType.Unitary,
-                x: 0,
-                controlsY: [],
-                targetsY: [],
-                label: 'X',
-                width: minGateWidth,
-            }]
+            [
+                {
+                    type: GateType.Unitary,
+                    x: 0,
+                    controlsY: [],
+                    targetsY: [],
+                    label: 'X',
+                    width: minGateWidth,
+                },
+            ],
         ];
         const expected: Metadata[][] = [
-            [{
-                type: GateType.Unitary,
-                x: startX + minGateWidth / 2,
-                controlsY: [],
-                targetsY: [],
-                label: 'X',
-                width: minGateWidth,
-            }]
+            [
+                {
+                    type: GateType.Unitary,
+                    x: startX + minGateWidth / 2,
+                    controlsY: [],
+                    targetsY: [],
+                    label: 'X',
+                    width: minGateWidth,
+                },
+            ],
         ];
         const endX: number = _fillMetadataX(opsMetadata, columnWidths);
         expect(opsMetadata).toEqual(expected);
         expect(endX).toEqual(expectedEndX);
     });
-    test("classically-isControlled gate with no children", () => {
+    test('classically-isControlled gate with no children', () => {
         const columnWidths: number[] = Array(1).fill(minGateWidth);
         const expectedEndX = startX + minGateWidth + gatePadding * 2;
         const opsMetadata: Metadata[][] = [
-            [{
-                type: GateType.ClassicalControlled,
-                x: 0,
-                controlsY: [],
-                targetsY: [],
-                label: 'X',
-                width: minGateWidth,
-            }]
+            [
+                {
+                    type: GateType.ClassicalControlled,
+                    x: 0,
+                    controlsY: [],
+                    targetsY: [],
+                    label: 'X',
+                    width: minGateWidth,
+                },
+            ],
         ];
         const expected: Metadata[][] = [
-            [{
-                type: GateType.ClassicalControlled,
-                x: startX,
-                controlsY: [],
-                targetsY: [],
-                label: 'X',
-                width: minGateWidth,
-            }]
+            [
+                {
+                    type: GateType.ClassicalControlled,
+                    x: startX,
+                    controlsY: [],
+                    targetsY: [],
+                    label: 'X',
+                    width: minGateWidth,
+                },
+            ],
         ];
         const endX: number = _fillMetadataX(opsMetadata, columnWidths);
         expect(opsMetadata).toEqual(expected);
         expect(endX).toEqual(expectedEndX);
     });
-    test("depth-1 children", () => {
+    test('depth-1 children', () => {
         const columnWidths: number[] = Array(1).fill(minGateWidth + gatePadding * 2);
         const expectedEndX = startX + minGateWidth + gatePadding * 4;
-        const opsMetadata: Metadata[][] = [[{
-            type: GateType.ClassicalControlled,
-            x: 0,
-            controlsY: [],
-            targetsY: [],
-            children: [[{
-                type: GateType.Unitary,
-                x: 0,
-                controlsY: [],
-                targetsY: [],
-                label: 'X',
-                width: minGateWidth,
-            }], [{
-                type: GateType.Unitary,
-                x: 0,
-                controlsY: [],
-                targetsY: [],
-                label: 'X',
-                width: minGateWidth,
-            }]],
-            label: 'X',
-            width: minGateWidth + controlBtnOffset + classicalBoxPadding * 2,
-        }]];
-        const expected: Metadata[][] = [[{
-            type: GateType.ClassicalControlled,
-            x: startX,
-            controlsY: [],
-            targetsY: [],
-            children: [[{
-                type: GateType.Unitary,
-                x: controlBtnOffset + classicalBoxPadding,
-                controlsY: [],
-                targetsY: [],
-                label: 'X',
-                width: minGateWidth,
-            }], [{
-                type: GateType.Unitary,
-                x: controlBtnOffset + classicalBoxPadding,
-                controlsY: [],
-                targetsY: [],
-                label: 'X',
-                width: minGateWidth,
-            }]],
-            label: 'X',
-            width: minGateWidth + controlBtnOffset + classicalBoxPadding * 2,
-        }]];
+        const opsMetadata: Metadata[][] = [
+            [
+                {
+                    type: GateType.ClassicalControlled,
+                    x: 0,
+                    controlsY: [],
+                    targetsY: [],
+                    children: [
+                        [
+                            {
+                                type: GateType.Unitary,
+                                x: 0,
+                                controlsY: [],
+                                targetsY: [],
+                                label: 'X',
+                                width: minGateWidth,
+                            },
+                        ],
+                        [
+                            {
+                                type: GateType.Unitary,
+                                x: 0,
+                                controlsY: [],
+                                targetsY: [],
+                                label: 'X',
+                                width: minGateWidth,
+                            },
+                        ],
+                    ],
+                    label: 'X',
+                    width: minGateWidth + controlBtnOffset + classicalBoxPadding * 2,
+                },
+            ],
+        ];
+        const expected: Metadata[][] = [
+            [
+                {
+                    type: GateType.ClassicalControlled,
+                    x: startX,
+                    controlsY: [],
+                    targetsY: [],
+                    children: [
+                        [
+                            {
+                                type: GateType.Unitary,
+                                x: controlBtnOffset + classicalBoxPadding,
+                                controlsY: [],
+                                targetsY: [],
+                                label: 'X',
+                                width: minGateWidth,
+                            },
+                        ],
+                        [
+                            {
+                                type: GateType.Unitary,
+                                x: controlBtnOffset + classicalBoxPadding,
+                                controlsY: [],
+                                targetsY: [],
+                                label: 'X',
+                                width: minGateWidth,
+                            },
+                        ],
+                    ],
+                    label: 'X',
+                    width: minGateWidth + controlBtnOffset + classicalBoxPadding * 2,
+                },
+            ],
+        ];
 
         const endX: number = _fillMetadataX(opsMetadata, columnWidths);
         expect(opsMetadata).toEqual(expected);
         expect(endX).toEqual(expectedEndX);
     });
-    test("empty args", () => {
+    test('empty args', () => {
         const opsMetadata: Metadata[][] = [];
         const endX: number = _fillMetadataX(opsMetadata, []);
         expect(opsMetadata).toEqual([]);
@@ -1200,42 +1820,42 @@ describe("Testing _fillMetadataX", () => {
     });
 });
 
-describe("Testing processOperations", () => {
-    test("single qubit gates", () => {
-        const rxWidth: number = 52;
+describe('Testing processOperations', () => {
+    test('single qubit gates', () => {
+        const rxWidth = 52;
         const operations: Operation[] = [
             {
-                gate: "H",
+                gate: 'H',
                 isMeasurement: false,
                 isControlled: false,
                 isAdjoint: false,
                 controls: [],
-                targets: [{ type: RegisterType.Qubit, qId: 0 }]
+                targets: [{ type: RegisterType.Qubit, qId: 0 }],
             },
             {
-                gate: "H",
+                gate: 'H',
                 isMeasurement: false,
                 isControlled: false,
                 isAdjoint: false,
                 controls: [],
-                targets: [{ type: RegisterType.Qubit, qId: 0 }]
+                targets: [{ type: RegisterType.Qubit, qId: 0 }],
             },
             {
-                gate: "H",
+                gate: 'H',
                 isMeasurement: false,
                 isControlled: false,
                 isAdjoint: false,
                 controls: [],
-                targets: [{ type: RegisterType.Qubit, qId: 1 }]
+                targets: [{ type: RegisterType.Qubit, qId: 1 }],
             },
             {
-                gate: "RX",
-                displayArgs: "(0.25)",
+                gate: 'RX',
+                displayArgs: '(0.25)',
                 isMeasurement: false,
                 isControlled: false,
                 isAdjoint: false,
                 controls: [],
-                targets: [{ type: RegisterType.Qubit, qId: 1 }]
+                targets: [{ type: RegisterType.Qubit, qId: 1 }],
             },
         ];
         const registers: RegisterMap = {
@@ -1248,7 +1868,7 @@ describe("Testing processOperations", () => {
                 x: startX + minGateWidth / 2,
                 controlsY: [],
                 targetsY: [startY],
-                label: "H",
+                label: 'H',
                 width: minGateWidth,
             },
             {
@@ -1256,7 +1876,7 @@ describe("Testing processOperations", () => {
                 x: startX + (minGateWidth + gatePadding * 2) + rxWidth / 2,
                 controlsY: [],
                 targetsY: [startY],
-                label: "H",
+                label: 'H',
                 width: minGateWidth,
             },
             {
@@ -1264,7 +1884,7 @@ describe("Testing processOperations", () => {
                 x: startX + minGateWidth / 2,
                 controlsY: [],
                 targetsY: [startY + registerHeight],
-                label: "H",
+                label: 'H',
                 width: minGateWidth,
             },
             {
@@ -1272,42 +1892,42 @@ describe("Testing processOperations", () => {
                 x: startX + (minGateWidth + gatePadding * 2) + rxWidth / 2,
                 controlsY: [],
                 targetsY: [startY + registerHeight],
-                label: "RX",
-                displayArgs: "(0.25)",
+                label: 'RX',
+                displayArgs: '(0.25)',
                 width: rxWidth,
-            }
+            },
         ];
         const expectedWidth: number = startX + minGateWidth + rxWidth + gatePadding * 4;
         const { metadataList, svgWidth } = processOperations(operations, registers);
         expect(metadataList).toEqual(expectedOps);
         expect(svgWidth).toEqual(expectedWidth);
     });
-    test("single wide qubit gates", () => {
-        const expectedCustomWidth: number = 67;
+    test('single wide qubit gates', () => {
+        const expectedCustomWidth = 67;
         const operations: Operation[] = [
             {
-                gate: "H",
+                gate: 'H',
                 isMeasurement: false,
                 isControlled: false,
                 isAdjoint: false,
                 controls: [],
-                targets: [{ type: RegisterType.Qubit, qId: 0 }]
+                targets: [{ type: RegisterType.Qubit, qId: 0 }],
             },
             {
-                gate: "FooBar",
+                gate: 'FooBar',
                 isMeasurement: false,
                 isControlled: false,
                 isAdjoint: false,
                 controls: [],
-                targets: [{ type: RegisterType.Qubit, qId: 0 }]
+                targets: [{ type: RegisterType.Qubit, qId: 0 }],
             },
             {
-                gate: "H",
+                gate: 'H',
                 isMeasurement: false,
                 isControlled: false,
                 isAdjoint: false,
                 controls: [],
-                targets: [{ type: RegisterType.Qubit, qId: 1 }]
+                targets: [{ type: RegisterType.Qubit, qId: 1 }],
             },
         ];
         const registers: RegisterMap = {
@@ -1320,7 +1940,7 @@ describe("Testing processOperations", () => {
                 x: startX + minGateWidth / 2,
                 controlsY: [],
                 targetsY: [startY],
-                label: "H",
+                label: 'H',
                 width: minGateWidth,
             },
             {
@@ -1328,7 +1948,7 @@ describe("Testing processOperations", () => {
                 x: startX + (minGateWidth + gatePadding * 2) + expectedCustomWidth / 2,
                 controlsY: [],
                 targetsY: [startY],
-                label: "FooBar",
+                label: 'FooBar',
                 width: expectedCustomWidth,
             },
             {
@@ -1336,40 +1956,40 @@ describe("Testing processOperations", () => {
                 x: startX + minGateWidth / 2,
                 controlsY: [],
                 targetsY: [startY + registerHeight],
-                label: "H",
+                label: 'H',
                 width: minGateWidth,
-            }
+            },
         ];
         const expectedWidth: number = startX + minGateWidth + expectedCustomWidth + gatePadding * 4;
         const { metadataList, svgWidth } = processOperations(operations, registers);
         expect(metadataList).toEqual(expectedOps);
         expect(svgWidth).toEqual(expectedWidth);
     });
-    test("single and multi qubit gates", () => {
+    test('single and multi qubit gates', () => {
         const operations: Operation[] = [
             {
-                gate: "H",
+                gate: 'H',
                 isMeasurement: false,
                 isControlled: false,
                 isAdjoint: false,
                 controls: [],
-                targets: [{ type: RegisterType.Qubit, qId: 0 }]
+                targets: [{ type: RegisterType.Qubit, qId: 0 }],
             },
             {
-                gate: "X",
+                gate: 'X',
                 isMeasurement: false,
                 isControlled: true,
                 isAdjoint: false,
                 controls: [{ type: RegisterType.Qubit, qId: 1 }],
-                targets: [{ type: RegisterType.Qubit, qId: 0 }]
+                targets: [{ type: RegisterType.Qubit, qId: 0 }],
             },
             {
-                gate: "H",
+                gate: 'H',
                 isMeasurement: false,
                 isControlled: false,
                 isAdjoint: false,
                 controls: [],
-                targets: [{ type: RegisterType.Qubit, qId: 1 }]
+                targets: [{ type: RegisterType.Qubit, qId: 1 }],
             },
         ];
         const registers: RegisterMap = {
@@ -1382,7 +2002,7 @@ describe("Testing processOperations", () => {
                 x: startX + minGateWidth / 2,
                 controlsY: [],
                 targetsY: [startY],
-                label: "H",
+                label: 'H',
                 width: minGateWidth,
             },
             {
@@ -1390,7 +2010,7 @@ describe("Testing processOperations", () => {
                 x: startX + (minGateWidth + gatePadding * 2) + minGateWidth / 2,
                 controlsY: [startY + registerHeight],
                 targetsY: [startY],
-                label: "X",
+                label: 'X',
                 width: minGateWidth,
             },
             {
@@ -1398,48 +2018,48 @@ describe("Testing processOperations", () => {
                 x: startX + (minGateWidth + gatePadding * 2) * 2 + minGateWidth / 2,
                 controlsY: [],
                 targetsY: [startY + registerHeight],
-                label: "H",
+                label: 'H',
                 width: minGateWidth,
-            }
+            },
         ];
         const expectedWidth: number = startX + (minGateWidth + gatePadding * 2) * 3;
         const { metadataList, svgWidth } = processOperations(operations, registers);
         expect(metadataList).toEqual(expectedOps);
         expect(svgWidth).toEqual(expectedWidth);
     });
-    test("measure gates", () => {
+    test('measure gates', () => {
         const operations: Operation[] = [
             {
-                gate: "H",
+                gate: 'H',
                 isMeasurement: false,
                 isControlled: false,
                 isAdjoint: false,
                 controls: [],
-                targets: [{ type: RegisterType.Qubit, qId: 0 }]
+                targets: [{ type: RegisterType.Qubit, qId: 0 }],
             },
             {
-                gate: "M",
+                gate: 'M',
                 isMeasurement: true,
                 isControlled: false,
                 isAdjoint: false,
                 controls: [{ type: RegisterType.Qubit, qId: 0 }],
-                targets: [{ type: RegisterType.Classical, qId: 0, cId: 0 }]
+                targets: [{ type: RegisterType.Classical, qId: 0, cId: 0 }],
             },
             {
-                gate: "H",
+                gate: 'H',
                 isMeasurement: false,
                 isControlled: false,
                 isAdjoint: false,
                 controls: [],
-                targets: [{ type: RegisterType.Qubit, qId: 1 }]
+                targets: [{ type: RegisterType.Qubit, qId: 1 }],
             },
             {
-                gate: "M",
+                gate: 'M',
                 isMeasurement: true,
                 isControlled: false,
                 isAdjoint: false,
                 controls: [{ type: RegisterType.Qubit, qId: 0 }],
-                targets: [{ type: RegisterType.Classical, qId: 0, cId: 1 }]
+                targets: [{ type: RegisterType.Classical, qId: 0, cId: 1 }],
             },
         ];
         const registers: RegisterMap = {
@@ -1449,7 +2069,7 @@ describe("Testing processOperations", () => {
                 children: [
                     { type: RegisterType.Classical, y: startY + classicalRegHeight },
                     { type: RegisterType.Classical, y: startY + classicalRegHeight * 2 },
-                ]
+                ],
             },
             1: { type: RegisterType.Qubit, y: startY + classicalRegHeight * 3 },
         };
@@ -1459,7 +2079,7 @@ describe("Testing processOperations", () => {
                 x: startX + minGateWidth / 2,
                 controlsY: [],
                 targetsY: [startY],
-                label: "H",
+                label: 'H',
                 width: minGateWidth,
             },
             {
@@ -1467,7 +2087,7 @@ describe("Testing processOperations", () => {
                 x: startX + minGateWidth + gatePadding * 2 + minGateWidth / 2,
                 controlsY: [startY],
                 targetsY: [startY + classicalRegHeight],
-                label: "",
+                label: '',
                 width: minGateWidth,
             },
             {
@@ -1475,7 +2095,7 @@ describe("Testing processOperations", () => {
                 x: startX + (minGateWidth + gatePadding * 2) * 2 + minGateWidth / 2,
                 controlsY: [startY],
                 targetsY: [startY + classicalRegHeight * 2],
-                label: "",
+                label: '',
                 width: minGateWidth,
             },
             {
@@ -1483,7 +2103,7 @@ describe("Testing processOperations", () => {
                 x: startX + minGateWidth / 2,
                 controlsY: [],
                 targetsY: [startY + classicalRegHeight * 3],
-                label: "H",
+                label: 'H',
                 width: minGateWidth,
             },
         ];
@@ -1492,23 +2112,23 @@ describe("Testing processOperations", () => {
         expect(metadataList).toEqual(expectedOps);
         expect(svgWidth).toEqual(expectedWidth);
     });
-    test("skipped registers", () => {
+    test('skipped registers', () => {
         const operations: Operation[] = [
             {
-                gate: "H",
+                gate: 'H',
                 isMeasurement: false,
                 isControlled: false,
                 isAdjoint: false,
                 controls: [],
-                targets: [{ type: RegisterType.Qubit, qId: 0 }]
+                targets: [{ type: RegisterType.Qubit, qId: 0 }],
             },
             {
-                gate: "H",
+                gate: 'H',
                 isMeasurement: false,
                 isControlled: false,
                 isAdjoint: false,
                 controls: [],
-                targets: [{ type: RegisterType.Qubit, qId: 2 }]
+                targets: [{ type: RegisterType.Qubit, qId: 2 }],
             },
         ];
         const registers: RegisterMap = {
@@ -1518,7 +2138,7 @@ describe("Testing processOperations", () => {
                 children: [
                     { type: RegisterType.Classical, y: startY + classicalRegHeight },
                     { type: RegisterType.Classical, y: startY + classicalRegHeight * 2 },
-                ]
+                ],
             },
             2: { type: RegisterType.Qubit, y: startY + classicalRegHeight * 3 },
         };
@@ -1528,7 +2148,7 @@ describe("Testing processOperations", () => {
                 x: startX + minGateWidth / 2,
                 controlsY: [],
                 targetsY: [startY],
-                label: "H",
+                label: 'H',
                 width: minGateWidth,
             },
             {
@@ -1536,7 +2156,7 @@ describe("Testing processOperations", () => {
                 x: startX + minGateWidth / 2,
                 controlsY: [],
                 targetsY: [startY + classicalRegHeight * 3],
-                label: "H",
+                label: 'H',
                 width: minGateWidth,
             },
         ];
@@ -1545,7 +2165,7 @@ describe("Testing processOperations", () => {
         expect(metadataList).toEqual(expectedOps);
         expect(svgWidth).toEqual(expectedWidth);
     });
-    test("no operations", () => {
+    test('no operations', () => {
         const operations: Operation[] = [];
         const registers: RegisterMap = {};
         const { metadataList, svgWidth } = processOperations(operations, registers);

--- a/src/Kernel/client/__tests__/ExecutionPathVisualizerTests/registerFormatter.test.ts
+++ b/src/Kernel/client/__tests__/ExecutionPathVisualizerTests/registerFormatter.test.ts
@@ -1,68 +1,57 @@
-import {
-    formatRegisters,
-    _classicalRegister,
-    _qubitRegister,
-} from "../../ExecutionPathVisualizer/formatters/registerFormatter";
-import { RegisterMap, RegisterType } from "../../ExecutionPathVisualizer/register";
-import { Metadata } from "../../ExecutionPathVisualizer/metadata";
-import {
-    startY,
-    registerHeight,
-    classicalRegHeight,
-    GateType,
-    startX,
-    minGateWidth
-} from "../../ExecutionPathVisualizer/constants";
+import { formatRegisters, _classicalRegister, _qubitRegister } from '../../ExecutionPathVisualizer/formatters/registerFormatter';
+import { RegisterMap, RegisterType } from '../../ExecutionPathVisualizer/register';
+import { Metadata } from '../../ExecutionPathVisualizer/metadata';
+import { startY, registerHeight, classicalRegHeight, GateType, startX, minGateWidth } from '../../ExecutionPathVisualizer/constants';
 
-describe("Testing _classicalRegister", () => {
-    test("register with normal width", () => {
+describe('Testing _classicalRegister', () => {
+    test('register with normal width', () => {
         expect(_classicalRegister(10, 10, 100, 20)).toMatchSnapshot();
         expect(_classicalRegister(10, 10, 100, 20)).toMatchSnapshot();
         expect(_classicalRegister(10, 10, 100, 20)).toMatchSnapshot();
     });
-    test("register with small width", () => {
+    test('register with small width', () => {
         expect(_classicalRegister(10, 10, 5, 20)).toMatchSnapshot();
         expect(_classicalRegister(10, 10, 5, 20)).toMatchSnapshot();
         expect(_classicalRegister(10, 10, 5, 20)).toMatchSnapshot();
     });
-    test("register with large width", () => {
+    test('register with large width', () => {
         expect(_classicalRegister(10, 10, 500, 20)).toMatchSnapshot();
         expect(_classicalRegister(10, 10, 500, 20)).toMatchSnapshot();
         expect(_classicalRegister(10, 10, 500, 20)).toMatchSnapshot();
     });
-    test("register with label offset", () => {
+    test('register with label offset', () => {
         expect(_classicalRegister(10, 10, 100, 20)).toMatchSnapshot();
         expect(_classicalRegister(10, 10, 100, 20)).toMatchSnapshot();
         expect(_classicalRegister(10, 10, 100, 20)).toMatchSnapshot();
     });
 });
 
-describe("Testing _qubitRegister", () => {
-    test("register with normal width", () => {
+describe('Testing _qubitRegister', () => {
+    test('register with normal width', () => {
         expect(_qubitRegister(0, 100, 20)).toMatchSnapshot();
         expect(_qubitRegister(1, 100, 20)).toMatchSnapshot();
         expect(_qubitRegister(2, 100, 20)).toMatchSnapshot();
     });
-    test("register with small width", () => {
+    test('register with small width', () => {
         expect(_qubitRegister(0, 5, 20)).toMatchSnapshot();
         expect(_qubitRegister(1, 5, 20)).toMatchSnapshot();
         expect(_qubitRegister(2, 5, 20)).toMatchSnapshot();
     });
-    test("register with large width", () => {
+    test('register with large width', () => {
         expect(_qubitRegister(0, 500, 20)).toMatchSnapshot();
         expect(_qubitRegister(1, 500, 20)).toMatchSnapshot();
         expect(_qubitRegister(2, 500, 20)).toMatchSnapshot();
     });
-    test("register with label offset", () => {
+    test('register with label offset', () => {
         expect(_qubitRegister(0, 100, 20, 0)).toMatchSnapshot();
         expect(_qubitRegister(1, 100, 20, 5)).toMatchSnapshot();
         expect(_qubitRegister(2, 100, 20, 50)).toMatchSnapshot();
     });
 });
 
-describe("Testing formatRegisters", () => {
-    test("1 quantum register", () => {
-        const registers: RegisterMap = { 0: { type: RegisterType.Qubit, y: startY } }
+describe('Testing formatRegisters', () => {
+    test('1 quantum register', () => {
+        const registers: RegisterMap = { 0: { type: RegisterType.Qubit, y: startY } };
         // Normal width
         expect(formatRegisters(registers, [], startX + 100)).toMatchSnapshot();
         // Small width
@@ -70,7 +59,7 @@ describe("Testing formatRegisters", () => {
         // Large width
         expect(formatRegisters(registers, [], startX + 500)).toMatchSnapshot();
     });
-    test("Multiple quantum registers", () => {
+    test('Multiple quantum registers', () => {
         const registers: RegisterMap = {
             0: { type: RegisterType.Qubit, y: startY },
             1: { type: RegisterType.Qubit, y: startY + registerHeight },
@@ -84,7 +73,7 @@ describe("Testing formatRegisters", () => {
         // Large width
         expect(formatRegisters(registers, [], startX + 500)).toMatchSnapshot();
     });
-    test("Skipped quantum registers", () => {
+    test('Skipped quantum registers', () => {
         const registers: RegisterMap = {
             0: { type: RegisterType.Qubit, y: startY },
             2: { type: RegisterType.Qubit, y: startY + registerHeight * 2 },
@@ -97,12 +86,12 @@ describe("Testing formatRegisters", () => {
         // Large width
         expect(formatRegisters(registers, [], startX + 500)).toMatchSnapshot();
     });
-    test("Quantum and classical registers", () => {
+    test('Quantum and classical registers', () => {
         let registers: RegisterMap = {
             0: {
                 type: RegisterType.Qubit,
                 y: startY,
-                children: [{ type: RegisterType.Classical, y: startY + classicalRegHeight }]
+                children: [{ type: RegisterType.Classical, y: startY + classicalRegHeight }],
             },
             1: { type: RegisterType.Qubit, y: startY + classicalRegHeight * 2 },
             2: { type: RegisterType.Qubit, y: startY + registerHeight + classicalRegHeight * 2 },
@@ -114,8 +103,8 @@ describe("Testing formatRegisters", () => {
                 controlsY: [startY],
                 targetsY: [startY + classicalRegHeight],
                 label: '',
-                width: minGateWidth
-            }
+                width: minGateWidth,
+            },
         ];
         // Normal width
         expect(formatRegisters(registers, measureGates, startX + 100)).toMatchSnapshot();
@@ -132,14 +121,12 @@ describe("Testing formatRegisters", () => {
                 children: [
                     { type: RegisterType.Classical, y: startY + registerHeight + classicalRegHeight },
                     { type: RegisterType.Classical, y: startY + registerHeight + classicalRegHeight * 2 },
-                ]
+                ],
             },
             2: {
                 type: RegisterType.Qubit,
                 y: startY + registerHeight + classicalRegHeight * 3,
-                children: [
-                    { type: RegisterType.Classical, y: startY + registerHeight + classicalRegHeight * 4 },
-                ]
+                children: [{ type: RegisterType.Classical, y: startY + registerHeight + classicalRegHeight * 4 }],
             },
         };
         measureGates = [
@@ -149,7 +136,7 @@ describe("Testing formatRegisters", () => {
                 controlsY: [startY],
                 targetsY: [startY + classicalRegHeight],
                 label: '',
-                width: minGateWidth
+                width: minGateWidth,
             },
             {
                 type: GateType.Measure,
@@ -157,7 +144,7 @@ describe("Testing formatRegisters", () => {
                 controlsY: [startY],
                 targetsY: [startY + classicalRegHeight * 2],
                 label: '',
-                width: minGateWidth
+                width: minGateWidth,
             },
             {
                 type: GateType.Measure,
@@ -165,7 +152,7 @@ describe("Testing formatRegisters", () => {
                 controlsY: [startY + classicalRegHeight * 3],
                 targetsY: [startY + classicalRegHeight * 4],
                 label: '',
-                width: minGateWidth
+                width: minGateWidth,
             },
         ];
         // Normal width

--- a/src/Kernel/client/__tests__/ExecutionPathVisualizerTests/utils.test.ts
+++ b/src/Kernel/client/__tests__/ExecutionPathVisualizerTests/utils.test.ts
@@ -1,60 +1,45 @@
-import { getGateWidth, _getStringWidth } from "../../ExecutionPathVisualizer/utils";
-import { Metadata } from "../../ExecutionPathVisualizer/metadata";
-import { GateType, minGateWidth, labelPadding } from "../../ExecutionPathVisualizer/constants";
+import { getGateWidth, _getStringWidth } from '../../ExecutionPathVisualizer/utils';
+import { GateType, minGateWidth, labelPadding } from '../../ExecutionPathVisualizer/constants';
 
-describe("Testing getGateWidth", () => {
-    const testOp: Metadata = {
-        type: GateType.Invalid,
-        x: 0,
-        controlsY: [],
-        targetsY: [],
-        label: '',
-        width: minGateWidth
-    };
-    test("measure gate", () =>
-        expect(getGateWidth(Object.assign({ type: GateType.Measure, label: '' })))
-            .toEqual(minGateWidth));
-    test("cnot gate", () =>
-        expect(getGateWidth(Object.assign({ type: GateType.Cnot, label: 'x' })))
-            .toEqual(minGateWidth));
-    test("swap gate", () =>
-        expect(getGateWidth(Object.assign({ type: GateType.Swap, label: '' })))
-            .toEqual(minGateWidth));
-    test("single unitary gate", () =>
-        expect(getGateWidth(Object.assign({ type: GateType.Unitary, label: 'x' })))
-            .toEqual(minGateWidth));
-    test("multi unitary gate", () =>
-        expect(getGateWidth(Object.assign({ type: GateType.Unitary, label: 'zz' })))
-            .toEqual(minGateWidth));
-    test("unitary gate with arguments", () =>
-        expect(getGateWidth(Object.assign({ type: GateType.Unitary, displayArgs: '(0.25)', label: 'RX' })))
-            .toEqual(52));
-    test("invalid", () =>
-        expect(getGateWidth(Object.assign({ type: GateType.Invalid, label: '' })))
-            .toEqual(minGateWidth));
-    test("unitary with long name", () =>
-        expect(getGateWidth(Object.assign({ type: GateType.Unitary, label: 'FOOBAR' })))
-            .toBeCloseTo(59 + labelPadding * 2));
-    test("classically controlled gate", () => {
-        expect(getGateWidth(Object.assign({ type: GateType.ClassicalControlled, label: '', width: 500 })))
-            .toEqual(500);
+describe('Testing getGateWidth', () => {
+    test('measure gate', () =>
+        expect(getGateWidth(Object.assign({ type: GateType.Measure, label: '' }))).toEqual(minGateWidth));
+    test('cnot gate', () =>
+        expect(getGateWidth(Object.assign({ type: GateType.Cnot, label: 'x' }))).toEqual(minGateWidth));
+    test('swap gate', () =>
+        expect(getGateWidth(Object.assign({ type: GateType.Swap, label: '' }))).toEqual(minGateWidth));
+    test('single unitary gate', () =>
+        expect(getGateWidth(Object.assign({ type: GateType.Unitary, label: 'x' }))).toEqual(minGateWidth));
+    test('multi unitary gate', () =>
+        expect(getGateWidth(Object.assign({ type: GateType.Unitary, label: 'zz' }))).toEqual(minGateWidth));
+    test('unitary gate with arguments', () =>
+        expect(getGateWidth(Object.assign({ type: GateType.Unitary, displayArgs: '(0.25)', label: 'RX' }))).toEqual(
+            52,
+        ));
+    test('invalid', () =>
+        expect(getGateWidth(Object.assign({ type: GateType.Invalid, label: '' }))).toEqual(minGateWidth));
+    test('unitary with long name', () =>
+        expect(getGateWidth(Object.assign({ type: GateType.Unitary, label: 'FOOBAR' }))).toBeCloseTo(
+            59 + labelPadding * 2,
+        ));
+    test('classically controlled gate', () => {
+        expect(getGateWidth(Object.assign({ type: GateType.ClassicalControlled, label: '', width: 500 }))).toEqual(500);
     });
 });
 
-describe("Testing _getStringWidth", () => {
-    test("correctly scaled width with font size", () => {
-        const fullSize: number = 423;
-        expect(_getStringWidth("FOOBAR", 14)).toEqual(59);
-        expect(_getStringWidth("FOOBAR", 20)).toEqual(84);
-        expect(_getStringWidth("FOOBAR", 5)).toEqual(21);
-        expect(_getStringWidth("FOOBAR", 100)).toEqual(423);
-        expect(_getStringWidth("FOOBAR", 200)).toEqual(844);
+describe('Testing _getStringWidth', () => {
+    test('correctly scaled width with font size', () => {
+        expect(_getStringWidth('FOOBAR', 14)).toEqual(59);
+        expect(_getStringWidth('FOOBAR', 20)).toEqual(84);
+        expect(_getStringWidth('FOOBAR', 5)).toEqual(21);
+        expect(_getStringWidth('FOOBAR', 100)).toEqual(423);
+        expect(_getStringWidth('FOOBAR', 200)).toEqual(844);
     });
 
-    test("varying size strings", () => {
-        expect(_getStringWidth("H", 14)).toBeGreaterThanOrEqual(9);
-        expect(_getStringWidth("H", 14)).toBeLessThanOrEqual(10);
-        expect(_getStringWidth("GateWithASuperLongName", 14)).toBeGreaterThanOrEqual(174);
-        expect(_getStringWidth("GateWithASuperLongName", 14)).toBeLessThanOrEqual(176);
+    test('varying size strings', () => {
+        expect(_getStringWidth('H', 14)).toBeGreaterThanOrEqual(9);
+        expect(_getStringWidth('H', 14)).toBeLessThanOrEqual(10);
+        expect(_getStringWidth('GateWithASuperLongName', 14)).toBeGreaterThanOrEqual(174);
+        expect(_getStringWidth('GateWithASuperLongName', 14)).toBeLessThanOrEqual(176);
     });
 });

--- a/src/Kernel/client/kernel.ts
+++ b/src/Kernel/client/kernel.ts
@@ -8,7 +8,7 @@ import { IPython } from "./ipython";
 declare var IPython: IPython;
 
 import { Telemetry, ClientInfo } from "./telemetry.js";
-import { executionPathToHtml } from "./ExecutionPathVisualizer";
+import { executionPathToHtml, ExecutionPath } from "./ExecutionPathVisualizer";
 import { StyleConfig, STYLES } from "./ExecutionPathVisualizer/styles";
 
 function defineQSharpMode() {
@@ -238,7 +238,7 @@ class Kernel {
         IPython.notebook.kernel.register_iopub_handler(
             "render_execution_path",
             message => {
-                const { executionPath, id, style } = message.content;
+                const { executionPath, id, style }: { executionPath: ExecutionPath, id: string, style: string } = message.content;
                 const userStyleConfig: StyleConfig = STYLES[style] || {};
                 const html: string = executionPathToHtml(executionPath, userStyleConfig);
                 const container: HTMLElement = document.getElementById(id);

--- a/src/Kernel/client/kernel.ts
+++ b/src/Kernel/client/kernel.ts
@@ -8,8 +8,7 @@ import { IPython } from "./ipython";
 declare var IPython: IPython;
 
 import { Telemetry, ClientInfo } from "./telemetry.js";
-import { executionPathToHtml, ExecutionPath } from "./ExecutionPathVisualizer";
-import { StyleConfig, STYLES } from "./ExecutionPathVisualizer/styles";
+import { executionPathToHtml, ExecutionPath, StyleConfig, STYLES } from "./ExecutionPathVisualizer";
 
 function defineQSharpMode() {
     console.log("Loading IQ# kernel-specific extension...");


### PR DESCRIPTION
The code within ExecutionPathVisualizer was put through a linter and a formatter as used in the standalone [sqore repo](https://dev.azure.com/t-rkoh/CircuitViz/_git/sqore). Aside from the many files changed due to linting, the main functional changes are as follows:
1. Inline styles on SVG elements were replaced in favour of using classes to allow easier config through CSS.
2. All gates are wrapped in a `gate` class for easier config (i.e. extra interactivity or styling by user).
3. Custom IDs are added to `Operation` to allow users to tag each operation's gate with an ID. This will allow them to be able to perform gate-specific interactions or styles (which will be crucial for the state visualizer).
4. Make sure all required variables and types are exposed via `ExecutionPathVisualizer/index.ts`.
5. Upgrade TypeScript MSBuild version to `3.9.6` (same version as [`feature/visualization-improvements`](https://github.com/microsoft/iqsharp/tree/feature/visualization-improvements) to allow `export type`.
6. Expose `excecutionPathToSvg` for other use cases when the circuit is to be injected into an existing HTML document.