### PR TITLE
Updating Docker image to include the Azure CLI and az quantum extension

### DIFF
--- a/images/iqsharp-base/Dockerfile
+++ b/images/iqsharp-base/Dockerfile
@@ -109,7 +109,7 @@ ENV AZURE_CLI_VERSION "2.14.2"
 RUN curl -sL https://aka.ms/InstallAzureCLIDeb | bash
 
 # Get the az quantum extension
-RUN az extension add --source https://msquantumpublic.blob.core.windows.net/az-quantum-cli/quantum-latest-py3-none-any.whl
+RUN az extension add --source https://msquantumpublic.blob.core.windows.net/az-quantum-cli/quantum-latest-py3-none-any.whl --yes
 
 # Switch to the notebook user to finish the installation.
 USER ${USER}

--- a/images/iqsharp-base/Dockerfile
+++ b/images/iqsharp-base/Dockerfile
@@ -132,7 +132,7 @@ ENV AZURE_CLI_VERSION "0.10.13"
 ENV NODEJS_APT_ROOT "node_6.x"
 ENV NODEJS_VERSION "6.10.0"
 RUN curl https://deb.nodesource.com/${NODEJS_APT_ROOT}/pool/main/n/nodejs/nodejs_${NODEJS_VERSION}-1nodesource1~jessie1_amd64.deb > node.deb && \
-    dpkg -i node.deb && \
+    sudo dpkg -i node.deb && \
     rm node.deb && \
     npm install --global azure-cli@${AZURE_CLI_VERSION} && \
     azure --completion >> ~/azure.completion.sh && \

