### PR TITLE
Use default version for packages from .csproj

### DIFF
--- a/src/Core/References/INugetPackages.cs
+++ b/src/Core/References/INugetPackages.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Threading.Tasks;
 using NuGet.Packaging.Core;
+using NuGet.Versioning;
 
 namespace Microsoft.Quantum.IQSharp
 {
@@ -23,6 +24,13 @@ namespace Microsoft.Quantum.IQSharp
         /// List of Assemblies from current Packages.
         /// </summary>
         IEnumerable<AssemblyInfo> Assemblies { get; }
+        
+        /// <summary>
+        /// Keeps track of what package version to use for certain packages specified in appsettings.json.
+        /// This way we can better control what the correct version of Microsoft.Quantum
+        /// packages to use, since all of them should ideally be in-sync.
+        /// </summary>
+        IReadOnlyDictionary<string, NuGetVersion> DefaultVersions { get; }
 
         /// <summary>
         /// Add a package.

--- a/src/Core/References/NugetPackages.cs
+++ b/src/Core/References/NugetPackages.cs
@@ -103,9 +103,7 @@ namespace Microsoft.Quantum.IQSharp
         // Nuget's global settings.
         public ISettings NugetSettings { get; }
 
-        // Keeps track of what package version to use for certain packages specified in the packageVersion.json.
-        // This way we can better control what the correct version of Microsoft.Quantum
-        // packages to use, since all of them need to be in-sync.
+        /// <inheritdoc/>
         public IReadOnlyDictionary<string, NuGetVersion> DefaultVersions { get; }
 
         public NugetPackages(

--- a/src/Tests/Mocks.cs
+++ b/src/Tests/Mocks.cs
@@ -162,7 +162,8 @@ namespace Tests.IQSharp
                 }
             }
         }
-
+        
+        public IReadOnlyDictionary<string, NuGetVersion> DefaultVersions => new Dictionary<string, NuGetVersion>();
 
         public Task<PackageIdentity> Add(string package, Action<string>? statusCallback = null)
         {


### PR DESCRIPTION
Since IQ# always loads the `Microsoft.Quantum.Standard` package that matches the current version of IQ#, it should do the same for any other packages that are part of the QDK, to ensure as much as possible that we don't load mismatched QDK package versions.

This PR updates the IQ# project references feature to check the `DefaultPackageVersions` list in `appsettings.json` for any package references found in a `.csproj` file. If it is present, it will load the specified default version of the package, rather than the version specified in the `.csproj`.

Fixes #306.