### PR TITLE
Add telemetry datapoints for projects and namespaces

### DIFF
--- a/src/Core/Snippets/ISnippets.cs
+++ b/src/Core/Snippets/ISnippets.cs
@@ -13,10 +13,11 @@ namespace Microsoft.Quantum.IQSharp
     /// </summary>
     public class SnippetCompiledEventArgs : EventArgs
     {
-        public SnippetCompiledEventArgs(string status, string[] errors, TimeSpan duration)
+        public SnippetCompiledEventArgs(string status, string[] errors, string[] namespaces, TimeSpan duration)
         {
             this.Status = status;
             this.Errors = errors;
+            this.Namespaces = namespaces;
             this.Duration = duration;
         }
 
@@ -29,6 +30,11 @@ namespace Microsoft.Quantum.IQSharp
         /// The list of error ids reported by the Q# parser (if any).
         /// </summary>
         public string[] Errors { get; }
+
+        /// <summary>
+        /// The list of namespaces opened automatically when compiling the snippet.
+        /// </summary>
+        public string[] Namespaces { get; }
 
         /// <summary>
         /// The total time the reload operation took.

--- a/src/Core/Snippets/Snippets.cs
+++ b/src/Core/Snippets/Snippets.cs
@@ -191,7 +191,7 @@ namespace Microsoft.Quantum.IQSharp
                 duration.Stop();
                 var status = logger.HasErrors ? "error" : "ok";
                 var errorIds = logger.ErrorIds .ToArray();
-                SnippetCompiled?.Invoke(this, new SnippetCompiledEventArgs(status, errorIds, duration.Elapsed));
+                SnippetCompiled?.Invoke(this, new SnippetCompiledEventArgs(status, errorIds, Compiler.AutoOpenNamespaces.Keys.ToArray(), duration.Elapsed));
             }
         }
 

