### PR TITLE
Avoid possible race condition during package loading

### DIFF
--- a/src/Core/References/NugetPackages.cs
+++ b/src/Core/References/NugetPackages.cs
@@ -208,7 +208,7 @@ namespace Microsoft.Quantum.IQSharp
 
                 await DownloadPackages(sourceCacheContext, packages, statusCallback);
 
-                lock (this)
+                lock (this) 
                 {
                     this.Items = Items.Union(new PackageIdentity[] { pkgId }).ToArray();
                     this.Assemblies = Assemblies.Union(packages.Reverse().SelectMany(GetAssemblies)).ToArray();

--- a/src/Core/References/NugetPackages.cs
+++ b/src/Core/References/NugetPackages.cs
@@ -208,7 +208,7 @@ namespace Microsoft.Quantum.IQSharp
 
                 await DownloadPackages(sourceCacheContext, packages, statusCallback);
 
-                lock (this) 
+                lock (this)
                 {
                     this.Items = Items.Union(new PackageIdentity[] { pkgId }).ToArray();
                     this.Assemblies = Assemblies.Union(packages.Reverse().SelectMany(GetAssemblies)).ToArray();

--- a/src/Core/References/NugetPackages.cs
+++ b/src/Core/References/NugetPackages.cs
@@ -208,8 +208,11 @@ namespace Microsoft.Quantum.IQSharp
 
                 await DownloadPackages(sourceCacheContext, packages, statusCallback);
 
-                this.Items = Items.Union(new PackageIdentity[] { pkgId }).ToArray();
-                this.Assemblies = Assemblies.Union(packages.Reverse().SelectMany(GetAssemblies)).ToArray();
+                lock (this)
+                {
+                    this.Items = Items.Union(new PackageIdentity[] { pkgId }).ToArray();
+                    this.Assemblies = Assemblies.Union(packages.Reverse().SelectMany(GetAssemblies)).ToArray();
+                }
             }
         }
 

--- a/src/Core/References/References.cs
+++ b/src/Core/References/References.cs
@@ -183,8 +183,11 @@ namespace Microsoft.Quantum.IQSharp
         /// </summary>
         public void AddAssemblies(params AssemblyInfo[] assemblies)
         {
-            Assemblies = Assemblies.Union(assemblies).ToImmutableArray();
-            Reset();
+            lock (this)
+            {
+                Assemblies = Assemblies.Union(assemblies).ToImmutableArray();
+                Reset();
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
This is a fix for what seems to be a possible race condition while loading packages.

We were seeing frequent Katas validation failures in the E2E build due to the assemblies from the Katas package not being available, even though the `%package Microsoft.Quantum.Katas` cell in the notebook had already completed successfully.

With this change, so far the Katas validation in the E2E build has passed 6/6 times, and considering we were seeing a failure rate that seemed to be nearly 50% recently, I think it's worth merging this fix to get further testing. I don't have high confidence that this actually fixes the issue, but it's a safe change and can't hurt anything.