### PR TITLE
Add newline before closing snippets namespace

### DIFF
--- a/src/Core/Compiler/CompilerService.cs
+++ b/src/Core/Compiler/CompilerService.cs
@@ -181,7 +181,7 @@ namespace Microsoft.Quantum.IQSharp
                     : $"open {entry.Key} as {entry.Value};"
                 ));
             string WrapInNamespace(Snippet s) =>
-                $"namespace {Snippets.SNIPPETS_NAMESPACE} {{ {openStatements}\n{s.code} }}";
+                $"namespace {Snippets.SNIPPETS_NAMESPACE} {{ {openStatements}\n{s.code}\n}}";
 
             var sources = snippets.ToImmutableDictionary(s => s.Uri, WrapInNamespace);
 

--- a/src/Tests/SNIPPETS.cs
+++ b/src/Tests/SNIPPETS.cs
@@ -94,6 +94,15 @@ namespace Tests.IQSharp
     }
 ";
 
+        public static string Op7_EndsWithComment =
+@"
+    operation Op7() : Unit
+    {
+        HelloQ();
+    } // This snippet ends with a comment";
+
+        public static string CommentOnly = @"// This snippet contains only a comment";
+
         public static string OpenNamespaces1 =
 @"
     open Microsoft.Quantum.Intrinsic;

--- a/src/Tests/SnippetsControllerTests.cs
+++ b/src/Tests/SnippetsControllerTests.cs
@@ -155,6 +155,10 @@ namespace Tests.IQSharp
             // Compile snippet with operations out of alphabetical order to ensure order is preserved:
             await AssertCompile(controller, SNIPPETS.Op6b_Op6a, "Op6b", "Op6a");
 
+            // Compile snippets that end with comments:
+            await AssertCompile(controller, SNIPPETS.CommentOnly);
+            await AssertCompile(controller, SNIPPETS.Op7_EndsWithComment, "Op7");
+
             // running Op2:
             await AssertSimulate(controller, "Op2", "Hello from quantum world!");
         }


### PR DESCRIPTION
This fixes #294, in which compilation of a snippet fails if the snippet ends with a comment. The closing brace of the automatically-generated snippets namespace was being appended to the final line of the snippet code, rather than on its own line.