--- a/src/Core/Workspace/IWorkspace.cs
+++ b/src/Core/Workspace/IWorkspace.cs
@@ -13,11 +13,12 @@ namespace Microsoft.Quantum.IQSharp
     /// </summary>
     public class ReloadedEventArgs : EventArgs
     {
-        public ReloadedEventArgs(string workspace, string status, int filecount, string[] errors, TimeSpan duration)
+        public ReloadedEventArgs(string workspace, string status, int fileCount, int projectCount, string[] errors, TimeSpan duration)
         {
             this.Workspace = workspace;
             this.Status = status;
-            this.FileCount = filecount;
+            this.FileCount = fileCount;
+            this.ProjectCount = projectCount;
             this.Errors = errors;
             this.Duration = duration;
         }
@@ -38,6 +39,11 @@ namespace Microsoft.Quantum.IQSharp
         public int FileCount { get; }
 
         /// <summary>
+        /// The number of projects used for compilation.
+        /// </summary>
+        public int ProjectCount { get; }
+
+        /// <summary>
         /// The list of error ids reported by the Q# parser (if any).
         /// </summary>
         public string[] Errors { get; }
@@ -55,9 +61,14 @@ namespace Microsoft.Quantum.IQSharp
     public interface IWorkspace
     {
         /// <summary>
-        /// This event is triggered when ever the workspace is reloaded.
+        /// This event is triggered whenever the workspace is reloaded.
         /// </summary>
         event EventHandler<ReloadedEventArgs> Reloaded;
+
+        /// <summary>
+        /// This event is triggered whenever a project is loaded into the workspace.
+        /// </summary>
+        event EventHandler<ProjectLoadedEventArgs> ProjectLoaded;
 
         /// <summary>
         /// The root folder.

--- a/src/Core/Workspace/Project.cs
+++ b/src/Core/Workspace/Project.cs
@@ -38,6 +38,46 @@ namespace Microsoft.Quantum.IQSharp
     }
 
     /// <summary>
+    /// List of arguments that are part of the project loaded event.
+    /// </summary>
+    public class ProjectLoadedEventArgs : EventArgs
+    {
+        public ProjectLoadedEventArgs(Uri? projectUri, int sourceFileCount, int projectReferenceCount, int packageReferenceCount, TimeSpan duration)
+        {
+            this.ProjectUri = projectUri;
+            this.SourceFileCount = sourceFileCount;
+            this.ProjectReferenceCount = projectReferenceCount;
+            this.PackageReferenceCount = packageReferenceCount;
+            this.Duration = duration;
+        }
+
+        /// <summary>
+        /// The location of the project file.
+        /// </summary>
+        public Uri? ProjectUri { get; }
+
+        /// <summary>
+        /// The number of source files to be compiled for this project.
+        /// </summary>
+        public int SourceFileCount { get; }
+
+        /// <summary>
+        /// The number of project references identified for this project.
+        /// </summary>
+        public int ProjectReferenceCount { get; }
+
+        /// <summary>
+        /// The number of package references identified for this project.
+        /// </summary>
+        public int PackageReferenceCount { get; }
+
+        /// <summary>
+        /// The total time the project load operation took.
+        /// </summary>
+        public TimeSpan Duration { get; }
+    }
+
+    /// <summary>
     /// Represents a Q# project referenced by a <see cref="Workspace"/>.
     /// 
     /// May be associated with a .csproj file on disk, in which case it will be associated

--- a/src/Core/Workspace/Project.cs
+++ b/src/Core/Workspace/Project.cs
@@ -42,12 +42,13 @@ namespace Microsoft.Quantum.IQSharp
     /// </summary>
     public class ProjectLoadedEventArgs : EventArgs
     {
-        public ProjectLoadedEventArgs(Uri? projectUri, int sourceFileCount, int projectReferenceCount, int packageReferenceCount, TimeSpan duration)
+        public ProjectLoadedEventArgs(Uri? projectUri, int sourceFileCount, int projectReferenceCount, int packageReferenceCount, bool userAdded, TimeSpan duration)
         {
             this.ProjectUri = projectUri;
             this.SourceFileCount = sourceFileCount;
             this.ProjectReferenceCount = projectReferenceCount;
             this.PackageReferenceCount = packageReferenceCount;
+            this.UserAdded = userAdded;
             this.Duration = duration;
         }
 
@@ -70,6 +71,11 @@ namespace Microsoft.Quantum.IQSharp
         /// The number of package references identified for this project.
         /// </summary>
         public int PackageReferenceCount { get; }
+
+        /// <summary>
+        /// Whether this project was explicitly added by a user vs. loaded implicitly.
+        /// </summary>
+        public bool UserAdded { get; }
 
         /// <summary>
         /// The total time the project load operation took.

--- a/src/Core/Workspace/Workspace.cs
+++ b/src/Core/Workspace/Workspace.cs
@@ -495,9 +495,10 @@ namespace Microsoft.Quantum.IQSharp
             {
                 duration.Stop();
                 var status = this.HasErrors ? "error" : "ok";
+                var projectCount = Projects.Count(project => !string.IsNullOrWhiteSpace(project.ProjectFile));
 
                 Logger?.LogInformation($"Reloading complete ({status}).");
-                Reloaded?.Invoke(this, new ReloadedEventArgs(Root, status, fileCount, Projects.Count(), errorIds.ToArray(), duration.Elapsed));
+                Reloaded?.Invoke(this, new ReloadedEventArgs(Root, status, fileCount, projectCount, errorIds.ToArray(), duration.Elapsed));
             }
         }
     }

--- a/src/Core/Workspace/Workspace.cs
+++ b/src/Core/Workspace/Workspace.cs
@@ -486,6 +486,7 @@ namespace Microsoft.Quantum.IQSharp
                             project.SourceFiles.Count(),
                             project.ProjectReferences.Count(),
                             project.PackageReferences.Count(),
+                            UserAddedProjects.Contains(project, new ProjectFileComparer()),
                             projectLoadDuration.Elapsed));
                     }
                 }

--- a/src/Core/Workspace/Workspace.cs
+++ b/src/Core/Workspace/Workspace.cs
@@ -479,12 +479,15 @@ namespace Microsoft.Quantum.IQSharp
                         project.AssemblyInfo = new AssemblyInfo(null, null, null);
                     }
 
-                    ProjectLoaded?.Invoke(this, new ProjectLoadedEventArgs(
-                        new Uri(project.ProjectFile),
-                        project.SourceFiles.Count(),
-                        project.ProjectReferences.Count(),
-                        project.PackageReferences.Count(),
-                        projectLoadDuration.Elapsed));
+                    if (!string.IsNullOrWhiteSpace(project.ProjectFile))
+                    {
+                        ProjectLoaded?.Invoke(this, new ProjectLoadedEventArgs(
+                            new Uri(project.ProjectFile),
+                            project.SourceFiles.Count(),
+                            project.ProjectReferences.Count(),
+                            project.PackageReferences.Count(),
+                            projectLoadDuration.Elapsed));
+                    }
                 }
 
             }

