### PR TITLE
Add version to workspace cache DLL names

### DIFF
--- a/src/Core/Workspace/Project.cs
+++ b/src/Core/Workspace/Project.cs
@@ -9,7 +9,6 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.InteropServices;
-using System.Text;
 using System.Xml.Linq;
 using System.Xml.XPath;
 using Microsoft.Extensions.Logging;

--- a/src/Tests/WorkspaceTests.cs
+++ b/src/Tests/WorkspaceTests.cs
@@ -17,7 +17,7 @@ namespace Tests.IQSharp
         {
             var ws = Startup.Create<Workspace>("Workspace");
 
-            var dll = Path.Combine(ws.CacheFolder, "__ws__.dll");
+            var dll = ws.Projects.Single().CacheDllPath;
             if (File.Exists(dll)) File.Delete(dll);
 
             // First time


### PR DESCRIPTION
When the QDK has breaking changes, Q# assemblies built with previous versions of the QDK may no longer interoperate correctly with the new QDK packages.

Since IQ# keeps a cached version of the workspace DLL around, we need a way to identify whether that DLL is still valid, given the currently-running version of IQ#. The assembly version of the IQ# executable (and all QDK assemblies) should change whenever there is a breaking change to the QDK, so by embedding this in the filename, we will only load cached DLLs that were built with a compatible version.

Fixes #199.