### PR TITLE
Update for compiler changes in qsharp-compiler#643

### DIFF
--- a/images/iqsharp-base/Dockerfile
+++ b/images/iqsharp-base/Dockerfile
@@ -109,7 +109,7 @@ ENV PATH=$PATH:${HOME}/dotnet:${HOME}/.dotnet/tools \
 # Install IQ# and the project templates, using the NuGet packages from the
 # build context.
 ARG IQSHARP_VERSION
-RUN dotnet new -i "Microsoft.Quantum.ProjectTemplates::0.12.200915062-beta" && \
+RUN dotnet new -i "Microsoft.Quantum.ProjectTemplates::0.12.20101601-beta" && \
     dotnet tool install \
            --global \
            Microsoft.Quantum.IQSharp \

--- a/src/AzureClient/AzureClient.csproj
+++ b/src/AzureClient/AzureClient.csproj
@@ -13,7 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Quantum.Client" Version="0.12.200915062-beta" />
+    <PackageReference Include="Microsoft.Azure.Quantum.Client" Version="0.12.20101601-beta" />
     <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.21" />
     <PackageReference Include="Microsoft.Rest.ClientRuntime.Azure" Version="3.3.19" />
     <PackageReference Include="System.Reactive" Version="4.3.2" />

--- a/src/Core/Compiler/CompilerService.cs
+++ b/src/Core/Compiler/CompilerService.cs
@@ -219,7 +219,9 @@ namespace Microsoft.Quantum.IQSharp
 
             // Ignore any @EntryPoint() attributes found in libraries.
             logger.ErrorCodesToIgnore.Add(QsCompiler.Diagnostics.ErrorCode.EntryPointInLibrary);
+            logger.WarningCodesToIgnore.Add(QsCompiler.Diagnostics.WarningCode.EntryPointInLibrary);
             var qsCompilation = this.UpdateCompilation(sources, metadata.QsMetadatas, logger, compileAsExecutable, executionTarget, runtimeCapabilities);
+            logger.WarningCodesToIgnore.Remove(QsCompiler.Diagnostics.WarningCode.EntryPointInLibrary);
             logger.ErrorCodesToIgnore.Remove(QsCompiler.Diagnostics.ErrorCode.EntryPointInLibrary);
 
             if (logger.HasErrors) return null;

--- a/src/Core/Compiler/CompilerService.cs
+++ b/src/Core/Compiler/CompilerService.cs
@@ -186,15 +186,15 @@ namespace Microsoft.Quantum.IQSharp
             var sources = snippets.ToImmutableDictionary(s => s.Uri, WrapInNamespace);
 
             // Ignore some warnings about already-open namespaces and aliases when compiling snippets.
-            var errorCodesToIgnore = new List<QsCompiler.Diagnostics.ErrorCode>()
+            var warningCodesToIgnore = new List<QsCompiler.Diagnostics.WarningCode>()
             {
-                QsCompiler.Diagnostics.ErrorCode.TypeRedefinition,
-                QsCompiler.Diagnostics.ErrorCode.TypeConstructorOverlapWithCallable,
+                QsCompiler.Diagnostics.WarningCode.NamespaceAleadyOpen,
+                QsCompiler.Diagnostics.WarningCode.NamespaceAliasIsAlreadyDefined,
             };
 
-            errorCodesToIgnore.ForEach(code => logger.ErrorCodesToIgnore.Add(code));
+            warningCodesToIgnore.ForEach(code => logger.WarningCodesToIgnore.Add(code));
             var assembly = BuildAssembly(sources, metadatas, logger, dllName, compileAsExecutable: false, executionTarget, runtimeCapabilities);
-            errorCodesToIgnore.ForEach(code => logger.ErrorCodesToIgnore.Remove(code));
+            warningCodesToIgnore.ForEach(code => logger.WarningCodesToIgnore.Remove(code));
 
             return assembly;
         }

