### PR TITLE
Updating Core assembly list to support targeting feature

### DIFF
--- a/src/Core/References/References.cs
+++ b/src/Core/References/References.cs
@@ -50,7 +50,8 @@ namespace Microsoft.Quantum.IQSharp
         public static readonly AssemblyInfo[] QUANTUM_CORE_ASSEMBLIES =
         {
             new AssemblyInfo(typeof(Simulation.Core.Operation<,>).Assembly),
-            new AssemblyInfo(typeof(Intrinsic.X).Assembly)
+            new AssemblyInfo(typeof(Intrinsic.X).Assembly),
+            new AssemblyInfo(typeof(Core.EntryPoint).Assembly)
         };
 
 


### PR DESCRIPTION
This change adds an additional class to reflect into the assemblies list so that the feature/decomp branch in qsharp-runtime can pass e2e notebook validation. As part of that feature, the Microsoft.Quantum.Qsharp.Core.dll was split into two dlls, with some of the implementation moving into the new Microsoft.Quantum.Qsharp.Foundation.dll. To allow that to work with iqsharp based notebooks, the new dll must be loaded by default, which requires checking an additional class via reflection. Against the current e2e, this just means that Qsharp.Core will be in the list twice, which should have no negative effects. This change will have to merge before the feature/decomp branch can be merged to qsharp-runtime main.