### PR TITLE
Update docs for PyPI and Anaconda packages

### DIFF
--- a/conda-recipes/iqsharp/meta.yaml
+++ b/conda-recipes/iqsharp/meta.yaml
@@ -47,5 +47,10 @@ test:
 about:
   home: https://docs.microsoft.com/quantum
   license: MIT
-  summary: Microsoft's IQ# Server.
+  summary: Microsoft's IQ# kernel providing Q# support for the Jupyter platform.
+  description: |
+    For details on how to get started with Jupyter and Q#, please see the guide at https://docs.microsoft.com/quantum/install-guide/jupyter.
+    You can also try our Quantum Computing Fundamentals learning path (https://aka.ms/learnqc) to get familiar with the basic concepts
+    of quantum computing, build quantum programs, and identify the kind of problems that can be solved.
   dev_url: https://github.com/microsoft/iqsharp
+  doc_url: https://docs.microsoft.com/quantum/install-guide/jupyter

--- a/conda-recipes/qsharp/meta.yaml
+++ b/conda-recipes/qsharp/meta.yaml
@@ -42,5 +42,10 @@ test:
 about:
   home: https://docs.microsoft.com/quantum
   license: MIT
-  summary: Python client for Q#, a domain-specific quantum programming language
+  summary: Python client for Q#, a domain-specific quantum programming language.
+  description: |
+    For details on how to get started with Python and Q#, please see the guide at https://docs.microsoft.com/quantum/install-guide/python.
+    You can also try our Quantum Computing Fundamentals learning path (https://aka.ms/learnqc) to get familiar with the basic concepts
+    of quantum computing, build quantum programs, and identify the kind of problems that can be solved.
   dev_url: https://github.com/microsoft/iqsharp
+  doc_url: https://docs.microsoft.com/quantum/install-guide/python

--- a/src/Python/qsharp-core/README.md
+++ b/src/Python/qsharp-core/README.md
@@ -4,6 +4,8 @@ The `qsharp-core` package for Python provides interoperability with the Quantum 
 
 For details on how to get started with Python and Q#, please see the [Getting Started with Python guide](https://docs.microsoft.com/quantum/install-guide/python).
 
+You can also try our [Quantum Computing Fundamentals](https://aka.ms/learnqc) learning path to get familiar with the basic concepts of quantum computing, build quantum programs, and identify the kind of problems that can be solved.
+
 ## Installing with Anaconda ##
 
 If you use Anaconda or Miniconda, installing the `qsharp` package will automatically include all dependencies:
@@ -22,7 +24,7 @@ cd iqsharp/src/Python/
 python setup.py install
 ```
 
-## Building the `qsharp` Package ##
+## Building the `qsharp-core` Package ##
 
 The Python interoperability feature uses a standard `setuptools`-based packaging strategy.
 To build a platform-independent wheel, run the setup script with `bdist_wheel` instead:
@@ -34,3 +36,7 @@ python setup.py bdist_wheel
 
 By default, this will create a `qsharp-core` wheel in `dist/` with the version number set to 0.0.0.1.
 To provide a more useful version number, set the `PYTHON_VERSION` environment variable before running `setup.py`.
+
+## Support and Q&A
+
+If you have questions about the Quantum Development Kit and the Q# language, or if you encounter issues while using any of the components of the kit, you can reach out to the quantum team and the community of users in [Stack Overflow](https://stackoverflow.com/questions/tagged/q%23) and in [Quantum Computing Stack Exchange](https://quantumcomputing.stackexchange.com/questions/tagged/q%23) tagging your questions with **q#**.


### PR DESCRIPTION
Following the example of https://github.com/microsoft/qsharp-compiler/pull/671, this PR adds links to support and learning paths for the metadata for the `qsharp-core` PyPI package and the `iqsharp`/`qsharp` Anaconda packages.