### PR TITLE
Specify version of iqsharp docs as a parameter

### DIFF
--- a/build/pack-docs.ps1
+++ b/build/pack-docs.ps1
@@ -8,7 +8,7 @@
 #>
 
 param(
-    [string] $Version
+    [string] $DockerImageTag
 );
 
 $ErrorActionPreference = 'Stop';
@@ -30,7 +30,7 @@ if ("$Env:BUILD_RELEASETYPE" -eq "release") {
 # easily inject the right base image into the FROM line. In doing so,
 # the build context should include the build_docs.py script that we need.
 $dockerfile = @"
-FROM ${Env:DOCKER_PREFIX}iqsharp-base:$Version
+FROM ${Env:DOCKER_PREFIX}iqsharp-base:$DockerImageTag
 
 USER root
 RUN pip install click ruamel.yaml

--- a/build/pack-docs.ps1
+++ b/build/pack-docs.ps1
@@ -8,7 +8,7 @@
 #>
 
 param(
-
+    [string] $Version
 );
 
 $ErrorActionPreference = 'Stop';
@@ -30,7 +30,7 @@ if ("$Env:BUILD_RELEASETYPE" -eq "release") {
 # easily inject the right base image into the FROM line. In doing so,
 # the build context should include the build_docs.py script that we need.
 $dockerfile = @"
-FROM ${Env:DOCKER_PREFIX}iqsharp-base:${Env:BUILD_BUILDNUMBER}
+FROM ${Env:DOCKER_PREFIX}iqsharp-base:$Version
 
 USER root
 RUN pip install click ruamel.yaml

--- a/build/pack.ps1
+++ b/build/pack.ps1
@@ -130,5 +130,5 @@ if (-not $runDocker -or ($Env:ENABLE_PYTHON -eq "false")) {
     Write-Host "##vso[task.logissue type=warning;]Skipping IQ# magic command documentation, either ENABLE_DOCKER or ENABLE_PYTHON was false.";
 } else {
     Write-Host "##[info]Packing IQ# reference docs..."
-    & (Join-Path $PSScriptRoot "pack-docs.ps1");
+    & (Join-Path $PSScriptRoot "pack-docs.ps1") -Version ${Env:BUILD_BUILDNUMBER};
 }

--- a/build/pack.ps1
+++ b/build/pack.ps1
@@ -130,5 +130,5 @@ if (-not $runDocker -or ($Env:ENABLE_PYTHON -eq "false")) {
     Write-Host "##vso[task.logissue type=warning;]Skipping IQ# magic command documentation, either ENABLE_DOCKER or ENABLE_PYTHON was false.";
 } else {
     Write-Host "##[info]Packing IQ# reference docs..."
-    & (Join-Path $PSScriptRoot "pack-docs.ps1") -Version ${Env:BUILD_BUILDNUMBER};
+    & (Join-Path $PSScriptRoot "pack-docs.ps1") -DockerImageTag ${Env:BUILD_BUILDNUMBER};
 }


### PR DESCRIPTION
The pack-docs script is shared by the CI build of this repository as well as the QDK internal build.

However, we're using different version formats in those builds. With this change, the version string is specified as a parameter so each build system can provide the expected version string.