--- a/src/Tests/TelemetryTests.cs
+++ b/src/Tests/TelemetryTests.cs
@@ -77,6 +77,8 @@ namespace Tests.IQSharp
             Assert.AreEqual("Workspace", logger.Events[0].Properties["Quantum.IQSharp.Workspace"]);
             Assert.AreEqual("ok", logger.Events[0].Properties["Quantum.IQSharp.Status"]);
             Assert.AreEqual("", logger.Events[0].Properties["Quantum.IQSharp.Errors"]);
+            Assert.AreEqual(2L, logger.Events[0].Properties["Quantum.IQSharp.FileCount"]);
+            Assert.AreEqual(0L, logger.Events[0].Properties["Quantum.IQSharp.ProjectCount"]);
         }
 
         [TestMethod]
@@ -98,6 +100,8 @@ namespace Tests.IQSharp
             Assert.AreEqual("Workspace.Broken", logger.Events[0].Properties["Quantum.IQSharp.Workspace"]);
             Assert.AreEqual("error", logger.Events[0].Properties["Quantum.IQSharp.Status"]);
             Assert.IsTrue(logger.Events[0].Properties["Quantum.IQSharp.Errors"].ToString().StartsWith("QS"));
+            Assert.AreEqual(2L, logger.Events[0].Properties["Quantum.IQSharp.FileCount"]);
+            Assert.AreEqual(0L, logger.Events[0].Properties["Quantum.IQSharp.ProjectCount"]);
         }
 
         [TestMethod]
@@ -146,6 +150,19 @@ namespace Tests.IQSharp
             Assert.AreEqual("Quantum.IQSharp.Compile", logger.Events[count].Name);
             Assert.AreEqual("ok", logger.Events[count].Properties["Quantum.IQSharp.Status"]);
             Assert.AreEqual("", logger.Events[0].Properties["Quantum.IQSharp.Errors"]);
+
+            Assert.AreEqual(
+                "Microsoft.Quantum.Canon,Microsoft.Quantum.Intrinsic",
+                logger.Events[count].Properties["Quantum.IQSharp.Namespaces"]);
+
+            count++;
+            snippets.Compile(SNIPPETS.OpenNamespaces2);
+
+            Assert.AreEqual("ok", logger.Events[count].Properties["Quantum.IQSharp.Status"]);
+            Assert.AreEqual("", logger.Events[0].Properties["Quantum.IQSharp.Errors"]);
+            Assert.AreEqual(
+                "Microsoft.Quantum.Canon,Microsoft.Quantum.Diagnostics,Microsoft.Quantum.Intrinsic,Tests.qss",
+                logger.Events[count].Properties["Quantum.IQSharp.Namespaces"]);
         }
 
         [TestMethod]
@@ -171,6 +188,55 @@ namespace Tests.IQSharp
             Assert.AreEqual("Quantum.IQSharp.PackageLoad", logger.Events[0].Name);
             Assert.AreEqual("Microsoft.Quantum.Standard", logger.Events[0].Properties["Quantum.IQSharp.PackageId"]);
             Assert.IsTrue(!string.IsNullOrWhiteSpace(logger.Events[0].Properties["Quantum.IQSharp.PackageVersion"]?.ToString()));
