### PR TITLE
Remove assertion that compilation had no warnings in engine tests

### DIFF
--- a/src/Tests/IQsharpEngineTests.cs
+++ b/src/Tests/IQsharpEngineTests.cs
@@ -52,7 +52,6 @@ namespace Tests.IQSharp
             var response = await engine.ExecuteMundane(source, channel);
             PrintResult(response, channel);
             Assert.AreEqual(ExecuteStatus.Ok, response.Status);
-            Assert.AreEqual(0, channel.msgs.Count);
             CollectionAssert.AreEquivalent(expectedOps, response.Output as string[]);
 
             return response.Output?.ToString();


### PR DESCRIPTION
microsoft/qsharp-compiler#791 adds deprecation warnings when parentheses are used for `for`, `using` and `borrowing` statements. IQ# has test snippets that trigger these warnings, for example:

https://github.com/microsoft/iqsharp/blob/afeb47a8b2957ba72e150a542f25d5d1aaedadad/src/Tests/SNIPPETS.cs#L319-L321

The IQ# tests also assert that no warnings were generated, which caused the end-to-end build to fail. Since the warnings were designed to not introduce any breaking changes yet, it would be nice if IQ# tests didn't rely on there being no warnings.

The other option is to update the tests to remove the deprecated parentheses and avoid the warnings - let me know which option seems better.

Cc: @bettinaheim