### PR TITLE
Fix symbol HTML display for missing description

### DIFF
--- a/src/Kernel/SymbolEncoders.cs
+++ b/src/Kernel/SymbolEncoders.cs
@@ -51,12 +51,16 @@ namespace Microsoft.Quantum.IQSharp.Kernel
             {
                 var codeLink =
                     $"<a href=\"{symbol.Source}\"><i class=\"fa fas fa-code\"></i></a>";
+                var summary = symbol.Summary != null
+                    ? "<h5>Summary</h5>" + Markdown.ToHtml(symbol.Summary)
+                    : string.Empty;
+                var description = symbol.Description != null
+                    ? "<h5>Description</h5>" + Markdown.ToHtml(symbol.Description)
+                    : string.Empty;
                 return $@"
                     <h4><i class=""fa fas fa-terminal""></i> {symbol.Name} {codeLink}</h4>
-                    <h5>Summary</h5>
-                    {Markdown.ToHtml(symbol.Summary)}
-                    <h5>Description</h5>
-                    {Markdown.ToHtml(symbol.Description)}
+                    {summary}
+                    {description}
                 ".ToEncodedData();
 
             }


### PR DESCRIPTION
`Markdown.ToHtml()` throws an exception if the provided string argument is `null`. This change simply makes the implementation of `IQSharpSymbolToHtmlResultEncoder` robust to this, so that symbols without a Summary and/or Description will still have correct HTML display in IQ#.

With this change, the expected behavior is restored:
![image](https://user-images.githubusercontent.com/3620100/101565539-15404f80-3982-11eb-8743-05216c61bde2.png)
