### PR TITLE
Skip serialization for non-targeted assemblies

### DIFF
--- a/src/Core/Compiler/CompilerService.cs
+++ b/src/Core/Compiler/CompilerService.cs
@@ -132,7 +132,7 @@ namespace Microsoft.Quantum.IQSharp
             var loadOptions = new CompilationLoader.Configuration
             {
                 GenerateFunctorSupport = true,
-                LoadReferencesBasedOnGeneratedCsharp = string.IsNullOrEmpty(executionTarget), // serialization is unnecessary if no execution target
+                LoadReferencesBasedOnGeneratedCsharp = string.IsNullOrEmpty(executionTarget), // deserialization of resources in references is only needed if there is an execution target
                 IsExecutable = compileAsExecutable,
                 AssemblyConstants = new Dictionary<string, string> { [AssemblyConstants.ProcessorArchitecture] = executionTarget ?? string.Empty },
                 RuntimeCapability = runtimeCapability ?? RuntimeCapability.FullComputation

--- a/src/Core/Compiler/CompilerService.cs
+++ b/src/Core/Compiler/CompilerService.cs
@@ -132,7 +132,7 @@ namespace Microsoft.Quantum.IQSharp
             var loadOptions = new CompilationLoader.Configuration
             {
                 GenerateFunctorSupport = true,
-                LoadReferencesBasedOnGeneratedCsharp = true,
+                LoadReferencesBasedOnGeneratedCsharp = string.IsNullOrEmpty(executionTarget), // serialization is unnecessary if no execution target
                 IsExecutable = compileAsExecutable,
                 AssemblyConstants = new Dictionary<string, string> { [AssemblyConstants.ProcessorArchitecture] = executionTarget ?? string.Empty },
                 RuntimeCapability = runtimeCapability ?? RuntimeCapability.FullComputation

--- a/src/Core/Compiler/CompilerService.cs
+++ b/src/Core/Compiler/CompilerService.cs
@@ -132,6 +132,7 @@ namespace Microsoft.Quantum.IQSharp
             var loadOptions = new CompilationLoader.Configuration
             {
                 GenerateFunctorSupport = true,
+                LoadReferencesBasedOnGeneratedCsharp = true,
                 IsExecutable = compileAsExecutable,
                 AssemblyConstants = new Dictionary<string, string> { [AssemblyConstants.ProcessorArchitecture] = executionTarget ?? string.Empty },
                 RuntimeCapability = runtimeCapability ?? RuntimeCapability.FullComputation
@@ -244,26 +245,33 @@ namespace Microsoft.Quantum.IQSharp
                     metadata.RoslynMetadatas,
                     options);
 
-                // Generate the assembly from the C# compilation:
                 var fromSources = qsCompilation.Namespaces.Select(ns => FilterBySourceFile.Apply(ns, s => s.EndsWith(".qs")));
-                var syntaxTree = new QsCompilation(fromSources.ToImmutableArray(), qsCompilation.EntryPoints);
 
-                using var serializedCompilation = new MemoryStream();
-                if (!CompilationLoader.WriteBinary(syntaxTree, serializedCompilation))
+                // Only create the serialization if we are compiling for an execution target:
+                List<ResourceDescription>? manifestResources = null;
+                if (!string.IsNullOrEmpty(executionTarget))
                 {
-                    logger.LogError("IQS005", "Failed to write compilation to binary stream.");
-                    return null;
+                    // Generate the assembly from the C# compilation:
+                    var syntaxTree = new QsCompilation(fromSources.ToImmutableArray(), qsCompilation.EntryPoints);
+
+                    using var serializedCompilation = new MemoryStream();
+                    if (!CompilationLoader.WriteBinary(syntaxTree, serializedCompilation))
+                    {
+                        logger.LogError("IQS005", "Failed to write compilation to binary stream.");
+                        return null;
+                    }
+
+                    manifestResources = new List<ResourceDescription>() {
+                        new ResourceDescription(
+                            resourceName: DotnetCoreDll.ResourceNameQsDataBondV1,
+                            dataProvider: () => new MemoryStream(serializedCompilation.ToArray()),
+                            isPublic: true
+                        )
+                    };
                 }
 
-                var resourceDescription = new ResourceDescription
-                (
-                    resourceName: DotnetCoreDll.ResourceNameQsDataBondV1,
-                    dataProvider: () => new MemoryStream(serializedCompilation.ToArray()),
-                    isPublic: true
-                );
-
                 using var ms = new MemoryStream();
-                var result = compilation.Emit(ms, manifestResources: new[] { resourceDescription });
+                var result = compilation.Emit(ms, manifestResources: manifestResources);
 
                 if (!result.Success)
                 {


### PR DESCRIPTION
PR #368 updated IQ# to use the new compiler serialization format for Q# assemblies. There is some perf cost associated with loading the serializers/deserializers that we would like to avoid. Fortunately, it looks like the serialization is only necessary for targeted assemblies (i.e., assemblies being built for submission to hardware targets). The bulk of IQ# scenarios do not compile to a hardware target, and so we can get performance improvement by skipping serialization in these cases.

This PR skips the Q# compilation serialization when the execution target is not set. It also sets `LoadReferencesBasedOnGeneratedCsharp=true` in the `CompilationLoader` configuration, which should allow the compiler to make a similar optimization.

Keeping this PR as a draft until verification is complete.