### PR TITLE
Add basic Selenium tests for IQ# notebook

### DIFF
--- a/build/ci.yml
+++ b/build/ci.yml
@@ -24,7 +24,6 @@ jobs:
       failOnAlert: true
 
 - job: "test_selenium"
-  dependsOn: "iqsharp"
   pool:
     vmImage: 'windows-2019'
   steps:

--- a/build/ci.yml
+++ b/build/ci.yml
@@ -23,6 +23,14 @@ jobs:
     inputs:
       failOnAlert: true
 
+- job: "test_selenium"
+  dependsOn: "iqsharp"
+  pool:
+    vmImage: 'windows-2019'
+  steps:
+  - template: steps-selenium.yml
+  condition: ne(variables['Skip.Tests'], 'true')
+
 - job: "pack_selfcontained"
   dependsOn: "iqsharp"
   pool:

--- a/build/steps-selenium.yml
+++ b/build/steps-selenium.yml
@@ -10,7 +10,7 @@ steps:
 ##
 - task: CondaEnvironment@1
   inputs:
-    packageSpecs: "python=3.7 pip setuptools pytest jupyter notebook numpy selenium"
+    packageSpecs: "python=3.7 pip setuptools pytest jupyter_client=6.1.7 notebook=6.1.1 selenium=3.141"
   displayName: 'Create conda environment'
 
 - task: UseDotNet@2

--- a/build/steps-selenium.yml
+++ b/build/steps-selenium.yml
@@ -29,8 +29,7 @@ steps:
 # Install IQ# kernel
 ##
 - pwsh: |
-    conda init powershell
-    conda activate selenium-env
+    activate selenium-env
     dotnet run -c $Env:BUILD_CONFIGURATION -- install --user
   displayName: "Installing IQ#"
   workingDirectory: '$(System.DefaultWorkingDirectory)/src/Tool'
@@ -39,8 +38,7 @@ steps:
 # Test
 ##
 - pwsh: |
-    conda init powershell
-    conda activate selenium-env
+    activate selenium-env
     python ./test-selenium.py
   displayName: "Running Selenium tests"
   workingDirectory: '$(System.DefaultWorkingDirectory)/build'

--- a/build/steps-selenium.yml
+++ b/build/steps-selenium.yml
@@ -41,6 +41,7 @@ steps:
 - script: |
     call activate selenium-env
     call conda info
+    start jupyter notebook --no-browser --NotebookApp.base_url=test/path
     python ./test-selenium.py
   displayName: "Running Selenium tests"
   workingDirectory: '$(System.DefaultWorkingDirectory)/build'

--- a/build/steps-selenium.yml
+++ b/build/steps-selenium.yml
@@ -11,8 +11,7 @@ steps:
 - pwsh: Write-Host "##vso[task.prependpath]$env:CONDA\Scripts"
   displayName: "Add conda to PATH"
 
-- pwsh: |
-    conda create -n selenium-env -y python=3.7 pip setuptools pytest jupyter_client=6.1.7 notebook=6.1.1 selenium=3.141
+- pwsh: conda create -n selenium-env -y python=3.7 pip setuptools pytest jupyter_client=6.1.7 notebook=6.1.1 selenium=3.141
   displayName: "Create conda environment"
 
 - task: UseDotNet@2
@@ -21,7 +20,7 @@ steps:
     packageType: sdk
     version: '3.1.100'
 
-- pwsh: .\bootstrap.ps1
+- pwsh: ./bootstrap.ps1
   displayName: "Bootstrap"
   workingDirectory: '$(System.DefaultWorkingDirectory)'
 

--- a/build/steps-selenium.yml
+++ b/build/steps-selenium.yml
@@ -8,11 +8,15 @@ steps:
 ##
 # Pre-reqs
 ##
-- pwsh: Write-Host "##vso[task.prependpath]$env:CONDA\Scripts"
-  displayName: "Add conda to PATH"
+- task: CondaEnvironment@1
+  inputs:
+    packageSpecs: "python=3.7 pip setuptools"
+  displayName: 'Use conda environment w/ Python 3.'
+  workingDirectory: '$(System.DefaultWorkingDirectory)'
 
