### PR TITLE
Properly handle npm install or test errors in CI

### DIFF
--- a/build/build.ps1
+++ b/build/build.ps1
@@ -36,6 +36,7 @@ Push-Location (Join-Path $PSScriptRoot ../src/Kernel)
         $ErrorActionPreference = 'Continue'
         npm install 2>&1 | ForEach-Object { "$_" }
     } Catch {
+        Write-Host $Error[0]
         Write-Host "##vso[task.logissue type=error;]Failed to install npm dependencies."
         $script:all_ok = $False
     } Finally {

--- a/build/build.ps1
+++ b/build/build.ps1
@@ -29,9 +29,22 @@ function Build-One {
 # Fetch TypeScript definitions
 Push-Location (Join-Path $PSScriptRoot ../src/Kernel)
     Try {
-        npm install
+        # npm install writes some output to stderr, which causes PowerShell to throw
+        # unless $ErrorActionPreference is set to 'Continue'.
+        # We also redirect stderr output to stdout to prevent an exception being incorrectly thrown.
+        $OldPreference = $ErrorActionPreference;
+        $ErrorActionPreference = 'Continue'
+        npm install 2>&1 | ForEach-Object { "$_" }
     } Catch {
         Write-Host "##vso[task.logissue type=error;]Failed to install npm dependencies."
+        $script:all_ok = $False
+    } Finally {
+        $ErrorActionPreference = $OldPreference
+    }
+
+    if ($LastExitCode -ne 0) {
+        Write-Host "##vso[task.logissue type=error;]Failed to install npm dependencies."
+        $script:all_ok = $False
     }
 Pop-Location
 

--- a/build/test.ps1
+++ b/build/test.ps1
@@ -82,36 +82,29 @@ function Test-Python {
 function Test-JavaScript {
     Param([string] $packageFolder, [string] $options)
 
-    Write-Host "##[info]Installing JS packages from $packageFolder"
     Push-Location (Join-Path $PSScriptRoot $packageFolder)
-        Try {
-            npm install
-        } Catch {
-            Write-Host $Error[0]
-            Write-Host "##vso[task.logissue type=warning;]Failed to install npm dependencies."
-        }
-    Pop-Location
+    Try {
+        # npm test writes some output to stderr, which causes PowerShell to throw
+        # unless $ErrorActionPreference is set to 'Continue'.
+        # We also redirect stderr output to stdout to prevent an exception being incorrectly thrown.
+        $OldPreference = $ErrorActionPreference;
+        $ErrorActionPreference = 'Continue'
+        Write-Host "##[info]Installing JS packages from $packageFolder"
+        npm install 2>&1 | ForEach-Object { "$_" }
 
-    Write-Host "##[info]Testing JS inside $packageFolder"    
-    Push-Location (Join-Path $PSScriptRoot $packageFolder)
-        Try {
-            # npm test writes some output to stderr, which causes PowerShell to throw
-            # unless $ErrorActionPreference is set to 'Continue'.
-            # We also redirect stderr output to stdout to prevent an exception being incorrectly thrown.
-            $OldPreference = $ErrorActionPreference;
-            $ErrorActionPreference = 'Continue'
-            if (!$options) {
-                npm test 2>&1 | ForEach-Object { "$_" }
-            } else {
-                npm test -- $options 2>&1 | ForEach-Object { "$_" }
-            }
-        } Catch {
-            Write-Host $Error[0]
-            Write-Host "##vso[task.logissue type=error;]Failed to test JS inside $packageFolder"
-            $script:all_ok = $False
-        } Finally {
-            $ErrorActionPreference = $OldPreference
+        Write-Host "##[info]Testing JS inside $packageFolder"
+        if (!$options) {
+            npm test 2>&1 | ForEach-Object { "$_" }
+        } else {
+            npm test -- $options 2>&1 | ForEach-Object { "$_" }
         }
+    } Catch {
+        Write-Host $Error[0]
+        Write-Host "##vso[task.logissue type=error;]Failed to test JS inside $packageFolder"
+        $script:all_ok = $False
+    } Finally {
+        $ErrorActionPreference = $OldPreference
+    }
     Pop-Location
 
     if ($LastExitCode -ne 0) {


### PR DESCRIPTION
Instead of catching and ignoring all errors in `npm install` and `npm test`, this PR properly redirects the errors to stdout in the PowerShell script and allows the code to continue, only reporting an error if the installation or tests did indeed fail (rather than just something being output to stderr).

This fix uses the same workaround as is used here: 
https://github.com/microsoft/iqsharp/blob/cb821411572f266c0d4c9f842cd014e6beb7def8/build/pack-conda.ps1#L31-L47

Using this PR to test impact on CI. I also have an end-to-end QDK build running to ensure that the CI passes there also.