### PR TITLE
Fix stackoverflow error for %trace

### DIFF
--- a/images/iqsharp-base/Dockerfile
+++ b/images/iqsharp-base/Dockerfile
@@ -109,7 +109,7 @@ ENV PATH=$PATH:${HOME}/dotnet:${HOME}/.dotnet/tools \
 # Install IQ# and the project templates, using the NuGet packages from the
 # build context.
 ARG IQSHARP_VERSION
-RUN dotnet new -i "Microsoft.Quantum.ProjectTemplates::0.12.20073008-beta" && \
+RUN dotnet new -i "Microsoft.Quantum.ProjectTemplates::0.12.20081729-beta" && \
     dotnet tool install \
            --global \
            Microsoft.Quantum.IQSharp \

--- a/src/AzureClient/AzureClient.csproj
+++ b/src/AzureClient/AzureClient.csproj
@@ -13,7 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Quantum.Client" Version="0.12.20073008-beta" />
+    <PackageReference Include="Microsoft.Azure.Quantum.Client" Version="0.12.20081729-beta" />
     <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.21" />
     <PackageReference Include="Microsoft.Rest.ClientRuntime.Azure" Version="3.3.19" />
     <PackageReference Include="System.Reactive" Version="4.3.2" />

--- a/src/Core/Core.csproj
+++ b/src/Core/Core.csproj
@@ -38,9 +38,9 @@
     <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="3.0.0" />
-    <PackageReference Include="Microsoft.Quantum.Compiler" Version="0.12.20073008-beta" />
-    <PackageReference Include="Microsoft.Quantum.CsharpGeneration" Version="0.12.20073008-beta" />
-    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.12.20073008-beta" />
+    <PackageReference Include="Microsoft.Quantum.Compiler" Version="0.12.20081729-beta" />
+    <PackageReference Include="Microsoft.Quantum.CsharpGeneration" Version="0.12.20081729-beta" />
+    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.12.20081729-beta" />
     <PackageReference Include="NuGet.Resolver" Version="5.1.0" />
     <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
   </ItemGroup>

--- a/src/ExecutionPathTracer/ExecutionPathTracer.csproj
+++ b/src/ExecutionPathTracer/ExecutionPathTracer.csproj
@@ -28,7 +28,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.12.20073008-beta" />
+    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.12.20081729-beta" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MockLibraries/Mock.Chemistry/Mock.Chemistry.csproj
+++ b/src/MockLibraries/Mock.Chemistry/Mock.Chemistry.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.12.20073008-beta">
+<Project Sdk="Microsoft.Quantum.Sdk/0.12.20081729-beta">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
@@ -6,6 +6,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.12.20073008-beta" />
+    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.12.20081729-beta" />
   </ItemGroup>
 </Project>

--- a/src/MockLibraries/Mock.Standard/Mock.Standard.csproj
+++ b/src/MockLibraries/Mock.Standard/Mock.Standard.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.12.20073008-beta">
+<Project Sdk="Microsoft.Quantum.Sdk/0.12.20081729-beta">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
@@ -6,6 +6,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.12.20073008-beta" />
+    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.12.20081729-beta" />
   </ItemGroup>
 </Project>

--- a/src/Tests/ExecutionPathTracerTests.cs
+++ b/src/Tests/ExecutionPathTracerTests.cs
@@ -489,6 +489,23 @@ namespace Tests.IQSharp
         }
 
         [TestMethod]