-- pwsh: conda create -n selenium-env -y python=3.7 pip setuptools pytest jupyter_client=6.1.7 notebook=6.1.1 selenium=3.141
-  displayName: "Create conda environment"
+- pwsh: pip install -r ./test-selenium-requirements.txt
+  displayName: 'Install Selenium and Jupyter Notebook'
+  workingDirectory: '$(System.DefaultWorkingDirectory)/build'
 
 - task: UseDotNet@2
   displayName: 'Use .NET Core SDK 3.1.100'
@@ -27,10 +31,7 @@ steps:
 ##
 # Install IQ# kernel
 ##
-- script: |
-    call activate selenium-env
-    call conda info
-    dotnet run -c %BUILD_CONFIGURATION% -- install --user
+- script: dotnet run -c %BUILD_CONFIGURATION% -- install --user
   displayName: "Installing IQ#"
   workingDirectory: '$(System.DefaultWorkingDirectory)/src/Tool'
 
@@ -38,8 +39,6 @@ steps:
 # Test
 ##
 - script: |
-    call activate selenium-env
-    call conda info
     start jupyter notebook --no-browser --NotebookApp.base_url=test/path
     pytest -v ./test-selenium.py
   displayName: "Running Selenium tests"

--- a/build/steps-selenium.yml
+++ b/build/steps-selenium.yml
@@ -28,20 +28,18 @@ steps:
 ##
 # Install IQ# kernel
 ##
-- pwsh: |
+- script: |
+    call activate selenium-env
     conda info
-    activate selenium-env
-    conda info
-    dotnet run -c $Env:BUILD_CONFIGURATION -- install --user
+    dotnet run -c %BUILD_CONFIGURATION% -- install --user
   displayName: "Installing IQ#"
   workingDirectory: '$(System.DefaultWorkingDirectory)/src/Tool'
 
 ##
 # Test
 ##
-- pwsh: |
-    conda info
-    activate selenium-env
+- script: |
+    call activate selenium-env
     conda info
     python ./test-selenium.py
   displayName: "Running Selenium tests"

--- a/build/steps-selenium.yml
+++ b/build/steps-selenium.yml
@@ -26,6 +26,9 @@ steps:
 ##
 # Install IQ# kernel
 ##
+- pwsh: conda install pyzmq -y --force-reinstall
+  displayName: "Installing pyzmq"
+
 - pwsh: dotnet run -c $Env:BUILD_CONFIGURATION -- install --user
   displayName: "Installing IQ#"
   workingDirectory: '$(System.DefaultWorkingDirectory)/src/Tool'

--- a/build/steps-selenium.yml
+++ b/build/steps-selenium.yml
@@ -11,7 +11,9 @@ steps:
 - pwsh: Write-Host "##vso[task.prependpath]$env:CONDA\Scripts"
   displayName: "Add conda to PATH"
 
-- pwsh: conda create -n selenium-env -y python=3.7 pip setuptools pytest jupyter_client=6.1.7 notebook=6.1.1 selenium=3.141
+- pwsh: |
+    conda create -n selenium-env -y python=3.7 pip setuptools pytest jupyter_client=6.1.7 notebook=6.1.1 selenium=3.141
+    conda init powershell
   displayName: "Create conda environment"
 
 - task: UseDotNet@2
@@ -27,7 +29,9 @@ steps:
 ##
 # Install IQ# kernel
 ##
-- pwsh: dotnet run -c $Env:BUILD_CONFIGURATION -- install --user
+- pwsh: |
+    conda activate selenium-env
+    dotnet run -c $Env:BUILD_CONFIGURATION -- install --user
   displayName: "Installing IQ#"
   workingDirectory: '$(System.DefaultWorkingDirectory)/src/Tool'
 

--- a/build/steps-selenium.yml
+++ b/build/steps-selenium.yml
@@ -1,0 +1,38 @@
+##
+# Test IQ# with Selenium.
+# Windows build agents have ChromeWebDriver and GeckoWebDriver pre-installed.
+##
+
+steps:
+
+##
+# Pre-reqs
+##
+- task: CondaEnvironment@1
+  inputs:
+    packageSpecs: "python=3.7 pip setuptools pytest jupyter notebook numpy selenium"
+  displayName: 'Create conda environment'
+
+- task: UseDotNet@2
+  displayName: 'Use .NET Core SDK 3.1.100'
+  inputs:
+    packageType: sdk
+    version: '3.1.100'
+
+- pwsh: .\bootstrap.ps1
+  displayName: "Bootstrap"
+  workingDirectory: '$(System.DefaultWorkingDirectory)'
+
+##
+# Install IQ# kernel
+##
+- pwsh: dotnet run -c $Env:BUILD_CONFIGURATION -- install --user
+  displayName: "Installing IQ#"
+  workingDirectory: '$(System.DefaultWorkingDirectory)/src/Tool'
+
+##
+# Test
+##
+- pwsh: python ./test-selenium.py
+  displayName: "Running Selenium tests"
+  workingDirectory: '$(System.DefaultWorkingDirectory)/build'

