### PR TITLE
Update Azure Quantum data plane URL for multi-region

### DIFF
--- a/src/AzureClient/AzureClient.cs
+++ b/src/AzureClient/AzureClient.cs
@@ -81,9 +81,10 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
             string resourceGroupName,
             string workspaceName,
             string storageAccountConnectionString,
+            string location,
             bool refreshCredentials = false)
         {
-            var connectionResult = await ConnectToWorkspaceAsync(channel, subscriptionId, resourceGroupName, workspaceName, refreshCredentials);
+            var connectionResult = await ConnectToWorkspaceAsync(channel, subscriptionId, resourceGroupName, workspaceName, location, refreshCredentials);
             if (connectionResult.Status != ExecuteStatus.Ok)
             {
                 return connectionResult;
@@ -98,7 +99,7 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
             ActiveTarget = null;
             MostRecentJobId = string.Empty;
 
-            channel.Stdout($"Connected to Azure Quantum workspace {ActiveWorkspace.Name}.");
+            channel.Stdout($"Connected to Azure Quantum workspace {ActiveWorkspace.Name} in location {ActiveWorkspace.Location}.");
 
             if (ValidExecutionTargets.Count() == 0)
             {
@@ -112,13 +113,14 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
             string subscriptionId,
             string resourceGroupName,
             string workspaceName,
+            string location,
             bool refreshCredentials)
         {
             var azureEnvironment = AzureEnvironment.Create(subscriptionId);
             IAzureWorkspace? workspace = null;
             try
             {
-                workspace = await azureEnvironment.GetAuthenticatedWorkspaceAsync(channel, Logger, resourceGroupName, workspaceName, refreshCredentials);
+                workspace = await azureEnvironment.GetAuthenticatedWorkspaceAsync(channel, Logger, resourceGroupName, workspaceName, location, refreshCredentials);
             }
             catch (Exception e)
             {
@@ -135,6 +137,8 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
             var providers = await workspace.GetProvidersAsync();
             if (providers == null)
             {
+                channel.Stderr($"The Azure Quantum workspace {workspace.Name} in location {workspace.Location} could not be reached. " +
+                    "Please check the provided parameters and try again.");
                 return AzureClientError.WorkspaceNotFound.ToExecutionResult();
             }
 
@@ -156,6 +160,7 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
                 ActiveWorkspace.SubscriptionId ?? string.Empty,
                 ActiveWorkspace.ResourceGroup ?? string.Empty,
                 ActiveWorkspace.Name ?? string.Empty,
+                ActiveWorkspace.Location ?? string.Empty,
                 refreshCredentials: false);
         }
 
@@ -173,7 +178,7 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
                 return connectionResult;
             }
 
-            channel.Stdout($"Connected to Azure Quantum workspace {ActiveWorkspace.Name}.");
+            channel.Stdout($"Connected to Azure Quantum workspace {ActiveWorkspace.Name} in location {ActiveWorkspace.Location}.");
 
             return ValidExecutionTargets.ToExecutionResult();
         }

--- a/src/AzureClient/AzureEnvironment.cs
+++ b/src/AzureClient/AzureEnvironment.cs
@@ -98,7 +98,7 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
                     break;
 
                 case AzureEnvironmentType.Production:
-                    logger?.LogInformation($"AZURE_QUANTUM_ENV set to Production. Connecting to production service.");
+                    logger?.LogInformation($"AZURE_QUANTUM_ENV not set, or set to Production. Connecting to production service.");
                     break;
             }
 

--- a/src/AzureClient/AzureEnvironment.cs
+++ b/src/AzureClient/AzureEnvironment.cs
@@ -60,13 +60,20 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
 
         private string GetNormalizedLocation(string location, IChannel channel)
         {
+            // Default to "westus" if no location was specified.
+            var defaultLocation = "westus";
+            if (string.IsNullOrWhiteSpace(location))
+            {
+                location = defaultLocation;
+            }
+
             // Convert user-provided location into names recognized by Azure resource manager.
             // For example, a customer-provided value of "West US" should be converted to "westus".
             var normalizedLocation = location.ToLowerInvariant().Replace(" ", "");
             if (UriHostNameType.Unknown == Uri.CheckHostName(normalizedLocation))
             {
                 // If provided location is invalid, "westus" is used.
-                normalizedLocation = "westus";
+                normalizedLocation = defaultLocation;
                 channel.Stdout($"Invalid location {location} specified. Falling back to location {normalizedLocation}.");
             }
 

--- a/src/AzureClient/AzureWorkspace.cs
+++ b/src/AzureClient/AzureWorkspace.cs
@@ -19,15 +19,17 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
         public string? Name => AzureQuantumClient?.WorkspaceName;
         public string? SubscriptionId => AzureQuantumClient?.SubscriptionId;
         public string? ResourceGroup => AzureQuantumClient?.ResourceGroupName;
+        public string? Location { get; private set; }
 
         private Azure.Quantum.IWorkspace AzureQuantumWorkspace { get; set; }
         private QuantumClient AzureQuantumClient { get; set; }
         private ILogger<AzureWorkspace> Logger { get; } = new LoggerFactory().CreateLogger<AzureWorkspace>();
 
-        public AzureWorkspace(QuantumClient azureQuantumClient, Azure.Quantum.Workspace azureQuantumWorkspace)
+        public AzureWorkspace(QuantumClient azureQuantumClient, Azure.Quantum.Workspace azureQuantumWorkspace, string location)
         {
             AzureQuantumClient = azureQuantumClient;
             AzureQuantumWorkspace = azureQuantumWorkspace;
+            Location = location;
         }
 
         public async Task<IEnumerable<ProviderStatus>?> GetProvidersAsync()

--- a/src/AzureClient/IAzureClient.cs
+++ b/src/AzureClient/IAzureClient.cs
@@ -28,6 +28,7 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
             string resourceGroupName,
             string workspaceName,
             string storageAccountConnectionString,
+            string location,
             bool refreshCredentials = false);
 
         /// <summary>

