### PR TITLE
Wait for package load to complete during workspace load

### DIFF
--- a/src/Core/Workspace/Workspace.cs
+++ b/src/Core/Workspace/Workspace.cs
@@ -359,7 +359,7 @@ namespace Microsoft.Quantum.IQSharp
                             GlobalReferences.AddPackage(package, (newStatus) =>
                             {
                                 statusCallback?.Invoke($"Adding package {package}: {newStatus}");
-                            });
+                            }).Wait();
                         }
                         catch (Exception e)
                         {


### PR DESCRIPTION
This change ensures that IQ# workspace load (or reload) waits for all packages referenced by project references to be fully loaded. This corrects a timing issue where the IQ# kernel was reporting itself as ready before required packages had finished loading.

This makes the package loading behavior here consistent with other places in IQ# that load packages. All of these places use either `await` or `Wait()` to ensure that the package loading completes before proceeding.

See https://github.com/microsoft/QuantumKatas/pull/475 for background and more discussion of this issue.