### PR TITLE
Update build schedule

### DIFF
--- a/build/ci.yml
+++ b/build/ci.yml
@@ -8,6 +8,14 @@ pr:
 - features/*
 - release/*
 
+schedules:
+- cron: "0 9 * * Sat"
+  displayName: 'Build for Component Governance'
+  branches:
+    include:
+    - main
+  always: true
+
 variables:
   Build.Major: 0
   Build.Minor: 14


### PR DESCRIPTION
Add a 'main' build scheduled for midnight PST on Saturdays to keep component governance detection current.