--- a/src/AzureClient/IAzureWorkspace.cs
+++ b/src/AzureClient/IAzureWorkspace.cs
@@ -16,6 +16,7 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
         public string? Name { get; }
         public string? SubscriptionId { get; }
         public string? ResourceGroup { get; }
+        public string? Location { get; }
 
         public Task<IEnumerable<ProviderStatus>?> GetProvidersAsync();
         public Task<CloudJob?> GetJobAsync(string jobId);

--- a/src/AzureClient/Magic/ConnectMagic.cs
+++ b/src/AzureClient/Magic/ConnectMagic.cs
@@ -25,6 +25,7 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
         private const string ParameterNameResourceGroupName = "resourceGroup";
         private const string ParameterNameWorkspaceName = "workspace";
         private const string ParameterNameResourceId = "resourceId";
+        private const string ParameterNameLocation = "location";
         
         // A valid resource ID looks like:
         // /subscriptions/f846b2bd-d0e2-4a1d-8141-4c6944a9d387/resourceGroups/RESOURCE_GROUP_NAME/providers/Microsoft.Quantum/Workspaces/WORKSPACE_NAME
@@ -73,6 +74,9 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
                         - `{ParameterNameStorageAccountConnectionString}=<string>`: The connection string to the Azure storage
                         account. Required if the specified Azure Quantum workspace was not linked to a storage
                         account at workspace creation time.
+                        - `{ParameterNameLocation}=<string>`: The Azure region where the Azure Quantum workspace is provisioned.
+                        This may be specified as a region name such as `""East US""` or a location name such as `""eastus""`.
+                        If no valid value is specified, defaults to `""westus""`.
                         
                         #### Possible errors
 
@@ -85,17 +89,18 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
                             Connect to an Azure Quantum workspace using its resource ID:
                             ```
                             In []: %azure.connect ""/subscriptions/.../Microsoft.Quantum/Workspaces/WORKSPACE_NAME""
-                            Out[]: Connected to Azure Quantum workspace WORKSPACE_NAME.
+                            Out[]: Connected to Azure Quantum workspace WORKSPACE_NAME in location westus.
                                     <list of Q# execution targets available in the Azure Quantum workspace>
                             ```
                         ".Dedent(),
 
                         $@"
-                            Connect to an Azure Quantum workspace using its resource ID and a storage account connection string:
+                            Connect to an Azure Quantum workspace using its resource ID, a storage account connection string, and a location:
                             ```
                             In []: %azure.connect {ParameterNameResourceId}=""/subscriptions/.../Microsoft.Quantum/Workspaces/WORKSPACE_NAME""
-                                                    {ParameterNameStorageAccountConnectionString}=""STORAGE_ACCOUNT_CONNECTION_STRING""
-                            Out[]: Connected to Azure Quantum workspace WORKSPACE_NAME.
+                                                  {ParameterNameStorageAccountConnectionString}=""STORAGE_ACCOUNT_CONNECTION_STRING""
+                                                  {ParameterNameLocation}=""East US""
+                            Out[]: Connected to Azure Quantum workspace WORKSPACE_NAME in location eastus.
                                     <list of Q# execution targets available in the Azure Quantum workspace>
                             ```
                         ".Dedent(),