--- a/build/steps-selenium.yml
+++ b/build/steps-selenium.yml
@@ -12,7 +12,7 @@ steps:
   displayName: "Add conda to PATH"
 
 - pwsh: |
-    conda create -n selenium-env -y python=3.7 pip setuptools pytest jupyter jupyter_client=6.1.7 notebook=6.1.1 selenium=3.141
+    conda create -n selenium-env -y python=3.7 pip setuptools pytest jupyter_client=6.1.7 notebook=6.1.1 selenium=3.141
   displayName: "Create conda environment"
 
 - task: UseDotNet@2

--- a/build/steps-selenium.yml
+++ b/build/steps-selenium.yml
@@ -13,7 +13,6 @@ steps:
 
 - pwsh: |
     conda create -n selenium-env -y python=3.7 pip setuptools pytest jupyter_client=6.1.7 notebook=6.1.1 selenium=3.141
-    conda init powershell
   displayName: "Create conda environment"
 
 - task: UseDotNet@2
@@ -30,6 +29,7 @@ steps:
 # Install IQ# kernel
 ##
 - pwsh: |
+    conda init powershell
     conda activate selenium-env
     dotnet run -c $Env:BUILD_CONFIGURATION -- install --user
   displayName: "Installing IQ#"
@@ -39,6 +39,7 @@ steps:
 # Test
 ##
 - pwsh: |
+    conda init powershell
     conda activate selenium-env
     python ./test-selenium.py
   displayName: "Running Selenium tests"

--- a/build/steps-selenium.yml
+++ b/build/steps-selenium.yml
@@ -42,6 +42,6 @@ steps:
     call activate selenium-env
     call conda info
     start jupyter notebook --no-browser --NotebookApp.base_url=test/path
-    python ./test-selenium.py
+    pytest -v ./test-selenium.py
   displayName: "Running Selenium tests"
   workingDirectory: '$(System.DefaultWorkingDirectory)/build'

--- a/build/steps-selenium.yml
+++ b/build/steps-selenium.yml
@@ -30,7 +30,7 @@ steps:
 ##
 - script: |
     call activate selenium-env
-    conda info
+    call conda info
     dotnet run -c %BUILD_CONFIGURATION% -- install --user
   displayName: "Installing IQ#"
   workingDirectory: '$(System.DefaultWorkingDirectory)/src/Tool'
@@ -40,7 +40,7 @@ steps:
 ##
 - script: |
     call activate selenium-env
-    conda info
+    call conda info
     python ./test-selenium.py
   displayName: "Running Selenium tests"
   workingDirectory: '$(System.DefaultWorkingDirectory)/build'

--- a/build/steps-selenium.yml
+++ b/build/steps-selenium.yml
@@ -12,7 +12,6 @@ steps:
   inputs:
     packageSpecs: "python=3.7 pip setuptools"
   displayName: 'Use conda environment w/ Python 3.'
-  workingDirectory: '$(System.DefaultWorkingDirectory)'
 
 - pwsh: pip install -r ./test-selenium-requirements.txt
   displayName: 'Install Selenium and Jupyter Notebook'

--- a/build/steps-selenium.yml
+++ b/build/steps-selenium.yml
@@ -12,7 +12,7 @@ steps:
   displayName: "Add conda to PATH"
 
 - pwsh: |
-    conda create -n selenium-env -y python=3.7 pip setuptools pytest jupyter_client=6.1.7 notebook=6.1.1 selenium=3.141
+    conda create -n selenium-env -y python=3.7 pip setuptools pytest jupyter jupyter_client=6.1.7 notebook=6.1.1 selenium=3.141
   displayName: "Create conda environment"
 
 - task: UseDotNet@2