--- a/images/iqsharp-base/Dockerfile
+++ b/images/iqsharp-base/Dockerfile
@@ -104,19 +104,9 @@ RUN chown ${USER} -R ${LOCAL_PACKAGES}/ && \
 RUN pip install $(ls ${LOCAL_PACKAGES}/wheels/*.whl)
 
 # Get the Azure CLI tool
-ENV AZURE_CLI_VERSION "0.10.13"
-ENV NODEJS_APT_ROOT "node_6.x"
-ENV NODEJS_VERSION "6.10.0"
+ENV AZURE_CLI_VERSION "2.14.2"
 
-RUN curl https://deb.nodesource.com/${NODEJS_APT_ROOT}/pool/main/n/nodejs/nodejs_${NODEJS_VERSION}-1nodesource1~jessie1_amd64.deb > node.deb && \
-    dpkg -i node.deb && \
-    rm node.deb && \
-    npm install --global azure-cli@${AZURE_CLI_VERSION} && \
-    azure --completion >> ~/azure.completion.sh && \
-    echo 'source ~/azure.completion.sh' >> ~/.bashrc && \
-    azure
-
-RUN azure config mode arm
+RUN curl -sL https://aka.ms/InstallAzureCLIDeb | bash
 
 # Get the az quantum extension
 RUN az extension add --source https://msquantumpublic.blob.core.windows.net/az-quantum-cli/quantum-latest-py3-none-any.whl

--- a/images/iqsharp-base/Dockerfile
+++ b/images/iqsharp-base/Dockerfile
@@ -24,7 +24,9 @@ RUN apt-get update && \
                        # interactive scenarios, so we finish by adding it as
                        # well. Thankfully, Git is a small dependency (~3 MiB)
                        # given what we have already installed.
-                       git && \
+                       git \
+                       # Used to retrieve node version information.
+                       curl && \
     # Upgrade optional dependencies brought in by the previous step.
     apt-get -y upgrade libidn2-0 && \
     # We clean the apt cache at the end of each apt command so that the caches
@@ -124,3 +126,20 @@ RUN echo "Adding standard packages..." && \
         python -c "import qsharp; qsharp.packages.add('$p')" && \
         echo "Added package: $p"; \
     done
+
+# Get the Azure CLI tool
+ENV AZURE_CLI_VERSION "0.10.13"
+ENV NODEJS_APT_ROOT "node_6.x"
+ENV NODEJS_VERSION "6.10.0"
+RUN curl https://deb.nodesource.com/${NODEJS_APT_ROOT}/pool/main/n/nodejs/nodejs_${NODEJS_VERSION}-1nodesource1~jessie1_amd64.deb > node.deb && \
+    dpkg -i node.deb && \
+    rm node.deb && \
+    npm install --global azure-cli@${AZURE_CLI_VERSION} && \
+    azure --completion >> ~/azure.completion.sh && \
+    echo 'source ~/azure.completion.sh' >> ~/.bashrc && \
+    azure
+
+RUN azure config mode arm
+
+# Get the az quantum extension
+RUN az extension add --source https://msquantumpublic.blob.core.windows.net/az-quantum-cli/quantum-latest-py3-none-any.whl

--- a/images/iqsharp-base/Dockerfile
+++ b/images/iqsharp-base/Dockerfile
@@ -103,6 +103,24 @@ RUN chown ${USER} -R ${LOCAL_PACKAGES}/ && \
 # Install all wheels from the build context.
 RUN pip install $(ls ${LOCAL_PACKAGES}/wheels/*.whl)
 
+# Get the Azure CLI tool
+ENV AZURE_CLI_VERSION "0.10.13"
+ENV NODEJS_APT_ROOT "node_6.x"
+ENV NODEJS_VERSION "6.10.0"
+
+RUN curl https://deb.nodesource.com/${NODEJS_APT_ROOT}/pool/main/n/nodejs/nodejs_${NODEJS_VERSION}-1nodesource1~jessie1_amd64.deb > node.deb && \
+    sudo dpkg -i node.deb && \
+    rm node.deb && \
+    npm install --global azure-cli@${AZURE_CLI_VERSION} && \
+    azure --completion >> ~/azure.completion.sh && \
+    echo 'source ~/azure.completion.sh' >> ~/.bashrc && \
+    azure
+
+RUN azure config mode arm
+
+# Get the az quantum extension
+RUN az extension add --source https://msquantumpublic.blob.core.windows.net/az-quantum-cli/quantum-latest-py3-none-any.whl
+
 # Switch to the notebook user to finish the installation.
 USER ${USER}
 # Make sure that .NET Core is on the notebook users' path.
@@ -126,20 +144,3 @@ RUN echo "Adding standard packages..." && \
         python -c "import qsharp; qsharp.packages.add('$p')" && \
         echo "Added package: $p"; \
     done
-
-# Get the Azure CLI tool
-ENV AZURE_CLI_VERSION "0.10.13"
-ENV NODEJS_APT_ROOT "node_6.x"
-ENV NODEJS_VERSION "6.10.0"
-RUN curl https://deb.nodesource.com/${NODEJS_APT_ROOT}/pool/main/n/nodejs/nodejs_${NODEJS_VERSION}-1nodesource1~jessie1_amd64.deb > node.deb && \
-    sudo dpkg -i node.deb && \
-    rm node.deb && \
-    npm install --global azure-cli@${AZURE_CLI_VERSION} && \
-    azure --completion >> ~/azure.completion.sh && \
-    echo 'source ~/azure.completion.sh' >> ~/.bashrc && \
-    azure
-
-RUN azure config mode arm
-
-# Get the az quantum extension
-RUN az extension add --source https://msquantumpublic.blob.core.windows.net/az-quantum-cli/quantum-latest-py3-none-any.whl

--- a/images/iqsharp-base/Dockerfile
+++ b/images/iqsharp-base/Dockerfile
@@ -109,7 +109,7 @@ ENV NODEJS_APT_ROOT "node_6.x"
 ENV NODEJS_VERSION "6.10.0"
 
 RUN curl https://deb.nodesource.com/${NODEJS_APT_ROOT}/pool/main/n/nodejs/nodejs_${NODEJS_VERSION}-1nodesource1~jessie1_amd64.deb > node.deb && \
-    sudo dpkg -i node.deb && \
+    dpkg -i node.deb && \
     rm node.deb && \
     npm install --global azure-cli@${AZURE_CLI_VERSION} && \
     azure --completion >> ~/azure.completion.sh && \


### PR DESCRIPTION
This change adds command line tools for Azure Quantum to the base Docker image in the Quantum Development Kit.