@@ -104,10 +109,10 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
                             Connect to an Azure Quantum workspace using individual subscription ID, resource group name, and workspace name parameters:
                             ```
                             In []: %azure.connect {ParameterNameSubscriptionId}=""SUBSCRIPTION_ID""
-                                                    {ParameterNameResourceGroupName}=""RESOURCE_GROUP_NAME""
-                                                    {ParameterNameWorkspaceName}=""WORKSPACE_NAME""
-                                                    {ParameterNameStorageAccountConnectionString}=""STORAGE_ACCOUNT_CONNECTION_STRING""
-                            Out[]: Connected to Azure Quantum workspace WORKSPACE_NAME.
+                                                  {ParameterNameResourceGroupName}=""RESOURCE_GROUP_NAME""
+                                                  {ParameterNameWorkspaceName}=""WORKSPACE_NAME""
+                                                  {ParameterNameStorageAccountConnectionString}=""STORAGE_ACCOUNT_CONNECTION_STRING""
+                            Out[]: Connected to Azure Quantum workspace WORKSPACE_NAME in location westus.
                                     <list of Q# execution targets available in the Azure Quantum workspace>
                             ```
                         ".Dedent(),
@@ -119,7 +124,7 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
                             In []: %azure.connect {ParameterNameRefresh} ""/subscriptions/.../Microsoft.Quantum/Workspaces/WORKSPACE_NAME""
                             Out[]: To sign in, use a web browser to open the page https://microsoft.com/devicelogin
                                     and enter the code [login code] to authenticate.
-                                    Connected to Azure Quantum workspace WORKSPACE_NAME.
+                                    Connected to Azure Quantum workspace WORKSPACE_NAME in location westus.
                                     <list of Q# execution targets available in the Azure Quantum workspace>
                             ```
                         ".Dedent(),
@@ -128,7 +133,7 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
                             Print information about the currently-connected Azure Quantum workspace:
                             ```
                             In []: %azure.connect
