### PR TITLE
Add support for IQSharpLoadAutomatically property

### DIFF
--- a/src/Core/Workspace/Project.cs
+++ b/src/Core/Workspace/Project.cs
@@ -230,7 +230,7 @@ namespace Microsoft.Quantum.IQSharp
                 return defaultProject;
             }
 
-            var defaultShouldAutoLoad = false; // REL0920: Change this default value in the future and update messaging below.
+            var defaultShouldAutoLoad = false; // REL1220: Change this default value in the future and update messaging below.
             var autoLoadProjects = projects.Where(project => project.ShouldAutoLoad.GetValueOrDefault(defaultShouldAutoLoad));
             if (autoLoadProjects.Count() != 1)
             {

--- a/src/Core/Workspace/Workspace.cs
+++ b/src/Core/Workspace/Workspace.cs
@@ -185,7 +185,7 @@ namespace Microsoft.Quantum.IQSharp
 
         private void ResolveProjectReferences()
         {
-            var projects = new List<Project>() { Project.FromWorkspaceFolder(Root, CacheFolder, SkipAutoLoadProject) };
+            var projects = new List<Project>() { Project.FromWorkspaceFolder(Root, CacheFolder, SkipAutoLoadProject, Logger) };
             projects.AddRange(UserAddedProjects);
 
             var projectsToResolve = projects.Distinct(new ProjectFileComparer()).ToList();

--- a/src/Tests/Workspace.ProjectReferences.ProjectB/ProjectB.csproj
+++ b/src/Tests/Workspace.ProjectReferences.ProjectB/ProjectB.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
     <IncludeQsharpCorePackages>false</IncludeQsharpCorePackages>    <!-- otherwise the standard library is included by the Sdk -->
+    <IQSharpLoadAutomatically>false</IQSharpLoadAutomatically>
   </PropertyGroup>
 
 </Project>

--- a/src/Tests/Workspace.ProjectReferences/Workspace.ProjectReferences.csproj
+++ b/src/Tests/Workspace.ProjectReferences/Workspace.ProjectReferences.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
     <IncludeQsharpCorePackages>false</IncludeQsharpCorePackages>    <!-- otherwise the standard library is included by the Sdk -->
+    <IQSharpLoadAutomatically>true</IQSharpLoadAutomatically>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Tests/WorkspaceTests.cs
+++ b/src/Tests/WorkspaceTests.cs
@@ -71,6 +71,8 @@ namespace Tests.IQSharp
         [TestMethod]
         public void ProjectReferencesWorkspace()
         {
+            // Loading this workspace should succeed and automatically pull in the referenced projects
+            // Workspace.ProjectReferences.ProjectA and Workspace.ProjectReferences.ProjectB.
             var ws = Startup.Create<Workspace>("Workspace.ProjectReferences");
             ws.Reload();
             Assert.IsFalse(ws.HasErrors, string.Join(Environment.NewLine, ws.ErrorMessages));
@@ -78,6 +80,7 @@ namespace Tests.IQSharp
             var operations = ws.Projects.SelectMany(p => p.AssemblyInfo?.Operations);
             Assert.IsTrue(operations.Where(o => o.FullName == "Tests.ProjectReferences.MeasureSingleQubit").Any());
             Assert.IsTrue(operations.Where(o => o.FullName == "Tests.ProjectReferences.ProjectA.RotateAndMeasure").Any());
+            Assert.IsTrue(operations.Where(o => o.FullName == "Tests.ProjectReferences.ProjectB.RotateAndMeasure").Any());
         }
 
         [TestMethod]
@@ -90,7 +93,7 @@ namespace Tests.IQSharp
             Assert.IsTrue(ws.HasErrors);
 
             // Loading this workspace should succeed, and its Q# operations should be available, but the .csproj
-            // reference should not be loaded because the .csproj does not specify <IQSharpLoadAutomatically>.
+            // reference should not be loaded because the .csproj specifies <IQSharpLoadAutomatically> as false.
             ws = Startup.Create<Workspace>("Workspace.ProjectReferences.ProjectB");
             ws.Reload();
             Assert.IsFalse(ws.HasErrors, string.Join(Environment.NewLine, ws.ErrorMessages));

--- a/src/Tests/WorkspaceTests.cs
+++ b/src/Tests/WorkspaceTests.cs
@@ -81,6 +81,26 @@ namespace Tests.IQSharp
         }
 
         [TestMethod]
+        public void ProjectReferencesWorkspaceNoAutoLoad()
+        {
+            // Loading this workspace should fail because the .csproj does not specify <IQSharpLoadAutomatically>,
+            // which prevents the code that depends on Workspace.ProjectReferences.ProjectB from compiling correctly.
+            var ws = Startup.Create<Workspace>("Workspace.ProjectReferences.ProjectA");
+            ws.Reload();
+            Assert.IsTrue(ws.HasErrors);
+
+            // Loading this workspace should succeed, and its Q# operations should be available, but the .csproj
+            // reference should not be loaded because the .csproj does not specify <IQSharpLoadAutomatically>.
+            ws = Startup.Create<Workspace>("Workspace.ProjectReferences.ProjectB");
+            ws.Reload();
+            Assert.IsFalse(ws.HasErrors, string.Join(Environment.NewLine, ws.ErrorMessages));
+            Assert.IsTrue(ws.Projects.Count() == 1);
+            Assert.IsTrue(string.IsNullOrEmpty(ws.Projects.First().ProjectFile));
+            var operations = ws.Projects.SelectMany(p => p.AssemblyInfo?.Operations);
+            Assert.IsTrue(operations.Where(o => o.FullName == "Tests.ProjectReferences.ProjectB.RotateAndMeasure").Any());
+        }
+
+        [TestMethod]
         public void ManuallyAddProjects()
         {
             var ws = Startup.Create<Workspace>("Workspace");


### PR DESCRIPTION
This PR disables the new `.csproj` auto-load feature by default. Instead, we will look for an `<IQSharpLoadAutomatically>` property in the `.csproj`, and only load the `.csproj` during workspace reload if that property is set to `true`.

Logging is also included to emit warnings that the default behavior may change in the future.