### PR TITLE
Add custom metadata to gates

### DIFF
--- a/src/Kernel/client/ExecutionPathVisualizer/circuit.ts
+++ b/src/Kernel/client/ExecutionPathVisualizer/circuit.ts
@@ -1,9 +1,9 @@
 import { Register } from './register';
 
 /**
- * Structure of JSON representation of the execution path of a Q# operation.
+ * Circuit to be visualized.
  */
-export interface ExecutionPath {
+export interface Circuit {
     /** Array of qubit resources. */
     qubits: Qubit[];
     operations: Operation[];
@@ -25,8 +25,6 @@ export interface Qubit {
 export interface Operation {
     /** Gate label. */
     gate: string;
-    /** HTML element ID. */
-    id?: string;
     /** Formatted gate arguments to be displayed. */
     displayArgs?: string;
     /** Classically-controlled gates.
@@ -44,4 +42,6 @@ export interface Operation {
     controls: Register[];
     /** Target registers the gate acts on. */
     targets: Register[];
+    /** Custom user metadata. */
+    customMetadata?: Record<string, unknown>;
 }

--- a/src/Kernel/client/ExecutionPathVisualizer/formatters/formatUtils.ts
+++ b/src/Kernel/client/ExecutionPathVisualizer/formatters/formatUtils.ts
@@ -5,16 +5,17 @@ import { labelFontSize } from '../constants';
 /**
  * Given an array of SVG elements, group them as an SVG group using the `<g>` tag.
  *
- * @param svgElems  Array of SVG elements.
- * @param className Class name of element.
- * @param id        ID of element.
+ * @param svgElems   Array of SVG elements.
+ * @param attributes Key-value pairs of attributes and they values.
  *
  * @returns SVG string for grouped elements.
  */
-export const group = (svgElems: string[], className?: string, id?: string): string => {
-    const clsString: string = className != null ? ` class="${className}"` : '';
-    const idString: string = id != null ? ` id="${id}"` : '';
-    return [`<g${clsString}${idString}>`, ...svgElems.flat(), '</g>'].join('\n');
+export const group = (svgElems: string[], attributes: { [attr: string]: string | undefined } = {}): string => {
+    const attrs: string = Object.entries(attributes)
+        .filter(([_, val]) => val != null)
+        .map(([attr, val]) => `${attr}='${val}'`)
+        .join(' ');
+    return [`<g ${attrs}>`, ...svgElems.flat(), '</g>'].join('\n');
 };
 
 /**

--- a/src/Kernel/client/ExecutionPathVisualizer/formatters/inputFormatter.ts
+++ b/src/Kernel/client/ExecutionPathVisualizer/formatters/inputFormatter.ts
@@ -1,4 +1,4 @@
-import { Qubit } from '../executionPath';
+import { Qubit } from '../circuit';
 import { RegisterType, RegisterMap, RegisterMetadata } from '../register';
 import { leftPadding, startY, registerHeight, classicalRegHeight } from '../constants';
 

--- a/src/Kernel/client/ExecutionPathVisualizer/index.ts
+++ b/src/Kernel/client/ExecutionPathVisualizer/index.ts
@@ -2,10 +2,11 @@ import { formatInputs } from './formatters/inputFormatter';
 import { formatGates } from './formatters/gateFormatter';
 import { formatRegisters } from './formatters/registerFormatter';
 import { processOperations } from './process';
-import { ExecutionPath } from './executionPath';
+import { Circuit } from './circuit';
 import { Metadata } from './metadata';
 import { GateType } from './constants';
 import { StyleConfig, style } from './styles';
+import { createUUID } from './utils';
 
 /**
  * Custom JavaScript code to be injected into visualization HTML string.
@@ -45,21 +46,23 @@ const script = `
 `;
 
 /**
- * Converts JSON representing an execution path of a Q# program given by the simulator and returns its SVG visualization.
+ * Generates the SVG visualization of the given circuit.
  *
- * @param json            JSON received from simulator.
+ * @param circuit         Circuit to be visualized.
  * @param userStyleConfig Custom CSS style config for visualization.
  *
  * @returns SVG representation of circuit.
  */
-export const executionPathToSvg = (json: ExecutionPath, userStyleConfig?: StyleConfig): string => {
-    const { qubits, operations } = json;
+export const circuitToSvg = (circuit: Circuit, userStyleConfig?: StyleConfig): string => {
+    const { qubits, operations } = circuit;
     const { qubitWires, registers, svgHeight } = formatInputs(qubits);
     const { metadataList, svgWidth } = processOperations(operations, registers);
     const formattedGates: string = formatGates(metadataList);
     const measureGates: Metadata[] = metadataList.filter(({ type }) => type === GateType.Measure);
     const formattedRegs: string = formatRegisters(registers, measureGates, svgWidth);
-    return `<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="${svgWidth}" height="${svgHeight}">
+    const uuid: string = createUUID();
+
+    return `<svg xmlns="http://www.w3.org/2000/svg" version="1.1" id="${uuid}" width="${svgWidth}" height="${svgHeight}">
     ${script}
     ${style(userStyleConfig)}
     ${qubitWires}
@@ -69,18 +72,18 @@ export const executionPathToSvg = (json: ExecutionPath, userStyleConfig?: StyleC
 };
 
 /**
- * Converts JSON representing an execution path of a Q# program given by the simulator and returns its HTML visualization.
+ * Generates the HTML visualization of the given circuit.
  *
- * @param json            JSON received from simulator.
+ * @param circuit         Circuit to be visualized.
  * @param userStyleConfig Custom CSS style config for visualization.
  *
  * @returns HTML representation of circuit.
  */
-export const executionPathToHtml = (json: ExecutionPath, userStyleConfig?: StyleConfig): string =>
+export const circuitToHtml = (circuit: Circuit, userStyleConfig?: StyleConfig): string =>
     `<html>
-    ${executionPathToSvg(json, userStyleConfig)}
+    ${circuitToSvg(circuit, userStyleConfig)}
 </html>`;
 
 // Export types
-export type { ExecutionPath, StyleConfig };
+export type { Circuit, StyleConfig };
 export { STYLES } from './styles';

--- a/src/Kernel/client/ExecutionPathVisualizer/metadata.ts
+++ b/src/Kernel/client/ExecutionPathVisualizer/metadata.ts
@@ -17,8 +17,6 @@ export interface Metadata {
     label: string;
     /** Gate arguments as string. */
     displayArgs?: string;
-    /** HTML element ID. */
-    id?: string;
     /** Gate width. */
     width: number;
     /** Classically-controlled gates.
@@ -28,4 +26,6 @@ export interface Metadata {
     children?: Metadata[][];
     /** HTML element class for interactivity. */
     htmlClass?: string;
+    /** Custom user metadata. */
+    customMetadata?: Record<string, unknown>;
 }

--- a/src/Kernel/client/ExecutionPathVisualizer/process.ts
+++ b/src/Kernel/client/ExecutionPathVisualizer/process.ts
@@ -1,5 +1,5 @@
 import { minGateWidth, startX, gatePadding, GateType, controlBtnOffset, classicalBoxPadding } from './constants';
-import { Operation } from './executionPath';
+import { Operation } from './circuit';
 import { Metadata } from './metadata';
 import { Register, RegisterMap, RegisterType } from './register';
 import { getGateWidth } from './utils';
@@ -182,7 +182,17 @@ const _opToMetadata = (op: Operation | null, registers: RegisterMap): Metadata =
 
     if (op == null) return metadata;
 
-    const { gate, id, displayArgs, isMeasurement, isControlled, isAdjoint, controls, targets, children } = op;
+    const {
+        gate,
+        customMetadata,
+        displayArgs,
+        isMeasurement,
+        isControlled,
+        isAdjoint,
+        controls,
+        targets,
+        children,
+    } = op;
 
     // Set y coords
     metadata.controlsY = controls.map((reg) => _getRegY(reg, registers));
@@ -235,8 +245,8 @@ const _opToMetadata = (op: Operation | null, registers: RegisterMap): Metadata =
     // Set gate width
     metadata.width = getGateWidth(metadata);
 
-    // Set custom gate ID
-    metadata.id = id;
+    // Set custom user-provided gate metadata
+    metadata.customMetadata = customMetadata;
 
     return metadata;
 };

--- a/src/Kernel/client/ExecutionPathVisualizer/utils.ts
+++ b/src/Kernel/client/ExecutionPathVisualizer/utils.ts
@@ -2,6 +2,18 @@ import { Metadata } from './metadata';
 import { GateType, minGateWidth, labelPadding, labelFontSize, argsFontSize } from './constants';
 
 /**
+ * Generate a UUID using `Math.random`.
+ *
+ * @returns UUID string.
+ */
+const createUUID = (): string =>
+    'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function (c) {
+        const r = (Math.random() * 16) | 0,
+            v = c == 'x' ? r : (r & 0x3) | 0x8;
+        return v.toString(16);
+    });
+
+/**
  * Calculate the width of a gate, given its metadata.
  *
  * @param metadata Metadata of a given gate.
@@ -43,4 +55,4 @@ const _getStringWidth = (text: string, fontSize: number = labelFontSize): number
     return metrics.width;
 };
 
-export { getGateWidth, _getStringWidth };
+export { createUUID, getGateWidth, _getStringWidth };

--- a/src/Kernel/client/ExecutionPathVisualizer/utils.ts
+++ b/src/Kernel/client/ExecutionPathVisualizer/utils.ts
@@ -3,6 +3,8 @@ import { GateType, minGateWidth, labelPadding, labelFontSize, argsFontSize } fro
 
 /**
  * Generate a UUID using `Math.random`.
+ * Note: this implementation came from https://stackoverflow.com/questions/105034/how-to-create-guid-uuid
+ * and is not cryptographically secure but works for our use case.
  *
  * @returns UUID string.
  */

--- a/src/Kernel/client/__tests__/ExecutionPathVisualizerTests/__snapshots__/gateFormatter.test.ts.snap
+++ b/src/Kernel/client/__tests__/ExecutionPathVisualizerTests/__snapshots__/gateFormatter.test.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Testing _classicalControlled No htmlClass 1`] = `
-"<g class=\\"classically-controlled-group classically-controlled-unknown\\">
+"<g class='classically-controlled-group classically-controlled-unknown'>
 <line class=\\"classical-line\\" x1=\\"95\\" x2=\\"120\\" y1=\\"180\\" y2=\\"180\\" stroke-dasharray=\\"8, 8\\"></line>
 <line class=\\"classical-line\\" x1=\\"95\\" x2=\\"95\\" y1=\\"175\\" y2=\\"180\\" stroke-dasharray=\\"8, 8\\"></line>
 <g class=\\"classically-controlled-btn classically-controlled\\" onClick=\\"toggleClassicalBtn('classically-controlled')\\">
@@ -11,7 +11,7 @@ exports[`Testing _classicalControlled No htmlClass 1`] = `
 <g class=\\"classically-controlled-zero hidden\\">
 </g>
 <g class=\\"classically-controlled-one\\">
-<g class=\\"gate\\">
+<g class='gate'>
 <rect class=\\"gate-unitary\\" x=\\"90\\" y=\\"20\\" width=\\"40\\" height=\\"40\\"></rect>
 <text font-size=\\"14\\" x=\\"110\\" y=\\"40\\">X</text>
 </g></g>
@@ -20,7 +20,7 @@ exports[`Testing _classicalControlled No htmlClass 1`] = `
 `;
 
 exports[`Testing _classicalControlled change padding 1`] = `
-"<g class=\\"classically-controlled-1-group classically-controlled-unknown\\">
+"<g class='classically-controlled-1-group classically-controlled-unknown'>
 <line class=\\"classical-line\\" x1=\\"95\\" x2=\\"120\\" y1=\\"180\\" y2=\\"180\\" stroke-dasharray=\\"8, 8\\"></line>
 <line class=\\"classical-line\\" x1=\\"95\\" x2=\\"95\\" y1=\\"175\\" y2=\\"180\\" stroke-dasharray=\\"8, 8\\"></line>
 <g class=\\"classically-controlled-btn classically-controlled-1\\" onClick=\\"toggleClassicalBtn('classically-controlled-1')\\">
@@ -30,7 +30,7 @@ exports[`Testing _classicalControlled change padding 1`] = `
 <g class=\\"classically-controlled-1-zero hidden\\">
 </g>
 <g class=\\"classically-controlled-1-one\\">
-<g class=\\"gate\\">
+<g class='gate'>
 <rect class=\\"gate-unitary\\" x=\\"90\\" y=\\"20\\" width=\\"40\\" height=\\"40\\"></rect>
 <text font-size=\\"14\\" x=\\"110\\" y=\\"40\\">X</text>
 </g></g>
@@ -39,7 +39,7 @@ exports[`Testing _classicalControlled change padding 1`] = `
 `;
 
 exports[`Testing _classicalControlled multiple 'zero'/'one' children 1`] = `
-"<g class=\\"classically-controlled-1-group classically-controlled-unknown\\">
+"<g class='classically-controlled-1-group classically-controlled-unknown'>
 <line class=\\"classical-line\\" x1=\\"95\\" x2=\\"120\\" y1=\\"180\\" y2=\\"180\\" stroke-dasharray=\\"8, 8\\"></line>
 <line class=\\"classical-line\\" x1=\\"95\\" x2=\\"95\\" y1=\\"175\\" y2=\\"180\\" stroke-dasharray=\\"8, 8\\"></line>
 <g class=\\"classically-controlled-btn classically-controlled-1\\" onClick=\\"toggleClassicalBtn('classically-controlled-1')\\">
@@ -47,16 +47,16 @@ exports[`Testing _classicalControlled multiple 'zero'/'one' children 1`] = `
 <text class=\\"classically-controlled-1 classically-controlled-text\\" font-size=\\"14\\" x=\\"95\\" y=\\"160\\">?</text>
 </g>
 <g class=\\"classically-controlled-1-zero hidden\\">
-<g class=\\"gate\\">
+<g class='gate'>
 <rect class=\\"gate-unitary\\" x=\\"90\\" y=\\"20\\" width=\\"40\\" height=\\"40\\"></rect>
 <text font-size=\\"14\\" x=\\"110\\" y=\\"40\\">X</text>
 </g></g>
 <g class=\\"classically-controlled-1-one\\">
-<g class=\\"gate\\">
+<g class='gate'>
 <rect class=\\"gate-unitary\\" x=\\"90\\" y=\\"20\\" width=\\"40\\" height=\\"40\\"></rect>
 <text font-size=\\"14\\" x=\\"110\\" y=\\"40\\">X</text>
 </g>
-<g class=\\"gate\\">
+<g class='gate'>
 <line x1=\\"170\\" x2=\\"170\\" y1=\\"40\\" y2=\\"100\\"></line>
 <circle class=\\"control-dot\\" cx=\\"170\\" cy=\\"100\\" r=\\"5\\"></circle>
 <circle class=\\"oplus\\" cx=\\"170\\" cy=\\"40\\" r=\\"15\\"></circle>
@@ -68,7 +68,7 @@ exports[`Testing _classicalControlled multiple 'zero'/'one' children 1`] = `
 `;
 
 exports[`Testing _classicalControlled nested children 1`] = `
-"<g class=\\"classically-controlled-1-group classically-controlled-unknown\\">
+"<g class='classically-controlled-1-group classically-controlled-unknown'>
 <line class=\\"classical-line\\" x1=\\"95\\" x2=\\"120\\" y1=\\"180\\" y2=\\"180\\" stroke-dasharray=\\"8, 8\\"></line>
 <line class=\\"classical-line\\" x1=\\"95\\" x2=\\"95\\" y1=\\"175\\" y2=\\"180\\" stroke-dasharray=\\"8, 8\\"></line>
 <g class=\\"classically-controlled-btn classically-controlled-1\\" onClick=\\"toggleClassicalBtn('classically-controlled-1')\\">
@@ -78,11 +78,11 @@ exports[`Testing _classicalControlled nested children 1`] = `
 <g class=\\"classically-controlled-1-zero hidden\\">
 </g>
 <g class=\\"classically-controlled-1-one\\">
-<g class=\\"gate\\">
+<g class='gate'>
 <rect class=\\"gate-unitary\\" x=\\"90\\" y=\\"20\\" width=\\"40\\" height=\\"40\\"></rect>
 <text font-size=\\"14\\" x=\\"110\\" y=\\"40\\">X</text>
 </g>
-<g class=\\"classically-controlled-1-group classically-controlled-unknown\\">
+<g class='classically-controlled-1-group classically-controlled-unknown'>
 <line class=\\"classical-line\\" x1=\\"165\\" x2=\\"190\\" y1=\\"240\\" y2=\\"240\\" stroke-dasharray=\\"8, 8\\"></line>
 <line class=\\"classical-line\\" x1=\\"165\\" x2=\\"165\\" y1=\\"235\\" y2=\\"240\\" stroke-dasharray=\\"8, 8\\"></line>
 <g class=\\"classically-controlled-btn classically-controlled-1\\" onClick=\\"toggleClassicalBtn('classically-controlled-1')\\">
@@ -92,7 +92,7 @@ exports[`Testing _classicalControlled nested children 1`] = `
 <g class=\\"classically-controlled-1-zero hidden\\">
 </g>
 <g class=\\"classically-controlled-1-one\\">
-<g class=\\"gate\\">
+<g class='gate'>
 <line x1=\\"180\\" x2=\\"180\\" y1=\\"40\\" y2=\\"100\\"></line>
 <circle class=\\"control-dot\\" cx=\\"180\\" cy=\\"100\\" r=\\"5\\"></circle>
 <circle class=\\"oplus\\" cx=\\"180\\" cy=\\"40\\" r=\\"15\\"></circle>
@@ -106,7 +106,7 @@ exports[`Testing _classicalControlled nested children 1`] = `
 `;
 
 exports[`Testing _classicalControlled one 'one' child 1`] = `
-"<g class=\\"classically-controlled-1-group classically-controlled-unknown\\">
+"<g class='classically-controlled-1-group classically-controlled-unknown'>
 <line class=\\"classical-line\\" x1=\\"95\\" x2=\\"120\\" y1=\\"180\\" y2=\\"180\\" stroke-dasharray=\\"8, 8\\"></line>
 <line class=\\"classical-line\\" x1=\\"95\\" x2=\\"95\\" y1=\\"175\\" y2=\\"180\\" stroke-dasharray=\\"8, 8\\"></line>
 <g class=\\"classically-controlled-btn classically-controlled-1\\" onClick=\\"toggleClassicalBtn('classically-controlled-1')\\">
@@ -116,7 +116,7 @@ exports[`Testing _classicalControlled one 'one' child 1`] = `
 <g class=\\"classically-controlled-1-zero hidden\\">
 </g>
 <g class=\\"classically-controlled-1-one\\">
-<g class=\\"gate\\">
+<g class='gate'>
 <rect class=\\"gate-unitary\\" x=\\"90\\" y=\\"20\\" width=\\"40\\" height=\\"40\\"></rect>
 <text font-size=\\"14\\" x=\\"110\\" y=\\"40\\">X</text>
 </g></g>
@@ -125,7 +125,7 @@ exports[`Testing _classicalControlled one 'one' child 1`] = `
 `;
 
 exports[`Testing _classicalControlled one 'zero' child 1`] = `
-"<g class=\\"classically-controlled-1-group classically-controlled-unknown\\">
+"<g class='classically-controlled-1-group classically-controlled-unknown'>
 <line class=\\"classical-line\\" x1=\\"95\\" x2=\\"120\\" y1=\\"180\\" y2=\\"180\\" stroke-dasharray=\\"8, 8\\"></line>
 <line class=\\"classical-line\\" x1=\\"95\\" x2=\\"95\\" y1=\\"175\\" y2=\\"180\\" stroke-dasharray=\\"8, 8\\"></line>
 <g class=\\"classically-controlled-btn classically-controlled-1\\" onClick=\\"toggleClassicalBtn('classically-controlled-1')\\">
@@ -133,7 +133,7 @@ exports[`Testing _classicalControlled one 'zero' child 1`] = `
 <text class=\\"classically-controlled-1 classically-controlled-text\\" font-size=\\"14\\" x=\\"95\\" y=\\"160\\">?</text>
 </g>
 <g class=\\"classically-controlled-1-zero hidden\\">
-<g class=\\"gate\\">
+<g class='gate'>
 <rect class=\\"gate-unitary\\" x=\\"90\\" y=\\"20\\" width=\\"40\\" height=\\"40\\"></rect>
 <text font-size=\\"14\\" x=\\"110\\" y=\\"40\\">X</text>
 </g></g>
@@ -144,7 +144,7 @@ exports[`Testing _classicalControlled one 'zero' child 1`] = `
 `;
 
 exports[`Testing _controlledGate CNOT gate 1`] = `
-"<g class=\\"gate\\">
+"<g class='gate'>
 <line x1=\\"80\\" x2=\\"80\\" y1=\\"40\\" y2=\\"100\\"></line>
 <circle class=\\"control-dot\\" cx=\\"80\\" cy=\\"40\\" r=\\"5\\"></circle>
 <circle class=\\"oplus\\" cx=\\"80\\" cy=\\"100\\" r=\\"15\\"></circle>
@@ -154,7 +154,7 @@ exports[`Testing _controlledGate CNOT gate 1`] = `
 `;
 
 exports[`Testing _controlledGate CNOT gate 2`] = `
-"<g class=\\"gate\\">
+"<g class='gate'>
 <line x1=\\"80\\" x2=\\"80\\" y1=\\"40\\" y2=\\"100\\"></line>
 <circle class=\\"control-dot\\" cx=\\"80\\" cy=\\"100\\" r=\\"5\\"></circle>
 <circle class=\\"oplus\\" cx=\\"80\\" cy=\\"40\\" r=\\"15\\"></circle>
@@ -164,7 +164,7 @@ exports[`Testing _controlledGate CNOT gate 2`] = `
 `;
 
 exports[`Testing _controlledGate Controlled U gate with 1 control + 1 target 1`] = `
-"<g class=\\"gate\\">
+"<g class='gate'>
 <line x1=\\"80\\" x2=\\"80\\" y1=\\"40\\" y2=\\"100\\"></line>
 <circle class=\\"control-dot\\" cx=\\"80\\" cy=\\"40\\" r=\\"5\\"></circle>
 <rect class=\\"gate-unitary\\" x=\\"57.5\\" y=\\"80\\" width=\\"45\\" height=\\"40\\"></rect>
@@ -173,7 +173,7 @@ exports[`Testing _controlledGate Controlled U gate with 1 control + 1 target 1`]
 `;
 
 exports[`Testing _controlledGate Controlled U gate with 1 control + 1 target 2`] = `
-"<g class=\\"gate\\">
+"<g class='gate'>
 <line x1=\\"80\\" x2=\\"80\\" y1=\\"40\\" y2=\\"100\\"></line>
 <circle class=\\"control-dot\\" cx=\\"80\\" cy=\\"100\\" r=\\"5\\"></circle>
 <rect class=\\"gate-unitary\\" x=\\"57.5\\" y=\\"20\\" width=\\"45\\" height=\\"40\\"></rect>
@@ -182,7 +182,7 @@ exports[`Testing _controlledGate Controlled U gate with 1 control + 1 target 2`]
 `;
 
 exports[`Testing _controlledGate Controlled U gate with 1 control + 2 targets 1`] = `
-"<g class=\\"gate\\">
+"<g class='gate'>
 <line x1=\\"80\\" x2=\\"80\\" y1=\\"40\\" y2=\\"160\\"></line>
 <circle class=\\"control-dot\\" cx=\\"80\\" cy=\\"160\\" r=\\"5\\"></circle>
 <rect class=\\"gate-unitary\\" x=\\"57.5\\" y=\\"20\\" width=\\"45\\" height=\\"100\\"></rect>
@@ -191,7 +191,7 @@ exports[`Testing _controlledGate Controlled U gate with 1 control + 2 targets 1`
 `;
 
 exports[`Testing _controlledGate Controlled U gate with 1 control + 2 targets 2`] = `
-"<g class=\\"gate\\">
+"<g class='gate'>
 <line x1=\\"80\\" x2=\\"80\\" y1=\\"40\\" y2=\\"160\\"></line>
 <circle class=\\"control-dot\\" cx=\\"80\\" cy=\\"40\\" r=\\"5\\"></circle>
 <rect class=\\"gate-unitary\\" x=\\"57.5\\" y=\\"80\\" width=\\"45\\" height=\\"100\\"></rect>
@@ -200,7 +200,7 @@ exports[`Testing _controlledGate Controlled U gate with 1 control + 2 targets 2`
 `;
 
 exports[`Testing _controlledGate Controlled U gate with 1 control + 2 targets 3`] = `
-"<g class=\\"gate\\">
+"<g class='gate'>
 <line x1=\\"80\\" x2=\\"80\\" y1=\\"40\\" y2=\\"160\\"></line>
 <circle class=\\"control-dot\\" cx=\\"80\\" cy=\\"100\\" r=\\"5\\"></circle>
 <rect class=\\"gate-unitary\\" x=\\"57.5\\" y=\\"20\\" width=\\"45\\" height=\\"40\\"></rect>
@@ -211,7 +211,7 @@ exports[`Testing _controlledGate Controlled U gate with 1 control + 2 targets 3`
 `;
 
 exports[`Testing _controlledGate Controlled U gate with 2 controls + 2 targets 1`] = `
-"<g class=\\"gate\\">
+"<g class='gate'>
 <line x1=\\"80\\" x2=\\"80\\" y1=\\"40\\" y2=\\"220\\"></line>
 <circle class=\\"control-dot\\" cx=\\"80\\" cy=\\"160\\" r=\\"5\\"></circle>
 <circle class=\\"control-dot\\" cx=\\"80\\" cy=\\"220\\" r=\\"5\\"></circle>
@@ -221,7 +221,7 @@ exports[`Testing _controlledGate Controlled U gate with 2 controls + 2 targets 1
 `;
 
 exports[`Testing _controlledGate Controlled U gate with 2 controls + 2 targets 2`] = `
-"<g class=\\"gate\\">
+"<g class='gate'>
 <line x1=\\"80\\" x2=\\"80\\" y1=\\"40\\" y2=\\"220\\"></line>
 <circle class=\\"control-dot\\" cx=\\"80\\" cy=\\"40\\" r=\\"5\\"></circle>
 <circle class=\\"control-dot\\" cx=\\"80\\" cy=\\"100\\" r=\\"5\\"></circle>
@@ -231,7 +231,7 @@ exports[`Testing _controlledGate Controlled U gate with 2 controls + 2 targets 2
 `;
 
 exports[`Testing _controlledGate Controlled U gate with 2 controls + 2 targets 3`] = `
-"<g class=\\"gate\\">
+"<g class='gate'>
 <line x1=\\"80\\" x2=\\"80\\" y1=\\"40\\" y2=\\"220\\"></line>
 <circle class=\\"control-dot\\" cx=\\"80\\" cy=\\"100\\" r=\\"5\\"></circle>
 <circle class=\\"control-dot\\" cx=\\"80\\" cy=\\"160\\" r=\\"5\\"></circle>
@@ -243,7 +243,7 @@ exports[`Testing _controlledGate Controlled U gate with 2 controls + 2 targets 3
 `;
 
 exports[`Testing _controlledGate Controlled U gate with 2 controls + 2 targets 4`] = `
-"<g class=\\"gate\\">
+"<g class='gate'>
 <line x1=\\"80\\" x2=\\"80\\" y1=\\"40\\" y2=\\"220\\"></line>
 <circle class=\\"control-dot\\" cx=\\"80\\" cy=\\"100\\" r=\\"5\\"></circle>
 <circle class=\\"control-dot\\" cx=\\"80\\" cy=\\"220\\" r=\\"5\\"></circle>
@@ -255,7 +255,7 @@ exports[`Testing _controlledGate Controlled U gate with 2 controls + 2 targets 4
 `;
 
 exports[`Testing _controlledGate Controlled U gate with multiple controls + 1 target 1`] = `
-"<g class=\\"gate\\">
+"<g class='gate'>
 <line x1=\\"80\\" x2=\\"80\\" y1=\\"40\\" y2=\\"160\\"></line>
 <circle class=\\"control-dot\\" cx=\\"80\\" cy=\\"40\\" r=\\"5\\"></circle>
 <circle class=\\"control-dot\\" cx=\\"80\\" cy=\\"100\\" r=\\"5\\"></circle>
@@ -265,7 +265,7 @@ exports[`Testing _controlledGate Controlled U gate with multiple controls + 1 ta
 `;
 
 exports[`Testing _controlledGate Controlled U gate with multiple controls + 1 target 2`] = `
-"<g class=\\"gate\\">
+"<g class='gate'>
 <line x1=\\"80\\" x2=\\"80\\" y1=\\"40\\" y2=\\"160\\"></line>
 <circle class=\\"control-dot\\" cx=\\"80\\" cy=\\"100\\" r=\\"5\\"></circle>
 <circle class=\\"control-dot\\" cx=\\"80\\" cy=\\"160\\" r=\\"5\\"></circle>
@@ -275,7 +275,7 @@ exports[`Testing _controlledGate Controlled U gate with multiple controls + 1 ta
 `;
 
 exports[`Testing _controlledGate Controlled U gate with multiple controls + 1 target 3`] = `
-"<g class=\\"gate\\">
+"<g class='gate'>
 <line x1=\\"80\\" x2=\\"80\\" y1=\\"40\\" y2=\\"160\\"></line>
 <circle class=\\"control-dot\\" cx=\\"80\\" cy=\\"40\\" r=\\"5\\"></circle>
 <circle class=\\"control-dot\\" cx=\\"80\\" cy=\\"160\\" r=\\"5\\"></circle>
@@ -285,7 +285,7 @@ exports[`Testing _controlledGate Controlled U gate with multiple controls + 1 ta
 `;
 
 exports[`Testing _controlledGate SWAP gate 1`] = `
-"<g class=\\"gate\\">
+"<g class='gate'>
 <line x1=\\"80\\" x2=\\"80\\" y1=\\"40\\" y2=\\"160\\"></line>
 <circle class=\\"control-dot\\" cx=\\"80\\" cy=\\"40\\" r=\\"5\\"></circle>
 <line x1=\\"72\\" x2=\\"88\\" y1=\\"92\\" y2=\\"108\\"></line>
@@ -296,7 +296,7 @@ exports[`Testing _controlledGate SWAP gate 1`] = `
 `;
 
 exports[`Testing _controlledGate SWAP gate 2`] = `
-"<g class=\\"gate\\">
+"<g class='gate'>
 <line x1=\\"80\\" x2=\\"80\\" y1=\\"40\\" y2=\\"160\\"></line>
 <circle class=\\"control-dot\\" cx=\\"80\\" cy=\\"160\\" r=\\"5\\"></circle>
 <line x1=\\"72\\" x2=\\"88\\" y1=\\"32\\" y2=\\"48\\"></line>
@@ -307,7 +307,7 @@ exports[`Testing _controlledGate SWAP gate 2`] = `
 `;
 
 exports[`Testing _controlledGate SWAP gate 3`] = `
-"<g class=\\"gate\\">
+"<g class='gate'>
 <line x1=\\"80\\" x2=\\"80\\" y1=\\"40\\" y2=\\"160\\"></line>
 <circle class=\\"control-dot\\" cx=\\"80\\" cy=\\"100\\" r=\\"5\\"></circle>
 <line x1=\\"72\\" x2=\\"88\\" y1=\\"32\\" y2=\\"48\\"></line>
@@ -318,7 +318,7 @@ exports[`Testing _controlledGate SWAP gate 3`] = `
 `;
 
 exports[`Testing _formatGate CNOT gate 1`] = `
-"<g class=\\"gate\\">
+"<g class='gate'>
 <line x1=\\"80\\" x2=\\"80\\" y1=\\"40\\" y2=\\"100\\"></line>
 <circle class=\\"control-dot\\" cx=\\"80\\" cy=\\"40\\" r=\\"5\\"></circle>
 <circle class=\\"oplus\\" cx=\\"80\\" cy=\\"100\\" r=\\"15\\"></circle>
@@ -328,7 +328,7 @@ exports[`Testing _formatGate CNOT gate 1`] = `
 `;
 
 exports[`Testing _formatGate classically controlled gate 1`] = `
-"<g class=\\"classically-controlled-group classically-controlled-unknown\\">
+"<g class='classically-controlled-group classically-controlled-unknown'>
 <line class=\\"classical-line\\" x1=\\"95\\" x2=\\"120\\" y1=\\"180\\" y2=\\"180\\" stroke-dasharray=\\"8, 8\\"></line>
 <line class=\\"classical-line\\" x1=\\"95\\" x2=\\"95\\" y1=\\"175\\" y2=\\"180\\" stroke-dasharray=\\"8, 8\\"></line>
 <g class=\\"classically-controlled-btn classically-controlled\\" onClick=\\"toggleClassicalBtn('classically-controlled')\\">
@@ -344,7 +344,7 @@ exports[`Testing _formatGate classically controlled gate 1`] = `
 `;
 
 exports[`Testing _formatGate controlled swap gate 1`] = `
-"<g class=\\"gate\\">
+"<g class='gate'>
 <line x1=\\"80\\" x2=\\"80\\" y1=\\"40\\" y2=\\"160\\"></line>
 <circle class=\\"control-dot\\" cx=\\"80\\" cy=\\"40\\" r=\\"5\\"></circle>
 <line x1=\\"72\\" x2=\\"88\\" y1=\\"92\\" y2=\\"108\\"></line>
@@ -355,7 +355,7 @@ exports[`Testing _formatGate controlled swap gate 1`] = `
 `;
 
 exports[`Testing _formatGate controlled unitary gate 1`] = `
-"<g class=\\"gate\\">
+"<g class='gate'>
 <line x1=\\"80\\" x2=\\"80\\" y1=\\"40\\" y2=\\"100\\"></line>
 <circle class=\\"control-dot\\" cx=\\"80\\" cy=\\"40\\" r=\\"5\\"></circle>
 <rect class=\\"gate-unitary\\" x=\\"60\\" y=\\"80\\" width=\\"40\\" height=\\"40\\"></rect>
@@ -364,7 +364,7 @@ exports[`Testing _formatGate controlled unitary gate 1`] = `
 `;
 
 exports[`Testing _formatGate controlled unitary gate with arguments 1`] = `
-"<g class=\\"gate\\">
+"<g class='gate'>
 <line x1=\\"80\\" x2=\\"80\\" y1=\\"40\\" y2=\\"100\\"></line>
 <circle class=\\"control-dot\\" cx=\\"80\\" cy=\\"40\\" r=\\"5\\"></circle>
 <rect class=\\"gate-unitary\\" x=\\"41.5\\" y=\\"80\\" width=\\"77\\" height=\\"40\\"></rect>
@@ -373,8 +373,15 @@ exports[`Testing _formatGate controlled unitary gate with arguments 1`] = `
 </g>"
 `;
 
+exports[`Testing _formatGate gate with metadata 1`] = `
+"<g class='gate' data-metadata='{\\"a\\":1,\\"b\\":2}'>
+<rect class=\\"gate-unitary\\" x=\\"60\\" y=\\"20\\" width=\\"40\\" height=\\"40\\"></rect>
+<text font-size=\\"14\\" x=\\"80\\" y=\\"40\\">H</text>
+</g>"
+`;
+
 exports[`Testing _formatGate measure gate 1`] = `
-"<g class=\\"gate\\">
+"<g class='gate'>
 <rect class=\\"gate-measure\\" x=\\"60\\" y=\\"20\\" width=\\"40\\" height=\\"40\\"></rect>
 <path class=\\"arc-measure\\" d=\\"M 95 42 A 15 12 0 0 0 65 42\\"></path>
 <line x1=\\"80\\" x2=\\"92\\" y1=\\"48\\" y2=\\"28\\"></line>
@@ -382,14 +389,14 @@ exports[`Testing _formatGate measure gate 1`] = `
 `;
 
 exports[`Testing _formatGate multi-qubit unitary gate 1`] = `
-"<g class=\\"gate\\">
+"<g class='gate'>
 <rect class=\\"gate-unitary\\" x=\\"60\\" y=\\"20\\" width=\\"40\\" height=\\"100\\"></rect>
 <text font-size=\\"14\\" x=\\"80\\" y=\\"70\\">U</text>
 </g>"
 `;
 
 exports[`Testing _formatGate multi-qubit unitary gate with arguments 1`] = `
-"<g class=\\"gate\\">
+"<g class='gate'>
 <line x1=\\"80\\" x2=\\"80\\" y1=\\"40\\" y2=\\"100\\"></line>
 <rect class=\\"gate-unitary\\" x=\\"41.5\\" y=\\"20\\" width=\\"77\\" height=\\"100\\"></rect>
 <text font-size=\\"14\\" x=\\"80\\" y=\\"63\\">U</text>
@@ -398,14 +405,14 @@ exports[`Testing _formatGate multi-qubit unitary gate with arguments 1`] = `
 `;
 
 exports[`Testing _formatGate single-qubit unitary gate 1`] = `
-"<g class=\\"gate\\">
+"<g class='gate'>
 <rect class=\\"gate-unitary\\" x=\\"60\\" y=\\"20\\" width=\\"40\\" height=\\"40\\"></rect>
 <text font-size=\\"14\\" x=\\"80\\" y=\\"40\\">H</text>
 </g>"
 `;
 
 exports[`Testing _formatGate single-qubit unitary gate with arguments 1`] = `
-"<g class=\\"gate\\">
+"<g class='gate'>
 <rect class=\\"gate-unitary\\" x=\\"54\\" y=\\"20\\" width=\\"52\\" height=\\"40\\"></rect>
 <text font-size=\\"14\\" x=\\"80\\" y=\\"33\\">Ry</text>
 <text font-size=\\"12\\" x=\\"80\\" y=\\"48\\">(0.25)</text>
@@ -413,7 +420,7 @@ exports[`Testing _formatGate single-qubit unitary gate with arguments 1`] = `
 `;
 
 exports[`Testing _formatGate swap gate 1`] = `
-"<g class=\\"gate\\">
+"<g class='gate'>
 <line x1=\\"72\\" x2=\\"88\\" y1=\\"32\\" y2=\\"48\\"></line>
 <line x1=\\"72\\" x2=\\"88\\" y1=\\"48\\" y2=\\"32\\"></line>,<line x1=\\"72\\" x2=\\"88\\" y1=\\"92\\" y2=\\"108\\"></line>
 <line x1=\\"72\\" x2=\\"88\\" y1=\\"108\\" y2=\\"92\\"></line>
@@ -519,24 +526,24 @@ exports[`Testing _unitary Single qubit unitary 1`] = `
 `;
 
 exports[`Testing formatGates Multiple gates 1`] = `
-"<g class=\\"gate\\">
+"<g class='gate'>
 <line x1=\\"80\\" x2=\\"80\\" y1=\\"40\\" y2=\\"100\\"></line>
 <circle class=\\"control-dot\\" cx=\\"80\\" cy=\\"100\\" r=\\"5\\"></circle>
 <circle class=\\"oplus\\" cx=\\"80\\" cy=\\"40\\" r=\\"15\\"></circle>
 <line x1=\\"80\\" x2=\\"80\\" y1=\\"25\\" y2=\\"55\\"></line>
 <line x1=\\"65\\" x2=\\"95\\" y1=\\"40\\" y2=\\"40\\"></line>
 </g>
-<g class=\\"gate\\">
+<g class='gate'>
 <line x1=\\"80\\" x2=\\"80\\" y1=\\"100\\" y2=\\"160\\"></line>
 <circle class=\\"control-dot\\" cx=\\"80\\" cy=\\"100\\" r=\\"5\\"></circle>
 <rect class=\\"gate-unitary\\" x=\\"60\\" y=\\"140\\" width=\\"40\\" height=\\"40\\"></rect>
 <text font-size=\\"14\\" x=\\"80\\" y=\\"160\\">X</text>
 </g>
-<g class=\\"gate\\">
+<g class='gate'>
 <rect class=\\"gate-unitary\\" x=\\"60\\" y=\\"140\\" width=\\"40\\" height=\\"40\\"></rect>
 <text font-size=\\"14\\" x=\\"80\\" y=\\"160\\">X</text>
 </g>
-<g class=\\"gate\\">
+<g class='gate'>
 <rect class=\\"gate-measure\\" x=\\"60\\" y=\\"20\\" width=\\"40\\" height=\\"40\\"></rect>
 <path class=\\"arc-measure\\" d=\\"M 95 42 A 15 12 0 0 0 65 42\\"></path>
 <line x1=\\"80\\" x2=\\"92\\" y1=\\"48\\" y2=\\"28\\"></line>
@@ -544,7 +551,7 @@ exports[`Testing formatGates Multiple gates 1`] = `
 `;
 
 exports[`Testing formatGates Single gate 1`] = `
-"<g class=\\"gate\\">
+"<g class='gate'>
 <line x1=\\"80\\" x2=\\"80\\" y1=\\"40\\" y2=\\"100\\"></line>
 <circle class=\\"control-dot\\" cx=\\"80\\" cy=\\"40\\" r=\\"5\\"></circle>
 <circle class=\\"oplus\\" cx=\\"80\\" cy=\\"100\\" r=\\"15\\"></circle>

--- a/src/Kernel/client/__tests__/ExecutionPathVisualizerTests/gateFormatter.test.ts
+++ b/src/Kernel/client/__tests__/ExecutionPathVisualizerTests/gateFormatter.test.ts
@@ -1,6 +1,7 @@
 import {
     formatGates,
     _formatGate,
+    _createGate,
     _measure,
     _unitary,
     _swap,
@@ -422,6 +423,22 @@ describe('Testing _measure', () => {
     });
 });
 
+describe('Testing _createGate', () => {
+    test('No metadata', () => {
+        expect(_createGate(['<line />'])).toEqual("<g class='gate'>\n<line />\n</g>");
+    });
+    test('With metadata', () => {
+        expect(_createGate(['<line />'], { a: 1, b: 2 })).toEqual(
+            `<g class='gate' data-metadata='{"a":1,"b":2}'>\n<line />\n</g>`,
+        );
+    });
+    test('With metadata containing string', () => {
+        expect(_createGate(['<line />'], { foo: 'bar' })).toEqual(
+            `<g class='gate' data-metadata='{"foo":"bar"}'>\n<line />\n</g>`,
+        );
+    });
+});
+
 describe('Testing _formatGate', () => {
     test('measure gate', () => {
         const metadata: Metadata = {
@@ -468,7 +485,6 @@ describe('Testing _formatGate', () => {
         };
         expect(_formatGate(metadata)).toMatchSnapshot();
     });
-
     test('multi-qubit unitary gate with arguments', () => {
         const metadata: Metadata = {
             type: GateType.ControlledUnitary,
@@ -548,7 +564,19 @@ describe('Testing _formatGate', () => {
         };
         expect(_formatGate(metadata)).toMatchSnapshot();
     });
-    test('Invalid gate', () => {
+    test('gate with metadata', () => {
+        const metadata: Metadata = {
+            type: GateType.Unitary,
+            x: startX,
+            controlsY: [],
+            targetsY: [startY],
+            label: 'H',
+            width: minGateWidth,
+            customMetadata: { a: 1, b: 2 },
+        };
+        expect(_formatGate(metadata)).toMatchSnapshot();
+    });
+    test('invalid gate', () => {
         const metadata: Metadata = {
             type: GateType.Invalid,
             x: startX,

--- a/src/Kernel/client/__tests__/ExecutionPathVisualizerTests/inputFormatter.test.ts
+++ b/src/Kernel/client/__tests__/ExecutionPathVisualizerTests/inputFormatter.test.ts
@@ -1,4 +1,4 @@
-import { Qubit } from '../../ExecutionPathVisualizer/executionPath';
+import { Qubit } from '../../ExecutionPathVisualizer/circuit';
 import { RegisterMap, RegisterType } from '../../ExecutionPathVisualizer/register';
 import { formatInputs, _qubitInput } from '../../ExecutionPathVisualizer/formatters/inputFormatter';
 import { startY, registerHeight, classicalRegHeight } from '../../ExecutionPathVisualizer/constants';

--- a/src/Kernel/client/__tests__/ExecutionPathVisualizerTests/process.test.ts
+++ b/src/Kernel/client/__tests__/ExecutionPathVisualizerTests/process.test.ts
@@ -1,4 +1,4 @@
-import { Operation } from '../../ExecutionPathVisualizer/executionPath';
+import { Operation } from '../../ExecutionPathVisualizer/circuit';
 import { RegisterMap, RegisterType, Register } from '../../ExecutionPathVisualizer/register';
 import { Metadata } from '../../ExecutionPathVisualizer/metadata';
 import {

--- a/src/Kernel/client/__tests__/ExecutionPathVisualizerTests/utils.test.ts
+++ b/src/Kernel/client/__tests__/ExecutionPathVisualizerTests/utils.test.ts
@@ -1,5 +1,10 @@
-import { getGateWidth, _getStringWidth } from '../../ExecutionPathVisualizer/utils';
+import { getGateWidth, _getStringWidth, createUUID } from '../../ExecutionPathVisualizer/utils';
 import { GateType, minGateWidth, labelPadding } from '../../ExecutionPathVisualizer/constants';
+
+describe('Testing createUUID', () => {
+    test('no x in uuid', () => expect(createUUID()).not.toContain('x'));
+    test('no y in uuid', () => expect(createUUID()).not.toContain('y'));
+});
 
 describe('Testing getGateWidth', () => {
     test('measure gate', () =>

--- a/src/Kernel/client/kernel.ts
+++ b/src/Kernel/client/kernel.ts
@@ -8,7 +8,7 @@ import { IPython } from "./ipython";
 declare var IPython: IPython;
 
 import { Telemetry, ClientInfo } from "./telemetry.js";
-import { executionPathToHtml, ExecutionPath, StyleConfig, STYLES } from "./ExecutionPathVisualizer";
+import { circuitToHtml, Circuit, StyleConfig, STYLES } from "./ExecutionPathVisualizer";
 
 function defineQSharpMode() {
     console.log("Loading IQ# kernel-specific extension...");
@@ -237,9 +237,9 @@ class Kernel {
         IPython.notebook.kernel.register_iopub_handler(
             "render_execution_path",
             message => {
-                const { executionPath, id, style }: { executionPath: ExecutionPath, id: string, style: string } = message.content;
+                const { executionPath, id, style }: { executionPath: Circuit, id: string, style: string } = message.content;
                 const userStyleConfig: StyleConfig = STYLES[style] || {};
-                const html: string = executionPathToHtml(executionPath, userStyleConfig);
+                const html: string = circuitToHtml(executionPath, userStyleConfig);
                 const container: HTMLElement = document.getElementById(id);
                 if (container == null) throw new Error(`Div with ID ${id} not found.`);
                 container.innerHTML = html;


### PR DESCRIPTION
This PR is another set of changes working towards extending the functionality of this visualizer and generalizing the use case of the library. Towards that goal, this PR includes the following changes:

1. Rename `ExecutionPath` to `Circuit`. This visualizer does not deal with or needs to know that the input given to it is an execution path of a program. It takes an input some list of qubits and operations and then outputs their visualization. In this sense, the library is just a circuit visualizer to which we pass in an execution path to render as a circuit.
2. Allow users to pass in custom metadata to each `Operation` to be added on as a data attribute on the operation's visualization.
3. Add UUID to SVG to distinguish between multiple visualizations in the same browser.