### PR TITLE
Fix DumpMachine to allow location-based output

### DIFF
--- a/src/Jupyter/Visualization/StateDisplayOperations.cs
+++ b/src/Jupyter/Visualization/StateDisplayOperations.cs
@@ -126,7 +126,7 @@ namespace Microsoft.Quantum.IQSharp.Jupyter
     ///     that dumps the state of its target machine to a Jupyter-displayable
     ///     object.
     /// </summary>
-    public class JupyterDumpMachine<T> : Microsoft.Quantum.Diagnostics.DumpMachine<T>
+    public class JupyterDumpMachine<T> : Microsoft.Quantum.Simulation.Simulators.QuantumSimulator.QsimDumpMachine<T>
     {
         private QuantumSimulator Simulator { get; }
         internal IConfigurationSource? ConfigurationSource = null;
@@ -169,7 +169,7 @@ namespace Microsoft.Quantum.IQSharp.Jupyter
     ///     that dumps the state of its target machine to a Jupyter-displayable
     ///     object.
     /// </summary>
-    public class JupyterDumpRegister<T> : Microsoft.Quantum.Diagnostics.DumpRegister<T>
+    public class JupyterDumpRegister<T> : Microsoft.Quantum.Simulation.Simulators.QuantumSimulator.QSimDumpRegister<T>
     {
         private QuantumSimulator Simulator { get; }
         internal IConfigurationSource? ConfigurationSource = null;

--- a/src/Tests/IQsharpEngineTests.cs
+++ b/src/Tests/IQsharpEngineTests.cs
@@ -262,6 +262,22 @@ namespace Tests.IQSharp
         }
 
         [TestMethod]
+        public async Task DumpToFile()
+        {
+            var engine = Init();
+
+            // Compile DumpMachine snippet.
+            await AssertCompile(engine, SNIPPETS.DumpToFile, "DumpToFile");
+
+            // Run, which should produce files in working directory.
+            await AssertSimulate(engine, "DumpToFile", "Dumped to file!");
+
+            // Ensure the expected files got created.
+            Assert.IsTrue(System.IO.File.Exists("DumpMachine.txt"));
+            Assert.IsTrue(System.IO.File.Exists("DumpRegister.txt"));
+        }
+
+        [TestMethod]
         public async Task UpdateDependency()
         {
             var engine = Init();

--- a/src/Tests/IQsharpEngineTests.cs
+++ b/src/Tests/IQsharpEngineTests.cs
@@ -273,8 +273,20 @@ namespace Tests.IQSharp
             await AssertSimulate(engine, "DumpToFile", "Dumped to file!");
 
             // Ensure the expected files got created.
-            Assert.IsTrue(System.IO.File.Exists("DumpMachine.txt"));
-            Assert.IsTrue(System.IO.File.Exists("DumpRegister.txt"));
+            var machineFile = "DumpMachine.txt";
+            var registerFile = "DumpRegister.txt";
+            Assert.IsTrue(System.IO.File.Exists(machineFile));
+            Assert.IsTrue(System.IO.File.Exists(registerFile));
+
+            // Clean up produced files, if any.
+            if (System.IO.File.Exists(machineFile))
+            {
+                System.IO.File.Delete(machineFile);
+            }
+            if (System.IO.File.Exists(registerFile))
+            {
+                System.IO.File.Delete(registerFile);
+            }
         }
 
         [TestMethod]

--- a/src/Tests/SNIPPETS.cs
+++ b/src/Tests/SNIPPETS.cs
@@ -155,6 +155,21 @@ namespace Tests.IQSharp
     }
 ";
 
+        public static string DumpToFile =
+@"
+    /// # Summary
+    ///     This checks the ability to dump simulator state to a file.
+    operation DumpToFile() : Unit
+    {
+        using (qs = Qubit[2])
+        {
+            Microsoft.Quantum.Diagnostics.DumpMachine(""DumpMachine.txt"");
+            Microsoft.Quantum.Diagnostics.DumpRegister(""DumpRegister.txt"", qs);
+            Message(""Dumped to file!"");
+        }
+    }
+";
+
 
         public static string OneWarning =
 @"


### PR DESCRIPTION
This fixes a bug in `DumpMachine` and `DumpRegister` where providing a location would fallback to the no-op implementation instead of the simulator implementation. I tested this by simulating an operation that included `DumpMachine("Foo.txt")` and saw that the file gets created with the expected content.