### PR TITLE
WIP: Use semantic version as identifier of Docker IQSharp images instead of build number

### DIFF
--- a/build/pack-docs.ps1
+++ b/build/pack-docs.ps1
@@ -30,7 +30,7 @@ if ("$Env:BUILD_RELEASETYPE" -eq "release") {
 # easily inject the right base image into the FROM line. In doing so,
 # the build context should include the build_docs.py script that we need.
 $dockerfile = @"
-FROM ${Env:DOCKER_PREFIX}iqsharp-base:${Env:BUILD_BUILDNUMBER}
+FROM ${Env:DOCKER_PREFIX}iqsharp-base:${Env:SEMVER_VERSION}
 
 USER root
 RUN pip install click ruamel.yaml

--- a/build/pack.ps1
+++ b/build/pack.ps1
@@ -87,8 +87,8 @@ function Pack-Image() {
         --build-arg EXTRA_NUGET_PACKAGES="" `
         <# Next, we tell Docker what version of IQ# to install. #> `
         --build-arg IQSHARP_VERSION=$Env:NUGET_VERSION `
-        <# Finally, we tag the image with the current build number. #> `
-        -t "${Env:DOCKER_PREFIX}${RepoName}:${Env:BUILD_BUILDNUMBER}"
+        <# Finally, we tag the image with the current semantic version number. #> `
+        -t "${Env:DOCKER_PREFIX}${RepoName}:${Env:SEMVER_VERSION}"
 
     if  ($LastExitCode -ne 0) {
         Write-Host "##vso[task.logissue type=error;]Failed to create docker image for $Dockerfile."


### PR DESCRIPTION
This change intends to add consistency in the version numbers used for different components of the QDK.

Using the semantic version is better aligned with the names of the SDK, the NuGet packages and the VS Code extension.
