### PR TITLE
Handle NuGet package loading errors if resolved version number is missing

### DIFF
--- a/src/Core/References/NugetPackages.cs
+++ b/src/Core/References/NugetPackages.cs
@@ -420,7 +420,7 @@ namespace Microsoft.Quantum.IQSharp
                 return resolver.Resolve(resolverContext, CancellationToken.None)
                         .Select(p => dependencies.Single(x => PackageIdentityComparer.Default.Equals(x, p)));
             }
-            catch (NuGetResolverConstraintException exception)
+            catch (Exception exception)
             {
                 Logger.LogWarning($"Exception caught when resolving package dependencies: {exception.Message}");
             }

--- a/src/Core/References/NugetPackages.cs
+++ b/src/Core/References/NugetPackages.cs
@@ -420,7 +420,7 @@ namespace Microsoft.Quantum.IQSharp
                 return resolver.Resolve(resolverContext, CancellationToken.None)
                         .Select(p => dependencies.Single(x => PackageIdentityComparer.Default.Equals(x, p)));
             }
-            catch (Exception exception)
+            catch (NuGetResolverConstraintException exception)
             {
                 Logger.LogWarning($"Exception caught when resolving package dependencies: {exception.Message}");
             }

--- a/src/Core/References/References.cs
+++ b/src/Core/References/References.cs
@@ -158,7 +158,7 @@ namespace Microsoft.Quantum.IQSharp
             AddAssemblies(Nugets.Assemblies.ToArray());
 
             duration.Stop();
-            PackageLoaded?.Invoke(this, new PackageLoadedEventArgs(pkg.Id, pkg.Version.ToNormalizedString(), duration.Elapsed));
+            PackageLoaded?.Invoke(this, new PackageLoadedEventArgs(pkg.Id, pkg.Version?.ToNormalizedString() ?? string.Empty, duration.Elapsed));
         }
 
         private void Reset()


### PR DESCRIPTION
This PR handles an edge case that may occur during package load if the resolved NuGet package identity does not have a version number specified. Fixes #237.