@@ -29,7 +29,9 @@ steps:
 # Install IQ# kernel
 ##
 - pwsh: |
+    conda info
     activate selenium-env
+    conda info
     dotnet run -c $Env:BUILD_CONFIGURATION -- install --user
   displayName: "Installing IQ#"
   workingDirectory: '$(System.DefaultWorkingDirectory)/src/Tool'
@@ -38,7 +40,9 @@ steps:
 # Test
 ##
 - pwsh: |
+    conda info
     activate selenium-env
+    conda info
     python ./test-selenium.py
   displayName: "Running Selenium tests"
   workingDirectory: '$(System.DefaultWorkingDirectory)/build'

--- a/build/steps-selenium.yml
+++ b/build/steps-selenium.yml
@@ -8,10 +8,11 @@ steps:
 ##
 # Pre-reqs
 ##
-- task: CondaEnvironment@1
-  inputs:
-    packageSpecs: "python=3.7 pip setuptools pytest jupyter_client=6.1.7 notebook=6.1.1 selenium=3.141"
-  displayName: 'Create conda environment'
+- pwsh: Write-Host "##vso[task.prependpath]$env:CONDA\Scripts"
+  displayName: "Add conda to PATH"
+
+- pwsh: conda create -n selenium-env -y python=3.7 pip setuptools pytest jupyter_client=6.1.7 notebook=6.1.1 selenium=3.141
+  displayName: "Create conda environment"
 
 - task: UseDotNet@2
   displayName: 'Use .NET Core SDK 3.1.100'
@@ -26,9 +27,6 @@ steps:
 ##
 # Install IQ# kernel
 ##
-- pwsh: conda install pyzmq -y --force-reinstall
-  displayName: "Installing pyzmq"
-
 - pwsh: dotnet run -c $Env:BUILD_CONFIGURATION -- install --user
   displayName: "Installing IQ#"
   workingDirectory: '$(System.DefaultWorkingDirectory)/src/Tool'
@@ -36,6 +34,8 @@ steps:
 ##
 # Test
 ##
-- pwsh: python ./test-selenium.py
+- pwsh: |
+    conda activate selenium-env
+    python ./test-selenium.py
   displayName: "Running Selenium tests"
   workingDirectory: '$(System.DefaultWorkingDirectory)/build'

--- a/build/test-selenium-requirements.txt
+++ b/build/test-selenium-requirements.txt
@@ -1,0 +1,4 @@
+pytest
+jupyter_client=6.1.7
+notebook=6.1.1
+selenium=3.141

--- a/build/test-selenium-requirements.txt
+++ b/build/test-selenium-requirements.txt
@@ -1,4 +1,4 @@
 pytest
-jupyter_client=6.1.7
-notebook=6.1.1
-selenium=3.141
+jupyter_client==6.1.7
+notebook==6.1.1
+selenium==3.141

--- a/build/test-selenium.py
+++ b/build/test-selenium.py
@@ -26,13 +26,14 @@ def setup_module():
     
 def test_cell_execution():
     '''
-    Check that %version executes and outputs a result
+    Check that %version executes and outputs an expected result
     '''
     nb = Notebook.new_notebook(quick_driver(), kernel_name='kernel-iqsharp')
     nb.edit_cell(index=0, content='%version')
     nb.execute_cell(cell_or_index=0)
-    nb.wait_for_cell_output(index=0, timeout=120)
+    outputs = nb.wait_for_cell_output(index=0, timeout=120)
 
-    assert len(nb.get_cell_output(index=0)) > 0
+    assert len(outputs) > 0
+    assert "iqsharp" in outputs[0].text, outputs[0].text
     
     nb.browser.quit()

--- a/build/test-selenium.py
+++ b/build/test-selenium.py
@@ -1,30 +1,38 @@
 import os
+import pytest
 import time
 
 from notebook.notebookapp import list_running_servers
 from notebook.tests.selenium.utils import Notebook
 from notebook.tests.selenium.quick_selenium import quick_driver
 
-remaining_time = 180
-iteration_time = 5
-print("Waiting for notebook server to start...")
-while not list(list_running_servers()) and remaining_time > 0:
-    time.sleep(iteration_time)
-    remaining_time -= iteration_time
-
-if not list(list_running_servers()):
-    raise Exception(f"Notebook server did not start in {remaining_time} seconds")
-
 # workaround for missing os.uname attribute on some Windows systems
 if not hasattr(os, "uname"):
     os.uname = lambda: ["Windows"]
 
