### PR TITLE
Initialize workspace asynchronously

### DIFF
--- a/src/Core/References/IReferences.cs
+++ b/src/Core/References/IReferences.cs
@@ -64,6 +64,12 @@ namespace Microsoft.Quantum.IQSharp
         IEnumerable<string>? Packages { get; }
 
         /// <summary>
+        /// Adds any default packages that should be loaded at initialization time.
+        /// </summary>
+        /// <returns></returns>
+        Task LoadDefaultPackages();
+
+        /// <summary>
         /// Adds a nuget package and its corresponding assemblies to the list of references.
         /// </summary>
         Task AddPackage(string name, Action<string>? statusCallback = null);

--- a/src/Core/References/IReferences.cs
+++ b/src/Core/References/IReferences.cs
@@ -66,7 +66,6 @@ namespace Microsoft.Quantum.IQSharp
         /// <summary>
         /// Adds any default packages that should be loaded at initialization time.
         /// </summary>
-        /// <returns></returns>
         Task LoadDefaultPackages();
 
         /// <summary>

--- a/src/Core/References/IReferences.cs
+++ b/src/Core/References/IReferences.cs
@@ -66,7 +66,7 @@ namespace Microsoft.Quantum.IQSharp
         /// <summary>
         /// Adds any default packages that should be loaded at initialization time.
         /// </summary>
-        Task LoadDefaultPackages();
+        void LoadDefaultPackages();
 
         /// <summary>
         /// Adds a nuget package and its corresponding assemblies to the list of references.

--- a/src/Core/References/References.cs
+++ b/src/Core/References/References.cs
@@ -105,13 +105,13 @@ namespace Microsoft.Quantum.IQSharp
         }
 
         /// <inheritdoc/>
-        public async Task LoadDefaultPackages()
+        public void LoadDefaultPackages()
         {
             foreach (var pkg in AutoLoadPackages)
             {
                 try
                 {
-                    await AddPackage(pkg);
+                    AddPackage(pkg).Wait();
                 }
                 catch (AggregateException e)
                 {

--- a/src/Core/References/References.cs
+++ b/src/Core/References/References.cs
@@ -77,6 +77,9 @@ namespace Microsoft.Quantum.IQSharp
         /// purposes, but are not strictly necessary for compilation:
         ///   * Microsoft.Quantum.Standard.Visualization
         /// </summary>
+        /// <remarks>
+        /// These packages will be loaded asynchronously as part of workspace initialization.
+        /// </remarks>
         public readonly ImmutableList<string> DeferredLoadPackages =
             ImmutableList.Create(
                 "Microsoft.Quantum.Standard.Visualization"
@@ -134,22 +137,6 @@ namespace Microsoft.Quantum.IQSharp
                 {
                     logger.LogError($"Unable to load package '{pkg}':  {e.InnerException.Message}");
                 }
-            }
-
-            foreach (var pkg in DeferredLoadPackages)
-            {
-                // Don't wait for DeferredLoadPackages to finish loading
-                this.AddPackage(pkg).ContinueWith(task =>
-                {
-                    if (task.Exception is AggregateException e)
-                    {
-                        logger.LogError(e, $"Unable to load package '{pkg}': {e.InnerException.Message}");
-                    }
-                    else
-                    {
-                        logger.LogError(task.Exception, $"Unable to load package '{pkg}': {task.Exception.Message}");
-                    }
-                }, TaskContinuationOptions.OnlyOnFaulted);
             }
 
             _metadata = new Lazy<CompilerMetadata>(() => new CompilerMetadata(this.Assemblies));

--- a/src/Core/Workspace/IWorkspace.cs
+++ b/src/Core/Workspace/IWorkspace.cs
@@ -138,5 +138,11 @@ namespace Microsoft.Quantum.IQSharp
         /// Triggers the workspace to be reloaded from disk.
         /// </summary>
         void Reload(Action<string> statusCallback = null);
+
+        /// <summary>
+        /// Waits for the initial workspace load to complete, including
+        /// package loads and project compilation.
+        /// </summary>
+        void WaitForInitialization();
     }
 }

--- a/src/Core/Workspace/IWorkspace.cs
+++ b/src/Core/Workspace/IWorkspace.cs
@@ -3,7 +3,7 @@
 
 using System;
 using System.Collections.Generic;
-
+using System.Threading.Tasks;
 using Microsoft.Quantum.IQSharp.Common;
 
 namespace Microsoft.Quantum.IQSharp
@@ -140,9 +140,10 @@ namespace Microsoft.Quantum.IQSharp
         void Reload(Action<string> statusCallback = null);
 
         /// <summary>
-        /// Waits for the initial workspace load to complete, including
-        /// package loads and project compilation.
+        /// Task that will be completed when the initial workspace
+        /// initialization has finished, including package loads and
+        /// project compilation.
         /// </summary>
-        void WaitForInitialization();
+        Task Initialization { get; }
     }
 }

