### PR TITLE
Improve ExecutionPathTracer test speed

### DIFF
--- a/src/Tests/ExecutionPathTracerTests.cs
+++ b/src/Tests/ExecutionPathTracerTests.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+#nullable enable
+
 using System.Collections.Generic;
 using System.Linq;
 
@@ -13,6 +15,7 @@ namespace Tests.IQSharp
 {
     public class ExecutionPathTracerTests
     {
+        IEnumerable<OperationInfo>? operations = null;
         public Workspace InitWorkspace()
         {
             var ws = Startup.Create<Workspace>("Workspace.ExecutionPathTracer");
@@ -24,8 +27,13 @@ namespace Tests.IQSharp
 
         public ExecutionPath GetExecutionPath(string name, int depth = 1)
         {
-            var ws = InitWorkspace();
-            var op = ws.AssemblyInfo.Operations.SingleOrDefault(o => o.FullName == $"Tests.ExecutionPathTracer.{name}");
+            if (this.operations == null)
+            {
+                var ws = InitWorkspace();
+                this.operations = ws.AssemblyInfo.Operations;
+            }
+
+            var op = this.operations.SingleOrDefault(o => o.FullName == $"Tests.ExecutionPathTracer.{name}");
             Assert.IsNotNull(op);
 
             var tracer = new ExecutionPathTracer(depth);


### PR DESCRIPTION
No one likes waiting 10 years for a test suite to complete, impacting their iteration speed in their development process.

I must admit I have been contributing to that through the ExecutionPathTracer test suite I wrote. But, here's my chance to right my wrongs (at least by a small but noticeable amount). ♻️

This PR cuts the ExecutionPathTracer suite's test time by ~13.2% (or ~24 seconds) locally. 