+        public void WithQArrayArgsTest()
+        {
+            var path = GetExecutionPath("WithQArrayArgsCirc");
+            var qubits = new QubitDeclaration[] { };
+            var operations = new Operation[]
+            {
+                new Operation()
+                {
+                    Gate = "WithQArrayArgs",
+                    DisplayArgs = "([False, True])",
+                },
+            };
+            var expected = new ExecutionPath(qubits, operations);
+            Assert.AreEqual(expected.ToJson(), path.ToJson());
+        }
+
+        [TestMethod]
         public void OperationArgsTest()
         {
             var path = GetExecutionPath("OperationArgsCirc");

--- a/src/Tests/Workspace.ExecutionPathTracer/Circuits.qs
+++ b/src/Tests/Workspace.ExecutionPathTracer/Circuits.qs
@@ -7,8 +7,7 @@ namespace Tests.ExecutionPathTracer {
 
     // Custom operation
     operation Foo(theta : Double, (qubit : Qubit, bar : String)) : Unit
-    is Adj + Ctl {
-    }
+    is Adj + Ctl { }
 
     operation FooCirc() : Unit {
         using (q = Qubit()) {
@@ -35,15 +34,19 @@ namespace Tests.ExecutionPathTracer {
         }
     }
 
-    operation NoQubitCirc(n : Int) : Unit {
-    }
+    operation NoQubitCirc(n : Int) : Unit { }
 
     operation NoQubitArgsCirc() : Unit {
         NoQubitCirc(2);
     }
 
-    operation OperationCirc(op : (Qubit => Unit), n : Int) : Unit {
+    operation WithQArrayArgs(bits: Bool[]): Unit { }
+
+    operation WithQArrayArgsCirc(): Unit {
+        WithQArrayArgs([false, true]);
     }
+
+    operation OperationCirc(op : (Qubit => Unit), n : Int) : Unit { }
 
     operation OperationArgsCirc() : Unit {
         OperationCirc(H, 5);
@@ -78,8 +81,7 @@ namespace Tests.ExecutionPathTracer {
     }
 
     operation Bar((alpha : Double, beta : Double), (q : Qubit, name : String)) : Unit
-    is Adj + Ctl {
-    }
+    is Adj + Ctl { }
 
     operation BigCirc() : Unit {
         using (qs = Qubit[3]) {
@@ -94,5 +96,5 @@ namespace Tests.ExecutionPathTracer {
             ResetAll(qs);
         }
     }
-    
+
 }

--- a/src/Tool/appsettings.json
+++ b/src/Tool/appsettings.json
@@ -6,25 +6,25 @@
     },
     "AllowedHosts": "*",
   "DefaultPackageVersions": [
-    "Microsoft.Quantum.Compiler::0.12.20073008-beta",
+    "Microsoft.Quantum.Compiler::0.12.20081729-beta",
 
-    "Microsoft.Quantum.CsharpGeneration::0.12.20073008-beta",
-    "Microsoft.Quantum.Development.Kit::0.12.20073008-beta",
-    "Microsoft.Quantum.Simulators::0.12.20073008-beta",
-    "Microsoft.Quantum.Xunit::0.12.20073008-beta",
+    "Microsoft.Quantum.CsharpGeneration::0.12.20081729-beta",
+    "Microsoft.Quantum.Development.Kit::0.12.20081729-beta",
+    "Microsoft.Quantum.Simulators::0.12.20081729-beta",
+    "Microsoft.Quantum.Xunit::0.12.20081729-beta",
 
-    "Microsoft.Quantum.Standard::0.12.20073008-beta",
-    "Microsoft.Quantum.Chemistry::0.12.20073008-beta",
-    "Microsoft.Quantum.Chemistry.Jupyter::0.12.20073008-beta",
-    "Microsoft.Quantum.MachineLearning::0.12.20073008-beta",
-    "Microsoft.Quantum.Numerics::0.12.20073008-beta",
+    "Microsoft.Quantum.Standard::0.12.20081729-beta",
+    "Microsoft.Quantum.Chemistry::0.12.20081729-beta",
+    "Microsoft.Quantum.Chemistry.Jupyter::0.12.20081729-beta",
+    "Microsoft.Quantum.MachineLearning::0.12.20081729-beta",
+    "Microsoft.Quantum.Numerics::0.12.20081729-beta",
 
-    "Microsoft.Quantum.Katas::0.12.20073008-beta",
+    "Microsoft.Quantum.Katas::0.12.20081729-beta",
 
-    "Microsoft.Quantum.Research::0.12.20073008-beta",
+    "Microsoft.Quantum.Research::0.12.20081729-beta",
 
-    "Microsoft.Quantum.Providers.IonQ::0.12.20073008-beta",
-    "Microsoft.Quantum.Providers.Honeywell::0.12.20073008-beta",
-    "Microsoft.Quantum.Providers.QCI::0.12.20073008-beta"
+    "Microsoft.Quantum.Providers.IonQ::0.12.20081729-beta",
+    "Microsoft.Quantum.Providers.Honeywell::0.12.20081729-beta",
+    "Microsoft.Quantum.Providers.QCI::0.12.20081729-beta"
   ]
 }


### PR DESCRIPTION
This PR fixes the stackoverflow error that occurs when an operation has an argument of type `QArray`. Specifically, it brings in the fix that was merged in to `qsharp-runtime` in [this PR](https://github.com/microsoft/qsharp-runtime/pull/341).

This PR fixes #270.