--- a/src/Core/Workspace/Workspace.cs
+++ b/src/Core/Workspace/Workspace.cs
@@ -183,11 +183,11 @@ namespace Microsoft.Quantum.IQSharp
             logger?.LogInformation($"Starting IQ# Workspace:\n----------------\nRoot: {Root}\nCache folder:{CacheFolder}\nMonitoring changes: {MonitorWorkspace}\nUser agent: {metadata?.UserAgent ?? "<unknown>"}\nHosting environment: {metadata?.HostingEnvironment ?? "<unknown>"}\n----------------");
 
             // Initialize the workspace asynchronously
-            Task.Run(async () =>
+            Task.Run(() =>
             {
                 try
                 {
-                    await GlobalReferences.LoadDefaultPackages();
+                    GlobalReferences.LoadDefaultPackages();
                     ResolveProjectReferences();
 
                     if (!LoadFromCache())

--- a/src/Core/Workspace/Workspace.cs
+++ b/src/Core/Workspace/Workspace.cs
@@ -6,6 +6,8 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 using System.Xml.Linq;
 using System.Xml.XPath;
 using Microsoft.CodeAnalysis;
@@ -147,16 +149,24 @@ namespace Microsoft.Quantum.IQSharp
         public string CacheFolder { get; set; }
 
         /// <summary>
+        /// An event that is set after the workspace initialization has completed.
+        /// </summary>
+        private ManualResetEvent initialized = new ManualResetEvent(false);
+
+        /// <inheritdoc/>
+        public void WaitForInitialization() => initialized.WaitOne();
+
+        /// <summary>
         /// Main constructor that accepts ILogger and IReferences as dependencies.
         /// </summary>
         /// <param name="logger">Used to log messages to the console.</param>
         /// <param name="references">List of references to use to compile the workspace.</param>
         public Workspace(
-            IOptions<Settings> config, 
-            ICompilerService compiler, 
-            IReferences references, 
+            IOptions<Settings> config,
+            ICompilerService compiler,
+            IReferences references,
             INugetPackages packages,
-            ILogger<Workspace> logger, 
+            ILogger<Workspace> logger,
             IMetadataController metadata,
             IEventService eventService)
         {
@@ -172,22 +182,52 @@ namespace Microsoft.Quantum.IQSharp
 
             logger?.LogInformation($"Starting IQ# Workspace:\n----------------\nRoot: {Root}\nCache folder:{CacheFolder}\nMonitoring changes: {MonitorWorkspace}\nUser agent: {metadata?.UserAgent ?? "<unknown>"}\nHosting environment: {metadata?.HostingEnvironment ?? "<unknown>"}\n----------------");
 
-            ResolveProjectReferences();
-
-            if (!LoadFromCache())
+            // Initialize the workspace asynchronously
+            Task.Run(() =>
             {
-                Reload();
-            }
-            else
-            {
-                LoadReferencedPackages();
-                if (MonitorWorkspace)
+                try
                 {
-                    StartFileWatching();
+                    LoadDeferredPackageReferences();
+                    ResolveProjectReferences();
+
+                    if (!LoadFromCache())
+                    {
+                        DoReload();
+                    }
+                    else
+                    {
+                        LoadReferencedPackages();
+                        if (MonitorWorkspace)
+                        {
+                            StartFileWatching();
+                        }
+                    }
+
+                    eventService?.TriggerServiceInitialized<IWorkspace>(this);
+                }
+                finally
+                {
+                    initialized.Set();
+                }
+            });
+        }
+
+        private void LoadDeferredPackageReferences()
+        {
+            if (GlobalReferences is References references)
+            {
+                foreach (var pkg in references.DeferredLoadPackages)
+                {
+                    try
+                    {
+                        GlobalReferences.AddPackage(pkg).Wait();
+                    }
+                    catch (AggregateException e)
+                    {
+                        Logger?.LogError($"Failed to load package '{pkg}':  {e.InnerException.Message}");
+                    }
                 }
             }
-
-            eventService?.TriggerServiceInitialized<IWorkspace>(this);
         }
 
         private void ResolveProjectReferences()
@@ -382,6 +422,8 @@ namespace Microsoft.Quantum.IQSharp
         /// <inheritdoc/>
         public void AddProject(string projectFile)
         {
+            WaitForInitialization();
+
             var fullProjectPath = Path.GetFullPath(projectFile, Root);
             if (!File.Exists(fullProjectPath))
             {
@@ -412,6 +454,12 @@ namespace Microsoft.Quantum.IQSharp
         /// </summary>
         public void Reload(Action<string> statusCallback = null)
         {
+            WaitForInitialization();
+            DoReload(statusCallback);
+        }
+
+        private void DoReload(Action<string> statusCallback = null)
+        { 
             var duration = Stopwatch.StartNew();
             var fileCount = 0;
             var errorIds = new List<string>();

--- a/src/Core/Workspace/Workspace.cs
+++ b/src/Core/Workspace/Workspace.cs
@@ -154,7 +154,7 @@ namespace Microsoft.Quantum.IQSharp
         private ManualResetEvent initialized = new ManualResetEvent(false);
 
         /// <inheritdoc/>
-        public void WaitForInitialization() => initialized.WaitOne();
+        public Task Initialization => Task.Run(() => initialized.WaitOne());
 
         /// <summary>
         /// Main constructor that accepts ILogger and IReferences as dependencies.
@@ -422,8 +422,6 @@ namespace Microsoft.Quantum.IQSharp
         /// <inheritdoc/>
         public void AddProject(string projectFile)
         {
-            WaitForInitialization();
-
             var fullProjectPath = Path.GetFullPath(projectFile, Root);
             if (!File.Exists(fullProjectPath))
             {
@@ -454,7 +452,7 @@ namespace Microsoft.Quantum.IQSharp
         /// </summary>
         public void Reload(Action<string> statusCallback = null)
         {
-            WaitForInitialization();
+            Initialization.Wait();
             DoReload(statusCallback);
         }
 

--- a/src/Core/Workspace/Workspace.cs
+++ b/src/Core/Workspace/Workspace.cs
@@ -183,11 +183,11 @@ namespace Microsoft.Quantum.IQSharp
             logger?.LogInformation($"Starting IQ# Workspace:\n----------------\nRoot: {Root}\nCache folder:{CacheFolder}\nMonitoring changes: {MonitorWorkspace}\nUser agent: {metadata?.UserAgent ?? "<unknown>"}\nHosting environment: {metadata?.HostingEnvironment ?? "<unknown>"}\n----------------");
 
             // Initialize the workspace asynchronously
-            Task.Run(() =>
+            Task.Run(async () =>
             {
                 try
                 {
-                    LoadDeferredPackageReferences();
+                    await GlobalReferences.LoadDefaultPackages();
                     ResolveProjectReferences();
 
                     if (!LoadFromCache())
@@ -210,24 +210,6 @@ namespace Microsoft.Quantum.IQSharp
                     initialized.Set();
                 }
             });
-        }
-
-        private void LoadDeferredPackageReferences()
-        {
-            if (GlobalReferences is References references)
-            {
-                foreach (var pkg in references.DeferredLoadPackages)
-                {
-                    try
-                    {
-                        GlobalReferences.AddPackage(pkg).Wait();
-                    }
-                    catch (AggregateException e)
-                    {
-                        Logger?.LogError($"Failed to load package '{pkg}':  {e.InnerException.Message}");
-                    }
-                }
-            }
         }
 
         private void ResolveProjectReferences()

--- a/src/Kernel/IQSharpEngine.cs
+++ b/src/Kernel/IQSharpEngine.cs
@@ -53,6 +53,7 @@ namespace Microsoft.Quantum.IQSharp.Kernel
             this.Snippets = services.GetService<ISnippets>();
             this.SymbolsResolver = services.GetService<ISymbolResolver>();
             this.MagicResolver = magicSymbolResolver;
+            this.Workspace = services.GetService<IWorkspace>();
 
             RegisterDisplayEncoder(new IQSharpSymbolToHtmlResultEncoder());
             RegisterDisplayEncoder(new IQSharpSymbolToTextResultEncoder());
@@ -172,6 +173,8 @@ namespace Microsoft.Quantum.IQSharp.Kernel
 
         internal ISymbolResolver MagicResolver { get; }
 
+        internal IWorkspace Workspace { get; }
+
         /// <summary>
         /// This is the method used to execute Jupyter "normal" cells. In this case, a normal
         /// cell is expected to have a Q# snippet, which gets compiled and we return the name of
@@ -185,6 +188,8 @@ namespace Microsoft.Quantum.IQSharp.Kernel
             {
                 try
                 {
+                    Workspace.WaitForInitialization();
+
                     var code = Snippets.Compile(input);
 
                     foreach (var m in code.warnings) { channel.Stdout(m); }

--- a/src/Kernel/IQSharpEngine.cs
+++ b/src/Kernel/IQSharpEngine.cs
@@ -184,11 +184,11 @@ namespace Microsoft.Quantum.IQSharp.Kernel
         {
             channel = channel.WithNewLines();
 
-            return await Task.Run(() =>
+            return await Task.Run(async () =>
             {
                 try
                 {
-                    Workspace.WaitForInitialization();
+                    await Workspace.Initialization;
 
                     var code = Snippets.Compile(input);
 

--- a/src/Kernel/Magic/Resolution/MagicResolver.cs
+++ b/src/Kernel/Magic/Resolution/MagicResolver.cs
@@ -27,6 +27,7 @@ namespace Microsoft.Quantum.IQSharp.Kernel
         private Dictionary<AssemblyInfo, MagicSymbol[]> cache;
         private IServiceProvider services;
         private IReferences references;
+        private IWorkspace workspace;
         private ILogger logger;
 
         /// <summary>
@@ -46,6 +47,7 @@ namespace Microsoft.Quantum.IQSharp.Kernel
             };
             this.services = services;
             this.references = services.GetService<IReferences>();
+            this.workspace = services.GetService<IWorkspace>();
         }
 
 
@@ -55,6 +57,8 @@ namespace Microsoft.Quantum.IQSharp.Kernel
         /// </summary>
         private IEnumerable<AssemblyInfo> RelevantAssemblies()
         {
+            workspace.WaitForInitialization();
+
             foreach (var asm in this.kernelAssemblies)
             {
                 yield return asm;

--- a/src/Kernel/Magic/Resolution/MagicResolver.cs
+++ b/src/Kernel/Magic/Resolution/MagicResolver.cs
@@ -57,7 +57,7 @@ namespace Microsoft.Quantum.IQSharp.Kernel
         /// </summary>
         private IEnumerable<AssemblyInfo> RelevantAssemblies()
         {
-            workspace.WaitForInitialization();
+            workspace.Initialization.Wait();
 
             foreach (var asm in this.kernelAssemblies)
             {

--- a/src/Tests/ExecutionPathTracerTests.cs
+++ b/src/Tests/ExecutionPathTracerTests.cs
@@ -20,6 +20,7 @@ namespace Tests.IQSharp
         public Workspace InitWorkspace()
         {
             var ws = Startup.Create<Workspace>("Workspace.ExecutionPathTracer");
+            ws.WaitForInitialization();
             ws.GlobalReferences.AddPackage("mock.standard").Wait();
             ws.Reload();
             Assert.IsFalse(ws.HasErrors);

--- a/src/Tests/ExecutionPathTracerTests.cs
+++ b/src/Tests/ExecutionPathTracerTests.cs
@@ -20,7 +20,7 @@ namespace Tests.IQSharp
         public Workspace InitWorkspace()
         {
             var ws = Startup.Create<Workspace>("Workspace.ExecutionPathTracer");
-            ws.WaitForInitialization();
+            ws.Initialization.Wait();
             ws.GlobalReferences.AddPackage("mock.standard").Wait();
             ws.Reload();
             Assert.IsFalse(ws.HasErrors);

--- a/src/Tests/IQsharpEngineTests.cs
+++ b/src/Tests/IQsharpEngineTests.cs
@@ -29,7 +29,7 @@ namespace Tests.IQSharp
         public IQSharpEngine Init(string workspace = "Workspace")
         {
             var engine = Startup.Create<IQSharpEngine>(workspace);
-            engine.Workspace.WaitForInitialization();
+            engine.Workspace.Initialization.Wait();
             return engine;
         }
 
@@ -390,7 +390,7 @@ namespace Tests.IQSharp
         public async Task TestWho()
         {
             var snippets = Startup.Create<Snippets>("Workspace");
-            snippets.Workspace.WaitForInitialization();
+            await snippets.Workspace.Initialization;
             snippets.Compile(SNIPPETS.HelloQ);
 
             var whoMagic = new WhoMagic(snippets);
@@ -467,10 +467,10 @@ namespace Tests.IQSharp
         }
 
         [TestMethod]
-        public void TestResolver()
+        public async void TestResolver()
         {
             var snippets = Startup.Create<Snippets>("Workspace");
-            snippets.Workspace.WaitForInitialization();
+            await snippets.Workspace.Initialization;
             snippets.Compile(SNIPPETS.HelloQ);
 
             var resolver = new SymbolResolver(snippets);

--- a/src/Tests/IQsharpEngineTests.cs
+++ b/src/Tests/IQsharpEngineTests.cs
@@ -28,7 +28,9 @@ namespace Tests.IQSharp
     {
         public IQSharpEngine Init(string workspace = "Workspace")
         {
-            return Startup.Create<IQSharpEngine>(workspace);
+            var engine = Startup.Create<IQSharpEngine>(workspace);
+            engine.Workspace.WaitForInitialization();
+            return engine;
         }
 
         public static void PrintResult(ExecutionResult result, MockChannel channel)
@@ -388,6 +390,7 @@ namespace Tests.IQSharp
         public async Task TestWho()
         {
             var snippets = Startup.Create<Snippets>("Workspace");
+            snippets.Workspace.WaitForInitialization();
             snippets.Compile(SNIPPETS.HelloQ);
 
             var whoMagic = new WhoMagic(snippets);
@@ -467,6 +470,7 @@ namespace Tests.IQSharp
         public void TestResolver()
         {
             var snippets = Startup.Create<Snippets>("Workspace");
+            snippets.Workspace.WaitForInitialization();
             snippets.Compile(SNIPPETS.HelloQ);
 
             var resolver = new SymbolResolver(snippets);

--- a/src/Tests/IQsharpEngineTests.cs
+++ b/src/Tests/IQsharpEngineTests.cs
@@ -326,7 +326,7 @@ namespace Tests.IQSharp
 
             var pkgMagic = new PackageMagic(snippets.GlobalReferences);
             var references = ((References)pkgMagic.References);
-            var packageCount = references.AutoLoadPackages.Count + references.DeferredLoadPackages.Count;
+            var packageCount = references.AutoLoadPackages.Count;
             var channel = new MockChannel();
             var response = await pkgMagic.Execute("", channel);
             var result = response.Output as string[];

--- a/src/Tests/IQsharpEngineTests.cs
+++ b/src/Tests/IQsharpEngineTests.cs
@@ -467,7 +467,7 @@ namespace Tests.IQSharp
         }
 
         [TestMethod]
-        public async void TestResolver()
+        public async Task TestResolver()
         {
             var snippets = Startup.Create<Snippets>("Workspace");
             await snippets.Workspace.Initialization;

--- a/src/Tests/PackagesControllerTest.cs
+++ b/src/Tests/PackagesControllerTest.cs
@@ -26,7 +26,7 @@ namespace Tests.IQSharp
             var controller = Init();
             var response = await controller.List();
             var references = (References)controller.References;
-            var packageCount = references.AutoLoadPackages.Count + references.DeferredLoadPackages.Count;
+            var packageCount = references.AutoLoadPackages.Count;
 
             Assert.AreEqual(Status.Success, response.Status);
             Assert.AreEqual(0, response.Messages.Length);

--- a/src/Tests/Startup.cs
+++ b/src/Tests/Startup.cs
@@ -40,6 +40,7 @@ namespace Tests.IQSharp
 
             var serviceProvider = services.BuildServiceProvider();
             serviceProvider.GetRequiredService<ITelemetryService>();
+            serviceProvider.GetService<IWorkspace>().WaitForInitialization();
             return serviceProvider;
         }
 

--- a/src/Tests/Startup.cs
+++ b/src/Tests/Startup.cs
@@ -40,7 +40,7 @@ namespace Tests.IQSharp
 
             var serviceProvider = services.BuildServiceProvider();
             serviceProvider.GetRequiredService<ITelemetryService>();
-            serviceProvider.GetService<IWorkspace>().WaitForInitialization();
+            serviceProvider.GetRequiredService<IWorkspace>().WaitForInitialization();
             return serviceProvider;
         }
 

--- a/src/Tests/Startup.cs
+++ b/src/Tests/Startup.cs
@@ -40,7 +40,7 @@ namespace Tests.IQSharp
 
             var serviceProvider = services.BuildServiceProvider();
             serviceProvider.GetRequiredService<ITelemetryService>();
-            serviceProvider.GetRequiredService<IWorkspace>().WaitForInitialization();
+            serviceProvider.GetRequiredService<IWorkspace>().Initialization.Wait();
             return serviceProvider;
         }
 

--- a/src/Tests/WorkspaceTests.cs
+++ b/src/Tests/WorkspaceTests.cs
@@ -13,17 +13,17 @@ namespace Tests.IQSharp
     public class WorkspaceTests
     {
         [TestMethod]
-        public void InitWorkspace()
+        public async void InitWorkspace()
         {
             var ws = Startup.Create<Workspace>("Workspace");
-            ws.WaitForInitialization();
+            await ws.Initialization;
 
             var dll = ws.Projects.Single().CacheDllPath;
             if (File.Exists(dll)) File.Delete(dll);
 
             // First time
             ws = Startup.Create<Workspace>("Workspace");
-            ws.WaitForInitialization();
+            await ws.Initialization;
             Assert.IsFalse(ws.HasErrors);
 
             var op = ws.AssemblyInfo.Operations.FirstOrDefault(o => o.FullName == "Tests.qss.NoOp");
@@ -31,7 +31,7 @@ namespace Tests.IQSharp
 
             // On next reload:
             ws = Startup.Create<Workspace>("Workspace");
-            ws.WaitForInitialization();
+            await ws.Initialization;
             Assert.IsFalse(ws.HasErrors);
 
             op = ws.AssemblyInfo.Operations.FirstOrDefault(o => o.FullName == "Tests.qss.NoOp");
@@ -39,10 +39,10 @@ namespace Tests.IQSharp
         }
 
         [TestMethod]
-        public void ReloadWorkspace()
+        public async void ReloadWorkspace()
         {
             var ws = Startup.Create<Workspace>("Workspace");
-            ws.WaitForInitialization();
+            await ws.Initialization;
             var originalAssembly = ws.AssemblyInfo;
             var op = ws.AssemblyInfo.Operations.FirstOrDefault(o => o.FullName == "Tests.qss.NoOp");
             Assert.IsFalse(ws.HasErrors);

--- a/src/Tests/WorkspaceTests.cs
+++ b/src/Tests/WorkspaceTests.cs
@@ -16,12 +16,14 @@ namespace Tests.IQSharp
         public void InitWorkspace()
         {
             var ws = Startup.Create<Workspace>("Workspace");
+            ws.WaitForInitialization();
 
             var dll = ws.Projects.Single().CacheDllPath;
             if (File.Exists(dll)) File.Delete(dll);
 
             // First time
             ws = Startup.Create<Workspace>("Workspace");
+            ws.WaitForInitialization();
             Assert.IsFalse(ws.HasErrors);
 
             var op = ws.AssemblyInfo.Operations.FirstOrDefault(o => o.FullName == "Tests.qss.NoOp");
@@ -29,6 +31,7 @@ namespace Tests.IQSharp
 
             // On next reload:
             ws = Startup.Create<Workspace>("Workspace");
+            ws.WaitForInitialization();
             Assert.IsFalse(ws.HasErrors);
 
             op = ws.AssemblyInfo.Operations.FirstOrDefault(o => o.FullName == "Tests.qss.NoOp");
@@ -39,6 +42,7 @@ namespace Tests.IQSharp
         public void ReloadWorkspace()
         {
             var ws = Startup.Create<Workspace>("Workspace");
+            ws.WaitForInitialization();
             var originalAssembly = ws.AssemblyInfo;
             var op = ws.AssemblyInfo.Operations.FirstOrDefault(o => o.FullName == "Tests.qss.NoOp");
             Assert.IsFalse(ws.HasErrors);

--- a/src/Tests/WorkspaceTests.cs
+++ b/src/Tests/WorkspaceTests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 using Microsoft.Quantum.IQSharp;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -13,7 +14,7 @@ namespace Tests.IQSharp
     public class WorkspaceTests
     {
         [TestMethod]
-        public async void InitWorkspace()
+        public async Task InitWorkspace()
         {
             var ws = Startup.Create<Workspace>("Workspace");
             await ws.Initialization;
@@ -39,7 +40,7 @@ namespace Tests.IQSharp
         }
 
         [TestMethod]
-        public async void ReloadWorkspace()
+        public async Task ReloadWorkspace()
         {
             var ws = Startup.Create<Workspace>("Workspace");
             await ws.Initialization;

--- a/src/Tool/Program.cs
+++ b/src/Tool/Program.cs
@@ -76,7 +76,6 @@ namespace Microsoft.Quantum.IQSharp
                             ["HOSTING_ENV"] = "HostingEnvironment",
                             ["LOG_PATH"] = "LogPath",
                             ["AUTO_LOAD_PACKAGES"] = "AutoLoadPackages",
-                            ["DEFERRED_LOAD_PACKAGES"] = "DeferredLoadPackages",
                             ["AUTO_OPEN_NAMESPACES"] = "AutoOpenNamespaces",
                             ["SKIP_AUTO_LOAD_PROJECT"] = "SkipAutoLoadProject",
                         }

--- a/src/Tool/Telemetry.cs
+++ b/src/Tool/Telemetry.cs
@@ -65,6 +65,9 @@ namespace Microsoft.Quantum.IQSharp
                 snippets.SnippetCompiled += (_, info) => TelemetryLogger.LogEvent(info.AsTelemetryEvent());
             eventService.OnServiceInitialized<IWorkspace>().On += (workspace) =>
             {
+                TelemetryLogger.LogEvent(
+                    "WorkspaceInitialized".AsTelemetryEvent().WithTimeSinceStart()
+                );
                 workspace.Reloaded += (_, info) => TelemetryLogger.LogEvent(info.AsTelemetryEvent());
                 workspace.ProjectLoaded += (_, info) => TelemetryLogger.LogEvent(info.AsTelemetryEvent());
             };

--- a/src/Web/SnippetsController.cs
+++ b/src/Web/SnippetsController.cs
@@ -23,15 +23,18 @@ namespace Microsoft.Quantum.IQSharp
     [ApiController]
     public class SnippetsController : AbstractOperationsController
     {
-        public SnippetsController(ISnippets snippets) : base()
+        public SnippetsController(ISnippets snippets, IWorkspace workspace) : base()
         {
             this.Snippets = snippets;
+            this.Workspace = workspace;
         }
 
         /// <summary>
         /// The list of available Snippets.
         /// </summary>
         public ISnippets Snippets { get; }
+
+        private IWorkspace Workspace { get; }
 
         /// <summary>
         /// Overrides this method to return the list of Operations available from the list of Snippets 
@@ -106,8 +109,13 @@ namespace Microsoft.Quantum.IQSharp
         /// <summary>
         /// Overrides CheckIfReady by not checking if the Workspace is actually available.
         /// It should be possible to build and run self-contained snippets.
+        /// We still need to wait for Workspace initialization to complete, however,
+        /// since this ensures that the kernel is ready to compile snippets.
         /// </summary>
-        protected override void CheckIfReady() { }
+        protected override void CheckIfReady()
+        {
+            Workspace.WaitForInitialization();
+        }
     }
 }
 

--- a/src/Web/SnippetsController.cs
+++ b/src/Web/SnippetsController.cs
@@ -114,7 +114,7 @@ namespace Microsoft.Quantum.IQSharp
         /// </summary>
         protected override void CheckIfReady()
         {
-            Workspace.WaitForInitialization();
+            Workspace.Initialization.Wait();
         }
     }
 }

--- a/src/Web/WorkspaceController.cs
+++ b/src/Web/WorkspaceController.cs
@@ -112,7 +112,10 @@ namespace Microsoft.Quantum.IQSharp
             {
                 throw new InvalidWorkspaceException($"Workspace is not ready. Try again.");
             }
-            else if (Workspace.HasErrors)
+
+            Workspace.WaitForInitialization();
+            
+            if (Workspace.HasErrors)
             {
                 throw new InvalidWorkspaceException(Workspace.ErrorMessages.ToArray());
             }

--- a/src/Web/WorkspaceController.cs
+++ b/src/Web/WorkspaceController.cs
@@ -113,7 +113,7 @@ namespace Microsoft.Quantum.IQSharp
                 throw new InvalidWorkspaceException($"Workspace is not ready. Try again.");
             }
 
-            Workspace.WaitForInitialization();
+            Workspace.Initialization.Wait();
             
             if (Workspace.HasErrors)
             {


### PR DESCRIPTION
In cases where we load a significant number of packages and/or compile a significant amount of Q# code at kernel initialization time, it's possible to exceed Jupyter's default 60-second timeout for kernel_info_reply, which results in an error message being displayed to the user (even though the initialization does eventually succeed).

In addition, client-side features such as Q# syntax highlighting don't light up until the kernel_info_reply is received.

This change moves the workspace initialization to be asynchronous, such that the kernel_info_reply can be sent prior to loading the packages or compiling the Q# code in the workspace. Cell execution will now wait for the workspace initialization to complete before attempting to execute the cell.

This PR is intended to address issues discovered in CI runs and local testing for https://github.com/microsoft/QuantumKatas/pull/468 and https://github.com/microsoft/QuantumKatas/pull/494.

Here is a diagram showing how this changes the behavior as compared to the August IQ# release (0.12.20082513) and September IQ# release (0.12.20092803):
![image](https://user-images.githubusercontent.com/3620100/94969658-fae88200-04b7-11eb-9cd0-05018f8906a8.png)

The change in this PR should fix two problems:

1. Loading M.Q.Standard.Visualization in the background caused some non-deterministic behavior depending on when the package finished loading because the package-loaded listeners that register display encoders were not thread-safe.
   - I believe this was the cause of the failures in the CI tests in https://github.com/microsoft/QuantumKatas/pull/494.
	
1. When loading project references, it's likely that loading package references and Q# compilation will take much longer than it would take otherwise. So those should be async to avoid delaying the kernel info reply too long.		
   - This was the cause of the CI failures in https://github.com/microsoft/QuantumKatas/pull/468. This is needed to enable project/package references in the Katas projects, without running the risk of Jupyter Notebook potentially showing the kernel info timeout message.