+        }
+
+        [TestMethod]
+        public void LoadProjects()
+        {
+            var workspace = "Workspace.ProjectReferences";
+            var services = Startup.CreateServiceProvider(workspace);
+            var logger = GetAppLogger(services);
+
+            var ws = services.GetService<IWorkspace>();
+
+            logger.Events.Clear();
+            Assert.AreEqual(0, logger.Events.Count);
+
+            ws.Reload();
+            Assert.AreEqual(5, logger.Events.Count);
+
+            Assert.AreEqual("Quantum.IQSharp.PackageLoad", logger.Events[0].Name);
+            Assert.IsTrue(logger.Events[0].Properties["Quantum.IQSharp.PackageId"].ToString().StartsWith("Microsoft.Quantum.Xunit"));
+            Assert.IsTrue(!string.IsNullOrWhiteSpace(logger.Events[0].Properties["Quantum.IQSharp.PackageVersion"]?.ToString()));
+
+            Assert.AreEqual("Quantum.IQSharp.ProjectLoad", logger.Events[1].Name);
+            Assert.AreEqual(PiiKind.Uri, logger.Events[1].PiiProperties["Quantum.IQSharp.ProjectUri"]);
+            Assert.IsTrue(logger.Events[1].Properties["Quantum.IQSharp.ProjectUri"].ToString().Contains("ProjectB.csproj"));
+            Assert.AreEqual(1L, logger.Events[1].Properties["Quantum.IQSharp.SourceFileCount"]);
+            Assert.AreEqual(0L, logger.Events[1].Properties["Quantum.IQSharp.ProjectReferenceCount"]);
+            Assert.AreEqual(0L, logger.Events[1].Properties["Quantum.IQSharp.PackageReferenceCount"]);
+
+            Assert.AreEqual("Quantum.IQSharp.ProjectLoad", logger.Events[2].Name);
+            Assert.AreEqual(PiiKind.Uri, logger.Events[2].PiiProperties["Quantum.IQSharp.ProjectUri"]);
+            Assert.IsTrue(logger.Events[2].Properties["Quantum.IQSharp.ProjectUri"].ToString().Contains("ProjectA.csproj"));
+            Assert.AreEqual(1L, logger.Events[2].Properties["Quantum.IQSharp.SourceFileCount"]);
+            Assert.AreEqual(1L, logger.Events[2].Properties["Quantum.IQSharp.ProjectReferenceCount"]);
+            Assert.AreEqual(0L, logger.Events[2].Properties["Quantum.IQSharp.PackageReferenceCount"]);
+
+            Assert.AreEqual("Quantum.IQSharp.ProjectLoad", logger.Events[3].Name);
+            Assert.AreEqual(PiiKind.Uri, logger.Events[3].PiiProperties["Quantum.IQSharp.ProjectUri"]);
+            Assert.IsTrue(logger.Events[3].Properties["Quantum.IQSharp.ProjectUri"].ToString().Contains("Workspace.ProjectReferences.csproj"));
+            Assert.AreEqual(1L, logger.Events[3].Properties["Quantum.IQSharp.SourceFileCount"]);
+            Assert.AreEqual(3L, logger.Events[3].Properties["Quantum.IQSharp.ProjectReferenceCount"]);
+            Assert.AreEqual(1L, logger.Events[3].Properties["Quantum.IQSharp.PackageReferenceCount"]);
+
+            Assert.AreEqual("Quantum.IQSharp.WorkspaceReload", logger.Events[4].Name);
+            Assert.AreEqual(PiiKind.GenericData, logger.Events[4].PiiProperties["Quantum.IQSharp.Workspace"]);
+            Assert.AreEqual("Workspace.ProjectReferences", logger.Events[4].Properties["Quantum.IQSharp.Workspace"]);
+            Assert.AreEqual("ok", logger.Events[4].Properties["Quantum.IQSharp.Status"]);
+            Assert.AreEqual("", logger.Events[4].Properties["Quantum.IQSharp.Errors"]);
+            Assert.AreEqual(3L, logger.Events[4].Properties["Quantum.IQSharp.FileCount"]);
+            Assert.AreEqual(3L, logger.Events[4].Properties["Quantum.IQSharp.ProjectCount"]);
         }
 
         [TestMethod]

--- a/src/Tests/TelemetryTests.cs
+++ b/src/Tests/TelemetryTests.cs
@@ -150,18 +150,18 @@ namespace Tests.IQSharp
             Assert.AreEqual("Quantum.IQSharp.Compile", logger.Events[count].Name);
             Assert.AreEqual("ok", logger.Events[count].Properties["Quantum.IQSharp.Status"]);
             Assert.AreEqual("", logger.Events[0].Properties["Quantum.IQSharp.Errors"]);
-
             Assert.AreEqual(
                 "Microsoft.Quantum.Canon,Microsoft.Quantum.Intrinsic",
                 logger.Events[count].Properties["Quantum.IQSharp.Namespaces"]);
 
             count++;
             snippets.Compile(SNIPPETS.OpenNamespaces2);
-
+            Assert.AreEqual(count + 1, logger.Events.Count);
+            Assert.AreEqual("Quantum.IQSharp.Compile", logger.Events[count].Name);
             Assert.AreEqual("ok", logger.Events[count].Properties["Quantum.IQSharp.Status"]);
             Assert.AreEqual("", logger.Events[0].Properties["Quantum.IQSharp.Errors"]);
             Assert.AreEqual(
-                "Microsoft.Quantum.Canon,Microsoft.Quantum.Diagnostics,Microsoft.Quantum.Intrinsic,Tests.qss",
+                "Microsoft.Quantum.Canon,Microsoft.Quantum.Diagnostics,Microsoft.Quantum.Intrinsic",
                 logger.Events[count].Properties["Quantum.IQSharp.Namespaces"]);
         }
 