-                            Out[]: Connected to Azure Quantum workspace WORKSPACE_NAME.
+                            Out[]: Connected to Azure Quantum workspace WORKSPACE_NAME in location westus.
                                     <list of Q# execution targets available in the Azure Quantum workspace>
                             ```
                         ".Dedent(),
@@ -187,6 +192,7 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
             }
 
             var storageAccountConnectionString = inputParameters.DecodeParameter<string>(ParameterNameStorageAccountConnectionString, defaultValue: string.Empty);
+            var location = inputParameters.DecodeParameter<string>(ParameterNameLocation, defaultValue: string.Empty);
             var refreshCredentials = inputParameters.DecodeParameter<bool>(ParameterNameRefresh, defaultValue: false);
             return await AzureClient.ConnectAsync(
                 channel,
@@ -194,6 +200,7 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
                 resourceGroupName,
                 workspaceName,
                 storageAccountConnectionString,
+                location,
                 refreshCredentials);
         }
     }

--- a/src/AzureClient/Mocks/MockAzureWorkspace.cs
+++ b/src/AzureClient/Mocks/MockAzureWorkspace.cs
@@ -27,6 +27,8 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
 
         public string ResourceGroup { get; private set; } = string.Empty;
 
+        public string Location { get; private set; } = string.Empty;
+
         public List<ProviderStatus> Providers => new List<ProviderStatus>
         {
             new ProviderStatus(null, null,
@@ -40,7 +42,11 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
 
         public List<CloudJob> Jobs => MockJobIds.Select(jobId => new MockCloudJob(jobId)).ToList<CloudJob>();
 
-        public MockAzureWorkspace(string workspaceName) => Name = workspaceName;
+        public MockAzureWorkspace(string workspaceName, string location)
+        {
+            Name = workspaceName;
+            Location = location;
+        }
 
         public async Task<CloudJob?> GetJobAsync(string jobId) => await Task.Run(() => Jobs.FirstOrDefault(job => job.Id == jobId));
 

--- a/src/Tests/AzureClientMagicTests.cs
+++ b/src/Tests/AzureClientMagicTests.cs
@@ -32,6 +32,7 @@ namespace Tests.IQSharp
         private readonly string resourceGroupName = "TEST_RESOURCE_GROUP_NAME";
         private readonly string workspaceName = "TEST_WORKSPACE_NAME";
         private readonly string storageAccountConnectionString = "TEST_CONNECTION_STRING";
+        private readonly string location = "TEST_LOCATION";
         private readonly string jobId = "TEST_JOB_ID";
         private readonly string operationName = "TEST_OPERATION_NAME";
         private readonly string targetId = "TEST_TARGET_ID";
@@ -57,6 +58,7 @@ namespace Tests.IQSharp
             Assert.AreEqual(resourceGroupName, azureClient.ResourceGroupName);
             Assert.AreEqual(workspaceName, azureClient.WorkspaceName);
             Assert.AreEqual(string.Empty, azureClient.ConnectionString);
+            Assert.AreEqual(string.Empty, azureClient.Location);
 
             // valid input with implied resource ID key, without surrounding quotes
             connectMagic.Test($"/subscriptions/{subscriptionId}/RESOurceGroups/{resourceGroupName}/providers/Microsoft.Quantum/Workspaces/{workspaceName}");
@@ -66,6 +68,7 @@ namespace Tests.IQSharp
             Assert.AreEqual(resourceGroupName, azureClient.ResourceGroupName);
             Assert.AreEqual(workspaceName, azureClient.WorkspaceName);
             Assert.AreEqual(string.Empty, azureClient.ConnectionString);
+            Assert.AreEqual(string.Empty, azureClient.Location);
 
             // valid input with implied resource ID key, with surrounding quotes
             connectMagic.Test($"\"/subscriptions/{subscriptionId}/RESOurceGroups/{resourceGroupName}/providers/Microsoft.Quantum/Workspaces/{workspaceName}\"");
@@ -75,6 +78,7 @@ namespace Tests.IQSharp
             Assert.AreEqual(resourceGroupName, azureClient.ResourceGroupName);
             Assert.AreEqual(workspaceName, azureClient.WorkspaceName);
             Assert.AreEqual(string.Empty, azureClient.ConnectionString);
+            Assert.AreEqual(string.Empty, azureClient.Location);
 
             // valid input with resource ID and storage account connection string
             connectMagic.Test(
@@ -86,23 +90,27 @@ namespace Tests.IQSharp
             Assert.AreEqual(resourceGroupName, azureClient.ResourceGroupName);
             Assert.AreEqual(workspaceName, azureClient.WorkspaceName);
             Assert.AreEqual(storageAccountConnectionString, azureClient.ConnectionString);
+            Assert.AreEqual(string.Empty, azureClient.Location);
 
             // valid input with individual parameters
             connectMagic.Test(
                 @$"subscription={subscriptionId}
                    resourceGroup={resourceGroupName}
                    workspace={workspaceName}
-                   storage={storageAccountConnectionString}");
+                   storage={storageAccountConnectionString}
+                   location={location}");
             Assert.AreEqual(AzureClientAction.Connect, azureClient.LastAction);
             Assert.IsFalse(azureClient.RefreshCredentials);
             Assert.AreEqual(subscriptionId, azureClient.SubscriptionId);
             Assert.AreEqual(resourceGroupName, azureClient.ResourceGroupName);
             Assert.AreEqual(workspaceName, azureClient.WorkspaceName);
             Assert.AreEqual(storageAccountConnectionString, azureClient.ConnectionString);
+            Assert.AreEqual(location, azureClient.Location);
 
             // valid input with extra whitespace and quotes
             connectMagic.Test(
-                @$"subscription   =   {subscriptionId}
+                @$"location ={location}
+                   subscription   =   {subscriptionId}
                    resourceGroup=  ""{resourceGroupName}""
                    workspace  ={workspaceName}
                    storage = '{storageAccountConnectionString}'");
@@ -112,6 +120,7 @@ namespace Tests.IQSharp
             Assert.AreEqual(resourceGroupName, azureClient.ResourceGroupName);
             Assert.AreEqual(workspaceName, azureClient.WorkspaceName);
             Assert.AreEqual(storageAccountConnectionString, azureClient.ConnectionString);
+            Assert.AreEqual(location, azureClient.Location);
 
             // valid input with forced login
             connectMagic.Test(
@@ -263,6 +272,7 @@ namespace Tests.IQSharp
         internal string ResourceGroupName = string.Empty;
         internal string WorkspaceName = string.Empty;
         internal string ConnectionString = string.Empty;
+        internal string Location = string.Empty;
         internal bool RefreshCredentials = false;
         internal string ActiveTargetId = string.Empty;
         internal List<string> SubmittedJobs = new List<string>();
@@ -295,13 +305,14 @@ namespace Tests.IQSharp
             return ExecuteStatus.Ok.ToExecutionResult();
         }
 
-        public async Task<ExecutionResult> ConnectAsync(IChannel channel, string subscriptionId, string resourceGroupName, string workspaceName, string storageAccountConnectionString, bool refreshCredentials)
+        public async Task<ExecutionResult> ConnectAsync(IChannel channel, string subscriptionId, string resourceGroupName, string workspaceName, string storageAccountConnectionString, string location, bool refreshCredentials)
         {
             LastAction = AzureClientAction.Connect;
             SubscriptionId = subscriptionId;
             ResourceGroupName = resourceGroupName;
             WorkspaceName = workspaceName;
             ConnectionString = storageAccountConnectionString;
+            Location = location;
             RefreshCredentials = refreshCredentials;
             return ExecuteStatus.Ok.ToExecutionResult();
         }


### PR DESCRIPTION
This change updates the base URL used by IQ# to connect to the Azure Quantum data plane.

It also adds a `location` parameter to the `%azure.connect` magic command (and therefore also the `qsharp.azure.connect()` Python API) allowing the user to specify the region in which their Azure Quantum workspace is provisioned.