### PR TITLE
Fixes for a few build/test issues

### DIFF
--- a/src/Jupyter/Visualization/StateDisplayOperations.cs
+++ b/src/Jupyter/Visualization/StateDisplayOperations.cs
@@ -46,6 +46,11 @@ namespace Microsoft.Quantum.IQSharp.Jupyter
         /// </summary>
         public BasisStateLabelingConvention BasisStateLabelingConvention { get; set; } = BasisStateLabelingConvention.Bitstring;
 
+        /// <summary>
+        ///     Whether the measurement probabilities will be displayed as an
+        ///     interactive histogram.
+        /// </summary>
+        private bool ShowMeasurementDisplayHistogram { get; set; } = false;
 
         /// <summary>
         ///     Sets the properties of this display dumper from a given
@@ -54,6 +59,7 @@ namespace Microsoft.Quantum.IQSharp.Jupyter
         public JupyterDisplayDumper Configure(IConfigurationSource configurationSource)
         {
             configurationSource
+                .ApplyConfiguration<bool>("dump.measurementDisplayHistogram", value => ShowMeasurementDisplayHistogram = value)
                 .ApplyConfiguration<bool>("dump.truncateSmallAmplitudes", value => TruncateSmallAmplitudes = value)
                 .ApplyConfiguration<double>("dump.truncationThreshold", value => TruncationThreshold = value)
                 .ApplyConfiguration<BasisStateLabelingConvention>(
@@ -110,17 +116,20 @@ namespace Microsoft.Quantum.IQSharp.Jupyter
             };
             Channel.Display(state);
 
-            Channel.SendIoPubMessage(new Message
+            if (ShowMeasurementDisplayHistogram)
             {
-                Header = new MessageHeader()
+                Channel.SendIoPubMessage(new Message
                 {
-                    MessageType = "iqsharp_state_dump"
-                },
-                Content = new MeasurementHistogramContent()
-                {
-                    State = state
-                },
-            });
+                    Header = new MessageHeader()
+                    {
+                        MessageType = "iqsharp_state_dump"
+                    },
+                    Content = new MeasurementHistogramContent()
+                    {
+                        State = state
+                    },
+                });
+            }
 
             // Clean up the state vector buffer.
             _data = null;

--- a/src/Kernel/SymbolResolver.cs
+++ b/src/Kernel/SymbolResolver.cs
@@ -72,7 +72,7 @@ namespace Microsoft.Quantum.IQSharp.Kernel
         /// <summary>
         /// </summary>
         [JsonProperty("inputs", NullValueHandling=NullValueHandling.Ignore)]
-        public ImmutableDictionary<string, string>? Inputs { get; private set; } = null;
+        public ImmutableDictionary<string?, string?>? Inputs { get; private set; } = null;
 
         // TODO: continue exposing documentation here.
 
@@ -146,7 +146,7 @@ namespace Microsoft.Quantum.IQSharp.Kernel
         ///     Symbol names without a dot are resolved to the first symbol
         ///     whose base name matches the given name.
         /// </remarks>
-        public ISymbol Resolve(string symbolName)
+        public ISymbol? Resolve(string symbolName)
         {
             var op = opsResolver.Resolve(symbolName);
             return op == null ? null : new IQSharpSymbol(op);

--- a/src/Python/qsharp-core/qsharp/tests/test_azure.py
+++ b/src/Python/qsharp-core/qsharp/tests/test_azure.py
@@ -9,22 +9,16 @@
 
 ## IMPORTS ##
 
-import importlib
-import os
 import pytest
 import qsharp
 from qsharp.azure import AzureError, AzureJob, AzureTarget
-import sys
+from .utils import set_environment_variables
 
 ## SETUP ##
 
 @pytest.fixture(scope="session", autouse=True)
-def set_environment_variables():
-    # Need to restart the IQ# kernel after setting the environment variable
-    os.environ["AZURE_QUANTUM_ENV"] = "mock"
-    importlib.reload(qsharp)
-    if "qsharp.chemistry" in sys.modules:
-        importlib.reload(qsharp.chemistry)
+def session_setup():
+    set_environment_variables()
 
 ## TESTS ##
 

--- a/src/Python/qsharp-core/qsharp/tests/test_iqsharp.py
+++ b/src/Python/qsharp-core/qsharp/tests/test_iqsharp.py
@@ -1,9 +1,29 @@
+#!/bin/env python
+# -*- coding: utf-8 -*-
+##
+# test_iqsharp.py: Tests basic Q#/Python interop functionality.
+##
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+##
+
+## IMPORTS ##
+
 import numpy as np
 import os
 import pytest
 import qsharp
+from .utils import set_environment_variables
 
 print ( qsharp.component_versions() )
+
+## SETUP ##
+
+@pytest.fixture(scope="session", autouse=True)
+def session_setup():
+    set_environment_variables()
+
+## TESTS ##
 
 def test_simulate():
     """

--- a/src/Python/qsharp-core/qsharp/tests/test_serialization.py
+++ b/src/Python/qsharp-core/qsharp/tests/test_serialization.py
@@ -1,4 +1,3 @@
-
 #!/bin/env python
 # -*- coding: utf-8 -*-
 ##
@@ -13,7 +12,17 @@
 import unittest
 import json
 import numpy as np
+import pytest
 from qsharp.serialization import map_tuples, unmap_tuples
+from .utils import set_environment_variables
+
+## SETUP ##
+
+@pytest.fixture(scope="session", autouse=True)
+def session_setup():
+    set_environment_variables()
+
+## TESTS ##
 
 class TestSerialization(unittest.TestCase):
     def test_map_shallow_tuple(self):

--- a/src/Python/qsharp-core/qsharp/tests/utils.py
+++ b/src/Python/qsharp-core/qsharp/tests/utils.py
@@ -1,0 +1,23 @@
+#!/bin/env python
+# -*- coding: utf-8 -*-
+##
+# utils.py: Common functions for use in IQ# Python tests.
+##
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+##
+
+import importlib
+import os
+import qsharp
+import sys
+
+def set_environment_variables():
+    '''
+    Sets environment variables for test execution and restarts the IQ# kernel.
+    '''        
+    os.environ["AZURE_QUANTUM_ENV"] = "mock"
+    os.environ["IQSHARP_AUTO_LOAD_PACKAGES"] = "$null"
+    importlib.reload(qsharp)
+    if "qsharp.chemistry" in sys.modules:
+        importlib.reload(qsharp.chemistry)

--- a/src/Tool/Program.cs
+++ b/src/Tool/Program.cs
@@ -152,6 +152,7 @@ namespace Microsoft.Quantum.IQSharp
            return WebHost.CreateDefaultBuilder(args)
                 .UseUrls("http://localhost:8888")
                 .UseStartup<Startup>()
+                .UseConfiguration(Configuration)
                 .Build();
         }
 


### PR DESCRIPTION
This PR contains fixes for a few small issues that should be addressed for build/test purposes:

1. Sets `IQSHARP_AUTO_LOAD_PACKAGES` to `$null` in HTTP server tests and in Python tests. This should avoid issues encountered when trying to perform E2E builds locally, since the default auto-load packages (Microsoft.Quantum.Standard and Microsoft.Quantum.Standard.Visualization) are built from the `QuantumLibraries` repo, which is downstream of this repo.

1. Avoid sending the `iqsharp_state_dump` IOPub message if the interactive histogram feature is not enabled. This is harmless in practice, but it produces ugly error messages when running `jupyter nbconvert` with notebooks that contain `DumpMachine()` calls.

1. Fixes a couple of build warnings in `SymbolResolver.cs`.