--- a/src/Core/Compiler/CompilerService.cs
+++ b/src/Core/Compiler/CompilerService.cs
@@ -126,9 +126,9 @@ namespace Microsoft.Quantum.IQSharp
         /// if the keys of the given references differ from the currently loaded ones.
         /// Returns an enumerable of all namespaces, including the content from both source files and references.
         /// </summary> 
-        private QsCompilation UpdateCompilation(
+        private QsCompilation? UpdateCompilation(
             ImmutableDictionary<Uri, string> sources,
-            QsReferences? references = null,
+            QsReferences references,
             QSharpLogger? logger = null,
             bool compileAsExecutable = false,
             string? executionTarget = null,
@@ -222,7 +222,7 @@ namespace Microsoft.Quantum.IQSharp
             var qsCompilation = this.UpdateCompilation(sources, metadata.QsMetadatas, logger, compileAsExecutable, executionTarget, runtimeCapabilities);
             logger.WarningCodesToIgnore.Remove(QsCompiler.Diagnostics.WarningCode.EntryPointInLibrary);
 
-            if (logger.HasErrors) return null;
+            if (logger.HasErrors || qsCompilation == null) return null;
 
             try
             {

--- a/src/Core/Core.csproj
+++ b/src/Core/Core.csproj
@@ -38,9 +38,9 @@
     <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="3.0.0" />
-    <PackageReference Include="Microsoft.Quantum.Compiler" Version="0.12.200915062-beta" />
-    <PackageReference Include="Microsoft.Quantum.CsharpGeneration" Version="0.12.200915062-beta" />
-    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.12.200915062-beta" />
+    <PackageReference Include="Microsoft.Quantum.Compiler" Version="0.12.20101601-beta" />
+    <PackageReference Include="Microsoft.Quantum.CsharpGeneration" Version="0.12.20101601-beta" />
+    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.12.20101601-beta" />
     <PackageReference Include="NuGet.Resolver" Version="5.1.0" />
     <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
   </ItemGroup>

--- a/src/Core/Loggers/QsharpLogger.cs
+++ b/src/Core/Loggers/QsharpLogger.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 using System.Linq;
 
 using Microsoft.Extensions.Logging;
-
+using Microsoft.Quantum.QsCompiler.CompilationBuilder;
 using LSP = Microsoft.VisualStudio.LanguageServer.Protocol;
 
 
@@ -23,6 +23,7 @@ namespace Microsoft.Quantum.IQSharp.Common
         public List<LSP.Diagnostic> Logs { get; }
 
         public List<QsCompiler.Diagnostics.ErrorCode> ErrorCodesToIgnore { get; } = new List<QsCompiler.Diagnostics.ErrorCode>();
+        public List<QsCompiler.Diagnostics.WarningCode> WarningCodesToIgnore { get; } = new List<QsCompiler.Diagnostics.WarningCode>();
 
         public QSharpLogger(ILogger logger, int lineNrOffset = 0) :
             base(lineNrOffset : lineNrOffset)
@@ -75,7 +76,8 @@ namespace Microsoft.Quantum.IQSharp.Common
 
         protected override void Print(LSP.Diagnostic m)
         {
-            if (ErrorCodesToIgnore.Any(code => m.Code == QsCompiler.CompilationBuilder.Errors.Code(code))) return;
+            if (m.IsError() && ErrorCodesToIgnore.Any(code => m.Code == QsCompiler.CompilationBuilder.Errors.Code(code))) return;
+            if (m.IsWarning() && WarningCodesToIgnore.Any(code => m.Code == QsCompiler.CompilationBuilder.Warnings.Code(code))) return;
 
             Logger?.Log(MapLevel(m.Severity), $"{m.Code}: {m.Message}");
             Logs.Add(m);

--- a/src/ExecutionPathTracer/ExecutionPathTracer.csproj
+++ b/src/ExecutionPathTracer/ExecutionPathTracer.csproj
@@ -32,7 +32,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.12.200915062-beta" />
+    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.12.20101601-beta" />
   </ItemGroup>
 
 </Project>

--- a/src/MockLibraries/Mock.Chemistry/Mock.Chemistry.csproj
+++ b/src/MockLibraries/Mock.Chemistry/Mock.Chemistry.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.12.200915062-beta">
+<Project Sdk="Microsoft.Quantum.Sdk/0.12.20101601-beta">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
@@ -6,6 +6,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.12.200915062-beta" />
+    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.12.20101601-beta" />
   </ItemGroup>
 </Project>

--- a/src/MockLibraries/Mock.Standard/Mock.Standard.csproj
+++ b/src/MockLibraries/Mock.Standard/Mock.Standard.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.12.200915062-beta">
+<Project Sdk="Microsoft.Quantum.Sdk/0.12.20101601-beta">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
@@ -6,6 +6,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.12.200915062-beta" />
+    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.12.20101601-beta" />
   </ItemGroup>
 </Project>

--- a/src/Tests/AzureClientEntryPointTests.cs
+++ b/src/Tests/AzureClientEntryPointTests.cs
@@ -6,15 +6,12 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Quantum.IQSharp;
 using Microsoft.Quantum.IQSharp.AzureClient;
 using Microsoft.Quantum.IQSharp.Common;
-using Microsoft.Quantum.Runtime;
 using Microsoft.Quantum.Simulation.Common;
-using Microsoft.Quantum.Simulation.Core;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Tests.IQSharp

--- a/src/Tests/IQsharpEngineTests.cs
+++ b/src/Tests/IQsharpEngineTests.cs
@@ -199,6 +199,18 @@ namespace Tests.IQSharp
         }
 
         [TestMethod]
+        public async Task CompileApplyWithin()
+        {
+            var engine = Init();
+
+            // Compile:
+            await AssertCompile(engine, SNIPPETS.ApplyWithinBlock, "ApplyWithinBlock");
+
+            // Run:
+            await AssertSimulate(engine, "ApplyWithinBlock", "Within", "Apply", "Within");
+        }
+
+        [TestMethod]
         public async Task Estimate()
         {
             var engine = Init();

--- a/src/Tests/SNIPPETS.cs
+++ b/src/Tests/SNIPPETS.cs
@@ -105,8 +105,7 @@ namespace Tests.IQSharp
 
         public static string OpenNamespaces1 =
 @"
-    open Microsoft.Quantum.Intrinsic;
-    open Microsoft.Quantum.Diagnostics;
+    open Microsoft.Quantum.Math;
 ";
 
         public static string OpenNamespaces2 =

--- a/src/Tests/SNIPPETS.cs
+++ b/src/Tests/SNIPPETS.cs
@@ -105,7 +105,8 @@ namespace Tests.IQSharp
 
         public static string OpenNamespaces1 =
 @"
-    open Microsoft.Quantum.Math;
+    open Microsoft.Quantum.Intrinsic;
+    open Microsoft.Quantum.Diagnostics;
 ";
 
         public static string OpenNamespaces2 =

--- a/src/Tests/SNIPPETS.cs
+++ b/src/Tests/SNIPPETS.cs
@@ -145,6 +145,28 @@ namespace Tests.IQSharp
     }
 ";
 
+        public static string ApplyWithinBlock =
+ @"
+    /// # Summary
+    ///     Checks that within/apply block is properly compiled.
+    ///     See https://github.com/microsoft/iqsharp/issues/266.
+    @EntryPoint()
+    operation ApplyWithinBlock() : Unit
+    {
+        using (q = Qubit())
+        {
+            within {
+                H(q);
+                Message(""Within"");
+            }
+            apply {
+                X(q);
+                Message(""Apply"");
+            }
+        }
+    }
+";
+
         public static string DependsOnWorkspace =
 @"
     /// # Summary

--- a/src/Tests/Workspace.ProjectReferences.ProjectA/ProjectA.csproj
+++ b/src/Tests/Workspace.ProjectReferences.ProjectA/ProjectA.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Quantum.Sdk/0.12.200915062-beta">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.12.20101601-beta">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>

--- a/src/Tests/Workspace.ProjectReferences.ProjectB/ProjectB.csproj
+++ b/src/Tests/Workspace.ProjectReferences.ProjectB/ProjectB.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Quantum.Sdk/0.12.200915062-beta">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.12.20101601-beta">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>

--- a/src/Tests/Workspace.ProjectReferences/Workspace.ProjectReferences.csproj
+++ b/src/Tests/Workspace.ProjectReferences/Workspace.ProjectReferences.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Quantum.Sdk/0.12.200915062-beta">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.12.20101601-beta">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.12.200915062-beta" />
+    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.12.20101601-beta" />
   </ItemGroup>
     
   <ItemGroup>

--- a/src/Tool/appsettings.json
+++ b/src/Tool/appsettings.json
@@ -6,26 +6,26 @@
     },
     "AllowedHosts": "*",
   "DefaultPackageVersions": [
-    "Microsoft.Quantum.Compiler::0.12.200915062-beta",
+    "Microsoft.Quantum.Compiler::0.12.20101601-beta",
 
-    "Microsoft.Quantum.CsharpGeneration::0.12.200915062-beta",
-    "Microsoft.Quantum.Development.Kit::0.12.200915062-beta",
-    "Microsoft.Quantum.Simulators::0.12.200915062-beta",
-    "Microsoft.Quantum.Xunit::0.12.200915062-beta",
+    "Microsoft.Quantum.CsharpGeneration::0.12.20101601-beta",
+    "Microsoft.Quantum.Development.Kit::0.12.20101601-beta",
+    "Microsoft.Quantum.Simulators::0.12.20101601-beta",
+    "Microsoft.Quantum.Xunit::0.12.20101601-beta",
 
-    "Microsoft.Quantum.Standard::0.12.200915062-beta",
-    "Microsoft.Quantum.Standard.Visualization::0.12.200915062-beta",
-    "Microsoft.Quantum.Chemistry::0.12.200915062-beta",
-    "Microsoft.Quantum.Chemistry.Jupyter::0.12.200915062-beta",
-    "Microsoft.Quantum.MachineLearning::0.12.200915062-beta",
-    "Microsoft.Quantum.Numerics::0.12.200915062-beta",
+    "Microsoft.Quantum.Standard::0.12.20101601-beta",
+    "Microsoft.Quantum.Standard.Visualization::0.12.20101601-beta",
+    "Microsoft.Quantum.Chemistry::0.12.20101601-beta",
+    "Microsoft.Quantum.Chemistry.Jupyter::0.12.20101601-beta",
+    "Microsoft.Quantum.MachineLearning::0.12.20101601-beta",
+    "Microsoft.Quantum.Numerics::0.12.20101601-beta",
 
-    "Microsoft.Quantum.Katas::0.12.200915062-beta",
+    "Microsoft.Quantum.Katas::0.12.20101601-beta",
 
-    "Microsoft.Quantum.Research::0.12.200915062-beta",
+    "Microsoft.Quantum.Research::0.12.20101601-beta",
 
-    "Microsoft.Quantum.Providers.IonQ::0.12.200915062-beta",
-    "Microsoft.Quantum.Providers.Honeywell::0.12.200915062-beta",
-    "Microsoft.Quantum.Providers.QCI::0.12.200915062-beta"
+    "Microsoft.Quantum.Providers.IonQ::0.12.20101601-beta",
+    "Microsoft.Quantum.Providers.Honeywell::0.12.20101601-beta",
+    "Microsoft.Quantum.Providers.QCI::0.12.20101601-beta"
   ]
 }


### PR DESCRIPTION
Updates to account for changes in https://github.com/microsoft/qsharp-compiler/pull/643. In particular, `EntryPointInLibrary` is becoming a warning rather than an error, so we need to update IQ# code and tests accordingly.

This will resolve #266 and in general will avoid differences in behavior depending on whether or not the Q# code being compiled contains an `@EntryPoint()`.

To do before merging:
- [x] Update the QDK version in this PR to a beta build that includes the changes from https://github.com/microsoft/qsharp-compiler/pull/643
- [x] Fix IQ# build warnings that appear due to recent compiler nullability changes, if any
- [x] Wait for https://github.com/microsoft/qsharp-compiler/pull/643 to be merged