### PR TITLE
Fix typo causing doc generation error

### DIFF
--- a/src/Python/qsharp-core/qsharp/azure.py
+++ b/src/Python/qsharp-core/qsharp/azure.py
@@ -28,7 +28,7 @@ __all__ = [
     'execute',
     'status',
     'output',
-    'jobs'
+    'jobs',
     'AzureTarget',
     'AzureJob',
     'AzureError'


### PR DESCRIPTION
This PR fixes a small typo that was causing an error in the Python API doc generation pipeline.