### PR TITLE
Fix warnings in generated magic command docs

### DIFF
--- a/build/docs/build_docs.py
+++ b/build/docs/build_docs.py
@@ -74,7 +74,7 @@ def main(output_dir : str, uid_base : str, package : List[str]):
     with open(output_dir / "index.md", 'w', encoding='utf8') as f:
         f.write(index_content)
 
-def format_as_section(name : str, content : Optional[str], heading_level : Optional[int] = 2) -> str:
+def format_as_section(name : str, content : Optional[str], heading_level : int = 2) -> str:
     content = content.strip() if content else None
     return f"""
 

--- a/build/docs/build_docs.py
+++ b/build/docs/build_docs.py
@@ -74,11 +74,11 @@ def main(output_dir : str, uid_base : str, package : List[str]):
     with open(output_dir / "index.md", 'w', encoding='utf8') as f:
         f.write(index_content)
 
-def format_as_section(name : str, content : Optional[str]) -> str:
+def format_as_section(name : str, content : Optional[str], heading_level : Optional[int] = 2) -> str:
     content = content.strip() if content else None
     return f"""
 
-## {name}
+{"#" * heading_level} {name}
 
 {content}
 
@@ -118,8 +118,10 @@ def format_as_document(magic, uid_base : str) -> MagicReferenceDocument:
     magic_name = magic['Name'].strip()
     safe_name = magic_name.replace('%', '')
     uid = f"{uid_base}.{safe_name}"
+    raw_summary = doc.get('Summary', "")
     metadata = {
         'title': f"{magic_name} (magic command)",
+        'description': raw_summary.strip(),
         'author': 'rmshaffer',
         'uid': uid,
         'ms.author': 'ryansha',
@@ -129,7 +131,6 @@ def format_as_document(magic, uid_base : str) -> MagicReferenceDocument:
     header = f"# `{magic_name}`"
     doc = magic['Documentation']
 
-    raw_summary = doc.get('Summary', "")
     summary = format_as_section('Summary', raw_summary)
     description = format_as_section(
         'Description',
@@ -138,10 +139,10 @@ def format_as_document(magic, uid_base : str) -> MagicReferenceDocument:
     remarks = format_as_section('Remarks', doc.get('Remarks', ""))
 
     raw_examples = doc.get('Examples', [])
-    examples = "\n".join(
-        format_as_section("Example", example)
+    examples = format_as_section('Examples', "\n".join(
+        format_as_section("Example", example, heading_level=3)
         for example in raw_examples
-    ) if raw_examples else ""
+    )) if raw_examples else ""
 
     raw_see_also = doc.get('SeeAlso', [])
     see_also = format_as_section(

--- a/build/docs/build_docs.py
+++ b/build/docs/build_docs.py
@@ -118,6 +118,7 @@ def format_as_document(magic, uid_base : str) -> MagicReferenceDocument:
     magic_name = magic['Name'].strip()
     safe_name = magic_name.replace('%', '')
     uid = f"{uid_base}.{safe_name}"
+    doc = magic['Documentation']
     raw_summary = doc.get('Summary', "")
     metadata = {
         'title': f"{magic_name} (magic command)",
@@ -128,8 +129,8 @@ def format_as_document(magic, uid_base : str) -> MagicReferenceDocument:
         'ms.date': datetime.date.today().strftime("%m/%d/%Y"),
         'ms.topic': 'article'
     }
+    
     header = f"# `{magic_name}`"
-    doc = magic['Documentation']
 
     summary = format_as_section('Summary', raw_summary)
     description = format_as_section(

--- a/build/docs/build_docs.py
+++ b/build/docs/build_docs.py
@@ -200,6 +200,7 @@ def format_index(all_magics : Dict[str, MagicReferenceDocument], uid_base : str)
     )
     metadata = {
         'title': "IQ# Magic Commands",
+        'description': "Lists the magic commands available in the IQ# Jupyter kernel.",
         'author': 'rmshaffer',
         'uid': f"{uid_base}.index",
         'ms.author': 'ryansha',

--- a/build/docs/build_docs.py
+++ b/build/docs/build_docs.py
@@ -140,7 +140,7 @@ def format_as_document(magic, uid_base : str) -> MagicReferenceDocument:
     remarks = format_as_section('Remarks', doc.get('Remarks', ""))
 
     raw_examples = doc.get('Examples', [])
-    examples = format_as_section('Examples', "\n".join(
+    examples = format_as_section(f'Examples for `{magic_name}`', "\n".join(
         format_as_section(f"Example {i+1}", example, heading_level=3)
         for i, example in enumerate(raw_examples)
     )) if raw_examples else ""

--- a/build/docs/build_docs.py
+++ b/build/docs/build_docs.py
@@ -141,8 +141,8 @@ def format_as_document(magic, uid_base : str) -> MagicReferenceDocument:
 
     raw_examples = doc.get('Examples', [])
     examples = format_as_section('Examples', "\n".join(
-        format_as_section("Example", example, heading_level=3)
-        for example in raw_examples
+        format_as_section(f"Example {i+1}", example, heading_level=3)
+        for i, example in enumerate(raw_examples)
     )) if raw_examples else ""
 
     raw_see_also = doc.get('SeeAlso', [])


### PR DESCRIPTION
This PR fixes a number of warnings/suggestions in auto-generated IQ# magic command documentation. See https://github.com/MicrosoftDocs/quantum-docs-pr/pull/1063#issuecomment-700757091 for the full list of problems.

In particular, these suggestions were emitted during the most recent release, and should be resolved by this PR:
```
Line 2, Column 1: [Suggestion-description-missing] Missing required attribute: 'description'.
Line 68, Column 1: [Suggestion-duplicate-headings] Duplicate heading: 'H2 'Example''. Each heading in an article must be unique. NOTE: This Suggestion will become a Warning on 1/29/21.
Line 78, Column 1: [Suggestion-duplicate-headings] Duplicate heading: 'H2 'Example''. Each heading in an article must be unique. NOTE: This Suggestion will become a Warning on 1/29/21.
Line 90, Column 1: [Suggestion-duplicate-headings] Duplicate heading: 'H2 'Example''. Each heading in an article must be unique. NOTE: This Suggestion will become a Warning on 1/29/21.
Line 102, Column 1: [Suggestion-duplicate-headings] Duplicate heading: 'H2 'Example''. Each heading in an article must be unique. NOTE: This Suggestion will become a Warning on 1/29/21.
```

This change has been validated through the docs pipeline here:
https://github.com/MicrosoftDocs/quantum-docs-pr/pull/1083#issuecomment-710084762
We can see there that all warnings and suggestions have been resolved.
