### PR TITLE
Fix ms.author for magic command doc generation

### DIFF
--- a/build/docs/build_docs.py
+++ b/build/docs/build_docs.py
@@ -122,7 +122,7 @@ def format_as_document(magic, uid_base : str) -> MagicReferenceDocument:
         'title': f"{magic_name} (magic command)",
         'author': 'rmshaffer',
         'uid': uid,
-        'ms.author': 'rmshaffer',
+        'ms.author': 'ryansha',
         'ms.date': datetime.date.today().strftime("%m/%d/%Y"),
         'ms.topic': 'article'
     }
@@ -200,7 +200,7 @@ def format_index(all_magics : Dict[str, MagicReferenceDocument], uid_base : str)
         'title': "IQ# Magic Commands",
         'author': 'rmshaffer',
         'uid': f"{uid_base}.index",
-        'ms.author': 'rmshaffer',
+        'ms.author': 'ryansha',
         'ms.date': datetime.date.today().strftime("%m/%d/%Y"),
         'ms.topic': 'article'
     }


### PR DESCRIPTION
Doc generation tool expects the `ms.author` field to be the internal alias rather than the GitHub username.

e.g., see generated warnings in this PR:
https://github.com/MicrosoftDocs/quantum-docs-pr/pull/1062#issuecomment-700751523