### PR TITLE
Fix Python docstring for projects.add()

### DIFF
--- a/src/Python/qsharp-core/qsharp/projects.py
+++ b/src/Python/qsharp-core/qsharp/projects.py
@@ -39,8 +39,9 @@ class Projects(object):
         """
         Adds a reference to the given Q# project to be loaded
         into the current IQ# session.
+
         :param project_path: Path to the .csproj to be added. May be an absolute
-        path or a path relative to the current workspace root folder.
+            path or a path relative to the current workspace root folder.
         """
         logger.info(f"Loading project: {project_path}")
         loaded_projects = self._client.add_project(project_path)


### PR DESCRIPTION
Generated Python documentation for `projects.add()` is not formatted correctly due to incorrect whitespace for the `param` in the docstring:

![image](https://user-images.githubusercontent.com/3620100/93806776-ade2f100-fc17-11ea-8008-05e6e42f692c.png)
([link](https://docs.microsoft.com/en-us/python/qsharp-core/qsharp.projects.projects#add-project-path--str-----none))

This PR simply fixes the whitespace so that the docstring will be generated correctly.