### PR TITLE
Remove unused open directives

### DIFF
--- a/src/Tests/SNIPPETS.cs
+++ b/src/Tests/SNIPPETS.cs
@@ -233,8 +233,6 @@ namespace Tests.IQSharp
 
         public static string UseJordanWignerEncodingData =
 @"
-    open Microsoft.Quantum.Convert;
-    open Microsoft.Quantum.Math;
     open Mock.Chemistry;
     
     operation UseJordanWignerEncodingData (qSharpData: JordanWignerEncodingData, nBitsPrecision : Int, trotterStepSize : Double) : (Double, Double) {        

--- a/src/Tests/Workspace.Chemistry/Operation.qs
+++ b/src/Tests/Workspace.Chemistry/Operation.qs
@@ -4,10 +4,6 @@
 // This file can only compile if the Mock.Chemistry project
 // is added as a reference.
 namespace Tests.IQSharp.Chemistry.Samples {
-    open Microsoft.Quantum.Intrinsic;
-    open Microsoft.Quantum.Canon;
-    open Microsoft.Quantum.Convert;
-    open Microsoft.Quantum.Math;
     open Mock.Chemistry;
     
     operation UseJordanWignerEncodingData (qSharpData: JordanWignerEncodingData, nBitsPrecision : Int, trotterStepSize : Double) : (Double, Double) {        


### PR DESCRIPTION

The tests for type loading from libraries have leftover open directives from an earlier version that are not used. These can cause problems in the e2e builds if contents of those libraries are changing. Removing the unused directives more clearly shows what the test depends on and does not incur any extra compilation of unused libraries.