@@ -215,6 +215,7 @@ namespace Tests.IQSharp
             Assert.AreEqual(1L, logger.Events[1].Properties["Quantum.IQSharp.SourceFileCount"]);
             Assert.AreEqual(0L, logger.Events[1].Properties["Quantum.IQSharp.ProjectReferenceCount"]);
             Assert.AreEqual(0L, logger.Events[1].Properties["Quantum.IQSharp.PackageReferenceCount"]);
+            Assert.AreEqual(false, logger.Events[1].Properties["Quantum.IQSharp.UserAdded"]);
 
             Assert.AreEqual("Quantum.IQSharp.ProjectLoad", logger.Events[2].Name);
             Assert.AreEqual(PiiKind.Uri, logger.Events[2].PiiProperties["Quantum.IQSharp.ProjectUri"]);
@@ -222,6 +223,7 @@ namespace Tests.IQSharp
             Assert.AreEqual(1L, logger.Events[2].Properties["Quantum.IQSharp.SourceFileCount"]);
             Assert.AreEqual(1L, logger.Events[2].Properties["Quantum.IQSharp.ProjectReferenceCount"]);
             Assert.AreEqual(0L, logger.Events[2].Properties["Quantum.IQSharp.PackageReferenceCount"]);
+            Assert.AreEqual(false, logger.Events[2].Properties["Quantum.IQSharp.UserAdded"]);
 
             Assert.AreEqual("Quantum.IQSharp.ProjectLoad", logger.Events[3].Name);
             Assert.AreEqual(PiiKind.Uri, logger.Events[3].PiiProperties["Quantum.IQSharp.ProjectUri"]);
@@ -229,6 +231,7 @@ namespace Tests.IQSharp
             Assert.AreEqual(1L, logger.Events[3].Properties["Quantum.IQSharp.SourceFileCount"]);
             Assert.AreEqual(3L, logger.Events[3].Properties["Quantum.IQSharp.ProjectReferenceCount"]);
             Assert.AreEqual(1L, logger.Events[3].Properties["Quantum.IQSharp.PackageReferenceCount"]);
+            Assert.AreEqual(false, logger.Events[3].Properties["Quantum.IQSharp.UserAdded"]);
 
             Assert.AreEqual("Quantum.IQSharp.WorkspaceReload", logger.Events[4].Name);
             Assert.AreEqual(PiiKind.GenericData, logger.Events[4].PiiProperties["Quantum.IQSharp.Workspace"]);

--- a/src/Tool/Telemetry.cs
+++ b/src/Tool/Telemetry.cs
@@ -64,7 +64,10 @@ namespace Microsoft.Quantum.IQSharp
             eventService.OnServiceInitialized<ISnippets>().On += (snippets) =>
                 snippets.SnippetCompiled += (_, info) => TelemetryLogger.LogEvent(info.AsTelemetryEvent());
             eventService.OnServiceInitialized<IWorkspace>().On += (workspace) =>
+            {
                 workspace.Reloaded += (_, info) => TelemetryLogger.LogEvent(info.AsTelemetryEvent());
+                workspace.ProjectLoaded += (_, info) => TelemetryLogger.LogEvent(info.AsTelemetryEvent());
+            };
             eventService.OnServiceInitialized<IReferences>().On += (references) =>
                 references.PackageLoaded += (_, info) => TelemetryLogger.LogEvent(info.AsTelemetryEvent());
             eventService.OnServiceInitialized<IExecutionEngine>().On += (executionEngine) =>
@@ -166,6 +169,7 @@ namespace Microsoft.Quantum.IQSharp
             evt.SetProperty("Workspace".WithTelemetryNamespace(), Path.GetFileName(info.Workspace), PiiKind.GenericData);
             evt.SetProperty("Status".WithTelemetryNamespace(), info.Status);
             evt.SetProperty("FileCount".WithTelemetryNamespace(), info.FileCount);
+            evt.SetProperty("ProjectCount".WithTelemetryNamespace(), info.ProjectCount);
             evt.SetProperty("Errors".WithTelemetryNamespace(), string.Join(",", info.Errors?.OrderBy(e => e) ?? Enumerable.Empty<string>()));
             evt.SetProperty("Duration".WithTelemetryNamespace(), info.Duration.ToString());
 
@@ -178,6 +182,7 @@ namespace Microsoft.Quantum.IQSharp
 
             evt.SetProperty("Status".WithTelemetryNamespace(), info.Status);
             evt.SetProperty("Errors".WithTelemetryNamespace(), string.Join(",", info.Errors?.OrderBy(e => e) ?? Enumerable.Empty<string>()));
