### PR TITLE
Add index.md link to IQ# magic command documentation TOC

### DIFF
--- a/build/docs/build_docs.py
+++ b/build/docs/build_docs.py
@@ -181,11 +181,17 @@ def format_as_document(magic, uid_base : str) -> MagicReferenceDocument:
 def format_toc(all_magics : Dict[str, MagicReferenceDocument]) -> str:
     toc_content = [
         {
+            'href': "index.md",
+            'name': "IQ# magic commands"
+        }
+    ]
+    toc_content.extend([
+        {
             'href': f"{doc.safe_name}.md",
             'name': f"{doc.name} magic command"
         }
         for magic_name, doc in sorted(all_magics.items(), key=lambda item: item[0])
-    ]
+    ])
     
     as_yaml = StringIO()
     yaml.dump(toc_content, as_yaml)


### PR DESCRIPTION
Fixes #379.

Note that I've also made the change manually to the generated docs in https://github.com/MicrosoftDocs/quantum-docs-pr/pull/1146, so that the link is there in the meantime until the next QDK release.