### PR TITLE
Fix pytest timing issues by upgrading Microsoft.Jupyter.Core

### DIFF
--- a/src/Jupyter/Jupyter.csproj
+++ b/src/Jupyter/Jupyter.csproj
@@ -35,7 +35,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Jupyter.Core" Version="1.4.80531" />
+    <PackageReference Include="Microsoft.Jupyter.Core" Version="1.4.112145" />
     <PackageReference Include="System.Reactive" Version="4.3.2" />
   </ItemGroup>
 


### PR DESCRIPTION
Fixes #310 by upgrading Microsoft.Jupyter.Core, which contains the fix for https://github.com/microsoft/jupyter-core/pull/65.