### PR TITLE
Avoid pyzmq incompatibility in CI and published packages

### DIFF
--- a/build/test-selenium-requirements.txt
+++ b/build/test-selenium-requirements.txt
@@ -1,4 +1,5 @@
 pytest
 jupyter_client==6.1.7
 notebook==6.1.1
+pyzmq==19.0.2
 selenium==3.141

--- a/build/test-selenium.py
+++ b/build/test-selenium.py
@@ -32,7 +32,8 @@ def setup_module():
 def create_notebook():
     '''
     Returns a new IQ# notebook in a Firefox web driver
-    '''    
+    '''
+    driver = None
     max_retries = 5
     for _ in range(max_retries):
         try:

--- a/build/test-selenium.py
+++ b/build/test-selenium.py
@@ -1,6 +1,7 @@
 import os
 import pytest
 import time
+import sys
 
 from notebook.notebookapp import list_running_servers
 from notebook.tests.selenium.test_interrupt import interrupt_from_menu
@@ -17,7 +18,8 @@ def setup_module():
     if not hasattr(os, "uname"):
         os.uname = lambda: ["Windows"]
 
-    remaining_time = 180
+    total_wait_time = 180
+    remaining_time = total_wait_time
     iteration_time = 5
     print("Waiting for notebook server to start...")
     while not list(list_running_servers()) and remaining_time > 0:
@@ -25,14 +27,24 @@ def setup_module():
         remaining_time -= iteration_time
 
     if not list(list_running_servers()):
-        raise Exception(f"Notebook server did not start in {remaining_time} seconds")
+        raise Exception(f"Notebook server did not start in {total_wait_time} seconds")
 
 def create_notebook():
     '''
     Returns a new IQ# notebook in a Firefox web driver
-    '''
+    '''    
+    max_retries = 5
+    for _ in range(max_retries):
+        try:
+            driver = Firefox()
+            break
+        except:
+            print(f"Exception creating Firefox driver, retrying. Exception info: {sys.exc_info()}")
+
+    if not driver:
+        raise Exception(f"Failed to create Firefox driver in {max_retries} tries")
+
     server = list(list_running_servers())[0]
-    driver = Firefox()
     driver.get('{url}?token={token}'.format(**server))
     return Notebook.new_notebook(driver, kernel_name='kernel-iqsharp')
 

--- a/conda-recipes/iqsharp/meta.yaml
+++ b/conda-recipes/iqsharp/meta.yaml
@@ -26,6 +26,7 @@ requirements:
   run:
     - python
     - jupyter_client
+    - pyzmq<20.0.0       # due to incompatibility of IQ# with pyzmq>=20.0.0
     - backports.weakref  # for https://github.com/microsoft/iqsharp/issues/39
 
 test:
@@ -33,6 +34,7 @@ test:
     - notebook=6.0.1
     - python>=3.6
     - jupyter_client<5.3.3
+    - pyzmq==19.0.2
     - pip
 
   source_files:

--- a/conda-recipes/qsharp/meta.yaml
+++ b/conda-recipes/qsharp/meta.yaml
@@ -18,6 +18,7 @@ requirements:
 
   run:
     - python
+    - pyzmq<20.0.0            # due to incompatibility of IQ# with pyzmq>=20.0.0
     - iqsharp={{ version }}
 
 build:
@@ -28,6 +29,7 @@ build:
 test:
   requires:
     - python
+    - pyzmq==19.0.2
     - iqsharp={{ version }}
     - pytest
 

--- a/images/iqsharp-base/Dockerfile
+++ b/images/iqsharp-base/Dockerfile
@@ -2,8 +2,9 @@
 FROM python:3.7-slim-buster
 
 # install the notebook package
+# force pyzmq==19.0.2 due to incompatibility of IQ# with pyzmq>=20.0.0
 RUN pip install --no-cache --upgrade pip && \
-    pip install --no-cache notebook
+    pip install --no-cache notebook pyzmq==19.0.2
 
 # Install APT prerequisites.
 RUN apt-get update && \

--- a/images/iqsharp-base/Dockerfile
+++ b/images/iqsharp-base/Dockerfile
@@ -24,7 +24,9 @@ RUN apt-get update && \
                        # interactive scenarios, so we finish by adding it as
                        # well. Thankfully, Git is a small dependency (~3 MiB)
                        # given what we have already installed.
-                       git && \
+                       git \
+                       # Used to retrieve node version information.
+                       curl && \
     # Upgrade optional dependencies brought in by the previous step.
     apt-get -y upgrade libidn2-0 && \
     # We clean the apt cache at the end of each apt command so that the caches
@@ -100,6 +102,14 @@ RUN chown ${USER} -R ${LOCAL_PACKAGES}/ && \
 
 # Install all wheels from the build context.
 RUN pip install $(ls ${LOCAL_PACKAGES}/wheels/*.whl)
+
+# Get the Azure CLI tool
+ENV AZURE_CLI_VERSION "2.14.2"
+
+RUN curl -sL https://aka.ms/InstallAzureCLIDeb | bash
+
+# Get the az quantum extension
+RUN az extension add --source https://msquantumpublic.blob.core.windows.net/az-quantum-cli/quantum-latest-py3-none-any.whl --yes
 
 # Switch to the notebook user to finish the installation.
 USER ${USER}

--- a/src/Python/qsharp-core/setup.py
+++ b/src/Python/qsharp-core/setup.py
@@ -61,6 +61,7 @@ setuptools.setup(
         "Operating System :: OS Independent",
     ],
     install_requires=[
-        'jupyter_client'
+        'jupyter_client',
+        'pyzmq<20.0.0'     # due to incompatibility of IQ# with pyzmq>=20.0.0
     ]
 )


### PR DESCRIPTION
A recent release of the `pyzmq` package (20.0.0) has resulted in some type of intermittent deadlock issues when running Jupyter with IQ#.

We haven't yet identified the root cause of this incompatibility, but we want to avoid getting that behavior in our CI builds, so this change pins the pyzmq version to the previous release (19.0.2). It does the same in the Docker image built from this repo.

This change also adds a version requirement `pyzmq<20.0.0` to our `qsharp` Python package and our `iqsharp`/`qsharp` conda packages to try to prevent users from getting into this incompatible state.