### PR TITLE
Avoid package version conflicts

### DIFF
--- a/src/AzureClient/Mocks/MockAzureExecutionTarget.cs
+++ b/src/AzureClient/Mocks/MockAzureExecutionTarget.cs
@@ -7,7 +7,8 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
 {
     internal class MockAzureExecutionTarget : AzureExecutionTarget
     {
-        public override string PackageName => $"Microsoft.Quantum.Providers.{GetProvider(TargetId)}::0.12.20082414-beta";
+        // We test using a non-QDK package name to avoid possible version conflicts.
+        public override string PackageName => "Microsoft.Extensions.DependencyInjection";
 
         public static MockAzureExecutionTarget? CreateMock(string targetId) =>
             IsValid(targetId)

--- a/src/Python/qsharp-core/qsharp/tests/test_iqsharp.py
+++ b/src/Python/qsharp-core/qsharp/tests/test_iqsharp.py
@@ -188,6 +188,7 @@ def test_packages():
         qsharp.packages.add('Invalid.Package.!!!!!!')
     assert pkg_count == len(qsharp.packages._client.get_packages())
 
+    # We test using a non-QDK package name to avoid possible version conflicts.
     qsharp.packages.add('Microsoft.Extensions.Logging')
     assert (pkg_count+1) == len(qsharp.packages._client.get_packages())
 


### PR DESCRIPTION
The PR https://github.com/microsoft/qdk/pull/22 had test failures because IQ# tests load specific version of Azure provider packages. This changes the tests to load a non-QDK package instead, which avoids such conflicts while still exercising the package load code path.