+            evt.SetProperty("Namespaces".WithTelemetryNamespace(), string.Join(",", info.Namespaces?.OrderBy(n => n) ?? Enumerable.Empty<string>()));
             evt.SetProperty("Duration".WithTelemetryNamespace(), info.Duration.ToString());
 
             return evt;
@@ -189,6 +194,19 @@ namespace Microsoft.Quantum.IQSharp
 
             evt.SetProperty("PackageId".WithTelemetryNamespace(), info.PackageId);
             evt.SetProperty("PackageVersion".WithTelemetryNamespace(), info.PackageVersion);
+            evt.SetProperty("Duration".WithTelemetryNamespace(), info.Duration.ToString());
+
+            return evt;
+        }
+
+        public static EventProperties AsTelemetryEvent(this ProjectLoadedEventArgs info)
+        {
+            var evt = new EventProperties() { Name = "ProjectLoad".WithTelemetryNamespace() };
+
+            evt.SetProperty("ProjectUri".WithTelemetryNamespace(), info.ProjectUri?.ToString(), PiiKind.Uri);
+            evt.SetProperty("SourceFileCount".WithTelemetryNamespace(), info.SourceFileCount);
+            evt.SetProperty("ProjectReferenceCount".WithTelemetryNamespace(), info.ProjectReferenceCount);
+            evt.SetProperty("PackageReferenceCount".WithTelemetryNamespace(), info.PackageReferenceCount);
             evt.SetProperty("Duration".WithTelemetryNamespace(), info.Duration.ToString());
 
             return evt;

--- a/src/Tool/Telemetry.cs
+++ b/src/Tool/Telemetry.cs
@@ -182,7 +182,8 @@ namespace Microsoft.Quantum.IQSharp
 
             evt.SetProperty("Status".WithTelemetryNamespace(), info.Status);
             evt.SetProperty("Errors".WithTelemetryNamespace(), string.Join(",", info.Errors?.OrderBy(e => e) ?? Enumerable.Empty<string>()));
-            evt.SetProperty("Namespaces".WithTelemetryNamespace(), string.Join(",", info.Namespaces?.OrderBy(n => n) ?? Enumerable.Empty<string>()));
+            evt.SetProperty("Namespaces".WithTelemetryNamespace(),
+                string.Join(",", info.Namespaces?.Where(n => n.StartsWith("Microsoft.Quantum.")).OrderBy(n => n) ?? Enumerable.Empty<string>()));
             evt.SetProperty("Duration".WithTelemetryNamespace(), info.Duration.ToString());
 
             return evt;
@@ -192,7 +193,8 @@ namespace Microsoft.Quantum.IQSharp
         {
             var evt = new EventProperties() { Name = "PackageLoad".WithTelemetryNamespace() };
 
-            evt.SetProperty("PackageId".WithTelemetryNamespace(), info.PackageId);
+            evt.SetProperty("PackageId".WithTelemetryNamespace(),
+                info.PackageId.StartsWith("Microsoft.Quantum.") ? info.PackageId : "other package");
             evt.SetProperty("PackageVersion".WithTelemetryNamespace(), info.PackageVersion);
             evt.SetProperty("Duration".WithTelemetryNamespace(), info.Duration.ToString());
 
@@ -207,6 +209,7 @@ namespace Microsoft.Quantum.IQSharp
             evt.SetProperty("SourceFileCount".WithTelemetryNamespace(), info.SourceFileCount);
             evt.SetProperty("ProjectReferenceCount".WithTelemetryNamespace(), info.ProjectReferenceCount);
             evt.SetProperty("PackageReferenceCount".WithTelemetryNamespace(), info.PackageReferenceCount);
+            evt.SetProperty("UserAdded".WithTelemetryNamespace(), info.UserAdded);
             evt.SetProperty("Duration".WithTelemetryNamespace(), info.Duration.ToString());
 
             return evt;


### PR DESCRIPTION
This PR adds the following datapoints for collection through the existing telemetry pipeline:

- List of opened namespaces (as part of existing `SnippetCompiled` event)
- Count of loaded projects (as part of existing `WorkspaceReloaded` event)
- New `ProjectLoaded` event, triggered when compiling a project, which contains:
   - Project identifier (based on the project file path, which will be treated as PII)
   - Count of source files
   - Count of project references
   - Count of package references
   - Elapsed time while compiling the project