### PR TITLE
Update ms.topic value in build_docs.py

### DIFF
--- a/build/docs/build_docs.py
+++ b/build/docs/build_docs.py
@@ -127,7 +127,7 @@ def format_as_document(magic, uid_base : str) -> MagicReferenceDocument:
         'uid': uid,
         'ms.author': 'ryansha',
         'ms.date': datetime.date.today().strftime("%m/%d/%Y"),
-        'ms.topic': 'article'
+        'ms.topic': 'managed-reference'
     }
     
     header = f"# `{magic_name}`"


### PR DESCRIPTION
For SEO tracking and statistics, the API topics should have an ms.topic value of 'managed-reference'. While the value 'article' is valid, it's a generic value that doesn't provide granular data.