-# Check that %version executes and outputs a result
-nb = Notebook.new_notebook(quick_driver(), kernel_name='kernel-iqsharp')
-nb.edit_cell(index=0, content='%version')
-nb.execute_cell(cell_or_index=0)
-nb.wait_for_cell_output(index=0, timeout=120)
+def setup_module():
+    '''
+    Wait for notebook server to start
+    '''
+    remaining_time = 180
+    iteration_time = 5
+    print("Waiting for notebook server to start...")
+    while not list(list_running_servers()) and remaining_time > 0:
+        time.sleep(iteration_time)
+        remaining_time -= iteration_time
 
-assert len(nb.get_cell_output(index=0)) > 0
+    if not list(list_running_servers()):
+        raise Exception(f"Notebook server did not start in {remaining_time} seconds")
+    
+def test_cell_execution():
+    '''
+    Check that %version executes and outputs a result
+    '''
+    nb = Notebook.new_notebook(quick_driver(), kernel_name='kernel-iqsharp')
+    nb.edit_cell(index=0, content='%version')
+    nb.execute_cell(cell_or_index=0)
+    nb.wait_for_cell_output(index=0, timeout=120)
 
-nb.browser.quit()
+    assert len(nb.get_cell_output(index=0)) > 0
+    
+    nb.browser.quit()

--- a/build/test-selenium.py
+++ b/build/test-selenium.py
@@ -1,9 +1,30 @@
+import os
+import time
+
+from notebook.notebookapp import list_running_servers
 from notebook.tests.selenium.utils import Notebook
 from notebook.tests.selenium.quick_selenium import quick_driver
 
-nb = Notebook.new_notebook(quick_driver(), kernel_name='kernel-iqsharp')
-nb.add_and_execute_cell(content='%version')
+remaining_time = 180
+iteration_time = 5
+print("Waiting for notebook server to start...")
+while not list(list_running_servers()) and remaining_time > 0:
+    time.sleep(iteration_time)
+    remaining_time -= iteration_time
 
-print(nb.get_cell_output())
+if not list(list_running_servers()):
+    raise Exception(f"Notebook server did not start in {remaining_time} seconds")
+
+# workaround for missing os.uname attribute on some Windows systems
+if not hasattr(os, "uname"):
+    os.uname = lambda: ["Windows"]
+
+# Check that %version executes and outputs a result
+nb = Notebook.new_notebook(quick_driver(), kernel_name='kernel-iqsharp')
+nb.edit_cell(index=0, content='%version')
+nb.execute_cell(cell_or_index=0)
+nb.wait_for_cell_output(index=0, timeout=120)
+
+assert len(nb.get_cell_output(index=0)) > 0
 
 nb.browser.quit()

--- a/build/test-selenium.py
+++ b/build/test-selenium.py
@@ -1,0 +1,9 @@
+from notebook.tests.selenium.utils import Notebook
+from notebook.tests.selenium.quick_selenium import quick_driver
+
+nb = Notebook.new_notebook(quick_driver(), kernel_name='kernel-iqsharp')
+nb.add_and_execute_cell(content='%version')
+
+print(nb.get_cell_output())
+
+nb.browser.quit()

--- a/build/test-selenium.py
+++ b/build/test-selenium.py
@@ -7,14 +7,14 @@ from notebook.tests.selenium.utils import Notebook
 from selenium.common.exceptions import JavascriptException
 from selenium.webdriver import Firefox
 
-# workaround for missing os.uname attribute on some Windows systems
-if not hasattr(os, "uname"):
-    os.uname = lambda: ["Windows"]
-
 def setup_module():
     '''
     Wait for notebook server to start
     '''
+    # workaround for missing os.uname attribute on some Windows systems
+    if not hasattr(os, "uname"):
+        os.uname = lambda: ["Windows"]
+
     remaining_time = 180
     iteration_time = 5
     print("Waiting for notebook server to start...")


### PR DESCRIPTION
This PR adds basic Selenium-based browser integration tests to the IQ# CI pipeline. The tests validate that a Q# Jupyter Notebook can be opened in a browser, that a simple cell execution succeeds, and that the expected JavaScript modules are loaded.