### PR TITLE
Load package perf improvements

### DIFF
--- a/src/Core/References/NugetPackages.cs
+++ b/src/Core/References/NugetPackages.cs
@@ -33,7 +33,8 @@ namespace Microsoft.Quantum.IQSharp
     /// </summary>
     public class NugetPackages : INugetPackages
     {
-        private HashSet<SourcePackageDependencyInfo> AvailablePackages = new HashSet<SourcePackageDependencyInfo>();
+        // Keeps track of all the packages that are available, i.e. packages explicitly added and their dependencies.
+        internal HashSet<SourcePackageDependencyInfo> AvailablePackages = new HashSet<SourcePackageDependencyInfo>();
 
         // The string we use to delimit the version from the package id.
         public static readonly string PACKAGE_VERSION_DELIMITER = "::";

--- a/src/Tests/NugetPackagesTests.cs
+++ b/src/Tests/NugetPackagesTests.cs
@@ -87,9 +87,8 @@ namespace Tests.IQSharp
 
             using (var context = new SourceCacheContext())
             {
-                var dependencies = new HashSet<SourcePackageDependencyInfo>(PackageIdentityComparer.Default);
-                await mgr.FindDependencies(pkgId, context, dependencies);
-                Assert.AreEqual(144, dependencies.Count());
+                await mgr.FindDependencies(pkgId, context);
+                Assert.AreEqual(144, mgr.AvailablePackages.Count());
             }
         }
 
@@ -101,11 +100,10 @@ namespace Tests.IQSharp
             
             using (var context = new SourceCacheContext())
             {
-                var dependencies = new HashSet<SourcePackageDependencyInfo>(PackageIdentityComparer.Default);
-                await mgr.FindDependencies(pkgId, context, dependencies);
-                var list = mgr.ResolveDependencyGraph(pkgId, dependencies).ToArray();
+                await mgr.FindDependencies(pkgId, context);
+                var list = mgr.ResolveDependencyGraph(pkgId).ToArray();
 
-                Assert.AreEqual(144, dependencies.Count());
+                Assert.AreEqual(144, mgr.AvailablePackages.Count());
                 Assert.AreEqual(107, list.Length);
             }
         }


### PR DESCRIPTION
Doing a couple of chagnes to improve the load of nuget packages:
1. Keeping alive the list of AvailablePackages. This was getting calculated every time that we want to add a package, so it was recalculating and redownloading the same package dependencies for common things like M.Q.Std and M.Q.Sim.
2. Remove the optimization to not download system packages. If the package is not installed better byte the bullet and download it, otherwise nuget will go to the server to fetch its dependencies.