### PR TITLE
Fallback to unencrypted credential cache on Linux when necessary

### DIFF
--- a/src/AzureClient/AzureClient.cs
+++ b/src/AzureClient/AzureClient.cs
@@ -118,7 +118,7 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
             IAzureWorkspace? workspace = null;
             try
             {
-                workspace = await azureEnvironment.GetAuthenticatedWorkspaceAsync(channel, resourceGroupName, workspaceName, refreshCredentials);
+                workspace = await azureEnvironment.GetAuthenticatedWorkspaceAsync(channel, Logger, resourceGroupName, workspaceName, refreshCredentials);
             }
             catch (Exception e)
             {

--- a/src/AzureClient/AzureEnvironment.cs
+++ b/src/AzureClient/AzureEnvironment.cs
@@ -110,6 +110,9 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
                     e.Message);
                 
                 storageCreationProperties = new StorageCreationPropertiesBuilder(unencryptedCacheFileName, cacheDirectory, ClientId)
+                    .WithMacKeyChain(
+                        serviceName: "Microsoft.Quantum.IQSharp",
+                        accountName: "MSALCache")
                     .WithLinuxUnprotectedFile()
                     .Build();
 


### PR DESCRIPTION
For a variety of reasons, encryption of the credential cache on Linux when using `MsalCacheHelper` may not be possible. This includes when the user is connected via SSH. For more details see: https://github.com/AzureAD/microsoft-authentication-extensions-for-dotnet/blob/master/docs/keyring_fallback_proposal.md

This PR follows [the pattern used in the official Azure .NET SDK](https://github.com/Azure/azure-sdk-for-net/blob/a5496b85d95a326316bf59a39c44213e1593a27f/sdk/identity/Azure.Identity/src/MsalClientBase.cs) by catching `MsalCachePersistenceException` and falling back to an unencrypted cache instead.

Fixes #303. 