### PR TITLE
Start engine services in Start() instead of constructor.

### DIFF
--- a/build/test.ps1
+++ b/build/test.ps1
@@ -43,6 +43,10 @@ function Test-One {
             --no-build `
             --logger trx `
             --filter $_ `
+            <# Enable additional output from the test logger, but
+               without also turning on lots of additional noise from msbuild.
+            #> `
+            --logger:"console;verbosity=detailed" `
             /property:DefineConstants=$Env:ASSEMBLY_CONSTANTS `
             /property:InformationalVersion=$Env:SEMVER_VERSION `
             /property:Version=$Env:ASSEMBLY_VERSION

--- a/src/Core/Loggers/NugetLogger.cs
+++ b/src/Core/Loggers/NugetLogger.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+#nullable enable
 
 using System;
 using System.Collections.Generic;
@@ -14,31 +15,24 @@ namespace Microsoft.Quantum.IQSharp.Common
     /// </summary>
     public class NuGetLogger : NuGet.Common.LoggerBase
     {
-        private ILogger _logger { get; set; }
+        private ILogger? _logger { get; set; }
         public List<NuGet.Common.ILogMessage> Logs { get; private set; }
 
-        public NuGetLogger(ILogger logger)
+        public NuGetLogger(ILogger? logger)
         {
             _logger = logger;
             this.Logs = new List<NuGet.Common.ILogMessage>();
         }
 
-        public static LogLevel MapLevel(NuGet.Common.LogLevel original)
-        {
-            switch (original)
+        public static LogLevel MapLevel(NuGet.Common.LogLevel original) =>
+            original switch
             {
-                case NuGet.Common.LogLevel.Error:
-                    return LogLevel.Error;
-                case NuGet.Common.LogLevel.Warning:
-                    return LogLevel.Warning;
-                case NuGet.Common.LogLevel.Information:
-                    return LogLevel.Information;
-                case NuGet.Common.LogLevel.Debug:
-                    return LogLevel.Debug;
-                default:
-                    return LogLevel.Trace;
-            }
-        }
+                NuGet.Common.LogLevel.Error => LogLevel.Error,
+                NuGet.Common.LogLevel.Warning => LogLevel.Warning,
+                NuGet.Common.LogLevel.Information => LogLevel.Information,
+                NuGet.Common.LogLevel.Debug => LogLevel.Debug,
+                _ => LogLevel.Trace
+            };
 
         public override void Log(NuGet.Common.ILogMessage m)
         {

--- a/src/Core/References/NugetPackages.cs
+++ b/src/Core/References/NugetPackages.cs
@@ -111,7 +111,7 @@ namespace Microsoft.Quantum.IQSharp
 
         public NugetPackages(
             IOptions<Settings> config,
-            ILogger<NugetPackages> logger
+            ILogger<NugetPackages>? logger
         )
         {
             this.Logger = new NuGetLogger(logger);

--- a/src/Jupyter/Jupyter.csproj
+++ b/src/Jupyter/Jupyter.csproj
@@ -35,7 +35,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Jupyter.Core" Version="1.5.124583" />
+    <PackageReference Include="Microsoft.Jupyter.Core" Version="1.5.21430-CI-20210115-174810" />
     <PackageReference Include="System.Reactive" Version="4.3.2" />
   </ItemGroup>
 

--- a/src/Jupyter/Jupyter.csproj
+++ b/src/Jupyter/Jupyter.csproj
@@ -35,7 +35,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Jupyter.Core" Version="1.5.124273" />
+    <PackageReference Include="Microsoft.Jupyter.Core" Version="1.5.124583" />
     <PackageReference Include="System.Reactive" Version="4.3.2" />
   </ItemGroup>
 

--- a/src/Jupyter/Jupyter.csproj
+++ b/src/Jupyter/Jupyter.csproj
@@ -35,7 +35,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Jupyter.Core" Version="1.5.21443-CI-20210115-190238" />
+    <PackageReference Include="Microsoft.Jupyter.Core" Version="1.5.124810" />
     <PackageReference Include="System.Reactive" Version="4.3.2" />
   </ItemGroup>
 

--- a/src/Jupyter/Jupyter.csproj
+++ b/src/Jupyter/Jupyter.csproj
@@ -35,7 +35,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Jupyter.Core" Version="1.5.21430-CI-20210115-174810" />
+    <PackageReference Include="Microsoft.Jupyter.Core" Version="1.5.21443-CI-20210115-190238" />
     <PackageReference Include="System.Reactive" Version="4.3.2" />
   </ItemGroup>
 

--- a/src/Kernel/CustomShell/ClientInfoHandler.cs
+++ b/src/Kernel/CustomShell/ClientInfoHandler.cs
@@ -17,34 +17,34 @@ namespace Microsoft.Quantum.IQSharp.Kernel
     internal class ClientInfoContent : MessageContent
     {
         [JsonProperty("hosting_environment")]
-        public string HostingEnvironment { get; set; }
+        public string? HostingEnvironment { get; set; }
 
         [JsonProperty("iqsharp_version")]
-        public string IQSharpVersion { get; set; }
+        public string? IQSharpVersion { get; set; }
 
         [JsonProperty("user_agent")]
-        public string UserAgent { get; set; }
+        public string? UserAgent { get; set; }
 
         [JsonProperty("client_id")]
-        public string ClientId { get; set; }
+        public string? ClientId { get; set; }
 
         [JsonProperty("client_isnew")]
         public bool? ClientIsNew { get; set; }
 
         [JsonProperty("client_host")]
-        public string ClientHost { get; set; }
+        public string? ClientHost { get; set; }
 
         [JsonProperty("client_origin")]
-        public string ClientOrigin { get; set; }
+        public string? ClientOrigin { get; set; }
 
         [JsonProperty("client_first_origin")]
-        public string ClientFirstOrigin { get; set; }
+        public string? ClientFirstOrigin { get; set; }
 
         [JsonProperty("client_language")]
-        public string ClientLanguage { get; set; }
+        public string? ClientLanguage { get; set; }
 
         [JsonProperty("client_country")]
-        public string ClientCountry { get; set; }
+        public string? ClientCountry { get; set; }
 
         [JsonProperty("telemetry_opt_out")]
         public bool? TelemetryOptOut { get; set; }
@@ -69,7 +69,7 @@ namespace Microsoft.Quantum.IQSharp.Kernel
     /// </summary>
     internal class ClientInfoHandler : IShellHandler
     {
-        public string UserAgent { get; private set; }
+        public string? UserAgent { get; private set; }
         private readonly ILogger<ClientInfoHandler> logger;
         private readonly IMetadataController metadata;
         private readonly IShellServer shellServer;

--- a/src/Kernel/CustomShell/EchoHandler.cs
+++ b/src/Kernel/CustomShell/EchoHandler.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Quantum.IQSharp.Kernel
         public async Task HandleAsync(Message message)
         {
             // Find out the thing we need to echo back.
-            var value = (message.Content as UnknownContent).Data["value"] as string;
+            var value = (message.Content as UnknownContent)?.Data?["value"] as string ?? "";
             // Send the echo both as an output and as a reply so that clients
             // can test both kinds of callbacks.
             await Task.Run(() =>

--- a/src/Kernel/CustomShell/EchoHandler.cs
+++ b/src/Kernel/CustomShell/EchoHandler.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Quantum.IQSharp.Kernel
     internal class EchoReplyContent : MessageContent
     {
         [JsonProperty("value")]
-        public string Value { get; set; }
+        public string Value { get; set; } = "";
     }
 
     /// <summary>

--- a/src/Kernel/IQSharpEngine.cs
+++ b/src/Kernel/IQSharpEngine.cs
@@ -78,6 +78,10 @@ namespace Microsoft.Quantum.IQSharp.Kernel
             // and deserializers. Since that runs in the background, starting
             // the engine should not be blocked, and other services can
             // continue to initialize while the Q# compilation loader works.
+            //
+            // For more details, see:
+            //     https://github.com/microsoft/qsharp-compiler/pull/727
+            //     https://github.com/microsoft/qsharp-compiler/pull/810
             logger.LogDebug("Loading serialization and deserialziation protocols.");
             Protocols.Initialize();
 

--- a/src/Kernel/IQSharpEngine.cs
+++ b/src/Kernel/IQSharpEngine.cs
@@ -45,7 +45,9 @@ namespace Microsoft.Quantum.IQSharp.Kernel
         internal IWorkspace? Workspace { get; private set; } = null;
 
         private TaskCompletionSource<bool> initializedSource = new TaskCompletionSource<bool>();
-        internal Task Initialized => initializedSource.Task;
+
+        /// <inheritdoc />
+        public override Task Initialized => initializedSource.Task;
 
         /// <summary>
         /// The main constructor. It expects an `ISnippets` instance that takes care

--- a/src/Kernel/IQSharpEngine.cs
+++ b/src/Kernel/IQSharpEngine.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Quantum.IQSharp.Kernel
         internal IWorkspace? Workspace { get; private set; } = null;
 
         private TaskCompletionSource<bool> initializedSource = new TaskCompletionSource<bool>();
-        private Task initialized => initializedSource.Task;
+        internal Task Initialized => initializedSource.Task;
 
         /// <summary>
         /// The main constructor. It expects an `ISnippets` instance that takes care
@@ -224,7 +224,7 @@ namespace Microsoft.Quantum.IQSharp.Kernel
             {
                 try
                 {
-                    await this.initialized;
+                    await this.Initialized;
                     // Once the engine is initialized, we know that Workspace
                     // and Snippets are both not-null.
                     var workspace = this.Workspace!;

--- a/src/Kernel/Kernel.csproj
+++ b/src/Kernel/Kernel.csproj
@@ -6,6 +6,7 @@
     <RootNamespace>Microsoft.Quantum.IQSharp.Kernel</RootNamespace>
     <AssemblyName>Microsoft.Quantum.IQSharp.Kernel</AssemblyName>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Kernel/KernelApp/IQSharpKernelApp.cs
+++ b/src/Kernel/KernelApp/IQSharpKernelApp.cs
@@ -63,7 +63,7 @@ namespace Microsoft.Quantum.IQSharp.Kernel
         /// </summary>
         /// <param name="eventService">The event service where the EventSubPub lives</param>
         /// <returns>The typed EventPubSub for the KernelStarted event</returns>
-        public static EventPubSub<KernelStartedEvent, IQSharpKernelApp> OnKernelStarted(this IEventService eventService)
+        public static EventPubSub<KernelStartedEvent, IQSharpKernelApp>? OnKernelStarted(this IEventService eventService)
         {
             return eventService?.Events<KernelStartedEvent, IQSharpKernelApp>();
         }
@@ -73,7 +73,7 @@ namespace Microsoft.Quantum.IQSharp.Kernel
         /// </summary>
         /// <param name="eventService">The event service where the EventSubPub lives</param>
         /// <returns>The typed EventPubSub for the KernelStopped event</returns>
-        public static EventPubSub<KernelStoppedEvent, IQSharpKernelApp> OnKernelStopped(this IEventService eventService)
+        public static EventPubSub<KernelStoppedEvent, IQSharpKernelApp>? OnKernelStopped(this IEventService eventService)
         {
             return eventService?.Events<KernelStoppedEvent, IQSharpKernelApp>();
         }

--- a/src/Kernel/Magic/LsMagicMagic.cs
+++ b/src/Kernel/Magic/LsMagicMagic.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.Linq;
 
 using Microsoft.Jupyter.Core;
@@ -54,8 +55,15 @@ namespace Microsoft.Quantum.IQSharp.Kernel
             })
         {
             this.resolver = resolver;
-            (engine as IQSharpEngine).RegisterDisplayEncoder(new MagicSymbolSummariesToHtmlEncoder());
-            (engine as IQSharpEngine).RegisterDisplayEncoder(new MagicSymbolSummariesToTextEncoder());
+            if (engine is IQSharpEngine iQSharpEngine)
+            {
+                iQSharpEngine.RegisterDisplayEncoder(new MagicSymbolSummariesToHtmlEncoder());
+                iQSharpEngine.RegisterDisplayEncoder(new MagicSymbolSummariesToTextEncoder());
+            }
+            else
+            {
+                throw new Exception($"Expected execution engine to be an IQ# engine, but was {engine.GetType()}.");
+            }
         }
 
         /// <inheritdoc />

--- a/src/Kernel/Magic/Resolution/IMagicResolver.cs
+++ b/src/Kernel/Magic/Resolution/IMagicResolver.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Quantum.IQSharp.Kernel
     /// </summary>
     public interface IMagicSymbolResolver : ISymbolResolver
     {
-        ISymbol ISymbolResolver.Resolve(string symbolName) =>
+        ISymbol? ISymbolResolver.Resolve(string symbolName) =>
             this.Resolve(symbolName);
 
         /// <summary>
@@ -29,11 +29,16 @@ namespace Microsoft.Quantum.IQSharp.Kernel
         /// </summary>
         /// <param name="symbolName">The magic symbol name to resolve.</param>
         /// <returns>The resolved <see cref="MagicSymbol"/> object, or <c>null</c> if none was found.</returns>
-        public new MagicSymbol Resolve(string symbolName);
+        public new MagicSymbol? Resolve(string symbolName);
 
         /// <summary>
         /// Returns the list of all <see cref="MagicSymbol"/> objects defined in loaded assemblies.
         /// </summary>
         public IEnumerable<MagicSymbol> FindAllMagicSymbols();
+
+        /// <summary>
+        /// Finds the MagicSymbols inside an assembly, and returns an instance of each.
+        /// </summary>
+        public IEnumerable<MagicSymbol> FindMagic(AssemblyInfo assm);
     }
 }

--- a/src/Kernel/Magic/Resolution/MagicResolver.cs
+++ b/src/Kernel/Magic/Resolution/MagicResolver.cs
@@ -139,9 +139,20 @@ namespace Microsoft.Quantum.IQSharp.Kernel
                     {
                         try
                         {
-                            var m = ActivatorUtilities.CreateInstance(services, t) as MagicSymbol;
-                            allMagic.Add(m);
-                            this.logger.LogInformation($"Found MagicSymbols {m.Name} ({t.FullName})");
+                            var symbol = ActivatorUtilities.CreateInstance(services, t);
+                            if (symbol is MagicSymbol magic)
+                            {
+                                allMagic.Add(magic);
+                                this.logger.LogInformation($"Found MagicSymbols {magic.Name} ({t.FullName})");
+                            }
+                            else if (symbol is {})
+                            {
+                                throw new Exception($"Unable to create magic symbol of type {t}; service activator returned an object of type {symbol.GetType()}, which is not a subtype of MagicSymbol.");
+                            }
+                            else if (symbol == null)
+                            {
+                                throw new Exception($"Unable to create magic symbol of type {t}; service activator returned null.");
+                            }
                         }
                         catch (Exception e)
                         {

--- a/src/Tests/IQsharpEngineTests.cs
+++ b/src/Tests/IQsharpEngineTests.cs
@@ -27,10 +27,6 @@ namespace Tests.IQSharp
     [TestClass]
     public class IQSharpEngineTests
     {
-        // We want to make sure that tests that exercise the %debug magic
-        // do not run at the same time, since they each check the list of IOPub
-        // messages going back and forth to the rest of the kernel.
-        private object debugTestLock = new object();
         public IQSharpEngine Init(string workspace = "Workspace")
         {
             var engine = Startup.Create<IQSharpEngine>(workspace);
@@ -609,105 +605,99 @@ namespace Tests.IQSharp
         [TestMethod]
         public async Task TestDebugMagic()
         {
-            lock (debugTestLock)
+            var engine = Init();
+            Assert.IsNotNull(engine.SymbolsResolver);
+            await AssertCompile(engine, SNIPPETS.SimpleDebugOperation, "SimpleDebugOperation");
+
+            var configSource = new ConfigurationSource(skipLoading: true);
+            var debugMagic = new DebugMagic(engine.SymbolsResolver!, configSource, engine.ShellRouter, engine.ShellServer, null);
+
+            // Start a debug session
+            var channel = new MockChannel();
+            var cts = new CancellationTokenSource();
+            var debugTask = debugMagic.RunAsync("SimpleDebugOperation", channel, cts.Token);
+
+            // Retrieve the debug session ID
+            var message = channel.iopubMessages[0];
+            Assert.IsNotNull(message);
+            Assert.AreEqual("iqsharp_debug_sessionstart", message.Header.MessageType);
+
+            var content = message.Content as DebugSessionContent;
+            Assert.IsNotNull(content);
+            var debugSessionId = content!.DebugSession;
+
+            // Send several iqsharp_debug_advance messages
+            var debugAdvanceMessage = new Message
             {
-                var engine = Init();
-                Assert.IsNotNull(engine.SymbolsResolver);
-                await AssertCompile(engine, SNIPPETS.SimpleDebugOperation, "SimpleDebugOperation");
-
-                var configSource = new ConfigurationSource(skipLoading: true);
-                var debugMagic = new DebugMagic(engine.SymbolsResolver!, configSource, engine.ShellRouter, engine.ShellServer, null);
-
-                // Start a debug session
-                var channel = new MockChannel();
-                var cts = new CancellationTokenSource();
-                var debugTask = debugMagic.RunAsync("SimpleDebugOperation", channel, cts.Token);
-
-                // Retrieve the debug session ID
-                var message = channel.iopubMessages[0];
-                Assert.IsNotNull(message);
-                Assert.AreEqual("iqsharp_debug_sessionstart", message.Header.MessageType);
-
-                var content = message.Content as DebugSessionContent;
-                Assert.IsNotNull(content);
-                var debugSessionId = content!.DebugSession;
-
-                // Send several iqsharp_debug_advance messages
-                var debugAdvanceMessage = new Message
+                Header = new MessageHeader
                 {
-                    Header = new MessageHeader
+                    MessageType = "iqsharp_debug_advance"
+                },
+                Content = new UnknownContent
+                {
+                    Data = new Dictionary<string, object>
                     {
-                        MessageType = "iqsharp_debug_advance"
-                    },
-                    Content = new UnknownContent
-                    {
-                        Data = new Dictionary<string, object>
-                        {
-                            ["debug_session"] = debugSessionId
-                        }
+                        ["debug_session"] = debugSessionId
                     }
-                };
-
-                foreach (int _ in Enumerable.Range(0, 1000))
-                {
-                    Thread.Sleep(millisecondsTimeout: 10);
-                    if (debugTask.IsCompleted)
-                        break;
-
-                    await debugMagic.HandleAdvanceMessage(debugAdvanceMessage);
                 }
+            };
 
-                // Verify that the command completes successfully
-                Assert.IsTrue(debugTask.IsCompleted);
-                Assert.AreEqual(System.Threading.Tasks.TaskStatus.RanToCompletion, debugTask.Status);
+            foreach (int _ in Enumerable.Range(0, 1000))
+            {
+                Thread.Sleep(millisecondsTimeout: 10);
+                if (debugTask.IsCompleted)
+                    break;
 
-                // Ensure that expected messages were sent
-                Assert.AreEqual("iqsharp_debug_sessionstart", channel.iopubMessages[0].Header.MessageType);
-                Assert.AreEqual("iqsharp_debug_opstart", channel.iopubMessages[1].Header.MessageType);
-                Assert.AreEqual("iqsharp_debug_sessionend", channel.iopubMessages.Last().Header.MessageType);
-                Assert.IsTrue(channel.msgs[0].Contains("Starting debug session"));
-                Assert.IsTrue(channel.msgs[1].Contains("Finished debug session"));
-
-                // Verify debug status content
-                var debugStatusContent = channel.iopubMessages[1].Content as DebugStatusContent;
-                Assert.IsNotNull(debugStatusContent?.State);
-                Assert.AreEqual(debugSessionId, debugStatusContent?.DebugSession);
+                await debugMagic.HandleAdvanceMessage(debugAdvanceMessage);
             }
+
+            // Verify that the command completes successfully
+            Assert.IsTrue(debugTask.IsCompleted);
+            Assert.AreEqual(System.Threading.Tasks.TaskStatus.RanToCompletion, debugTask.Status);
+
+            // Ensure that expected messages were sent
+            Assert.AreEqual("iqsharp_debug_sessionstart", channel.iopubMessages[0].Header.MessageType);
+            Assert.AreEqual("iqsharp_debug_opstart", channel.iopubMessages[1].Header.MessageType);
+            Assert.AreEqual("iqsharp_debug_sessionend", channel.iopubMessages.Last().Header.MessageType);
+            Assert.IsTrue(channel.msgs[0].Contains("Starting debug session"));
+            Assert.IsTrue(channel.msgs[1].Contains("Finished debug session"));
+
+            // Verify debug status content
+            var debugStatusContent = channel.iopubMessages[1].Content as DebugStatusContent;
+            Assert.IsNotNull(debugStatusContent?.State);
+            Assert.AreEqual(debugSessionId, debugStatusContent?.DebugSession);
         }
 
         [TestMethod]
         public async Task TestDebugMagicCancel()
         {
-            lock (debugTestLock)
-            {
-                var engine = Init();
-                // Since Init guarantees that engine services have started, we
-                // assert non-nullness here.
-                Assert.IsNotNull(engine.SymbolsResolver);
-                await AssertCompile(engine, SNIPPETS.SimpleDebugOperation, "SimpleDebugOperation");
+            var engine = Init();
+            // Since Init guarantees that engine services have started, we
+            // assert non-nullness here.
+            Assert.IsNotNull(engine.SymbolsResolver);
+            await AssertCompile(engine, SNIPPETS.SimpleDebugOperation, "SimpleDebugOperation");
 
-                var configSource = new ConfigurationSource(skipLoading: true);
-                // We asserted that SymbolsResolver is not null above, and can use
-                // the null-forgiving operator here as a result.
-                var debugMagic = new DebugMagic(engine.SymbolsResolver!, configSource, engine.ShellRouter, engine.ShellServer, null);
+            var configSource = new ConfigurationSource(skipLoading: true);
+            // We asserted that SymbolsResolver is not null above, and can use
+            // the null-forgiving operator here as a result.
+            var debugMagic = new DebugMagic(engine.SymbolsResolver!, configSource, engine.ShellRouter, engine.ShellServer, null);
 
-                // Start a debug session
-                var channel = new MockChannel();
-                var cts = new CancellationTokenSource();
-                var debugTask = debugMagic.RunAsync("SimpleDebugOperation", channel, cts.Token);
+            // Start a debug session
+            var channel = new MockChannel();
+            var cts = new CancellationTokenSource();
+            var debugTask = debugMagic.RunAsync("SimpleDebugOperation", channel, cts.Token);
 
-                // Cancel the session
-                cts.Cancel();
+            // Cancel the session
+            cts.Cancel();
 
-                // Ensure that the task throws an exception
-                Assert.ThrowsException<AggregateException>(() => debugTask.Wait());
+            // Ensure that the task throws an exception
+            Assert.ThrowsException<AggregateException>(() => debugTask.Wait());
 
-                // Ensure that expected messages were sent
-                Assert.AreEqual("iqsharp_debug_sessionstart", channel.iopubMessages[0].Header.MessageType);
-                Assert.AreEqual("iqsharp_debug_sessionend", channel.iopubMessages[1].Header.MessageType);
-                Assert.IsTrue(channel.msgs[0].Contains("Starting debug session"));
-                Assert.IsTrue(channel.msgs[1].Contains("Finished debug session"));
-            }
+            // Ensure that expected messages were sent
+            Assert.AreEqual("iqsharp_debug_sessionstart", channel.iopubMessages[0].Header.MessageType);
+            Assert.AreEqual("iqsharp_debug_sessionend", channel.iopubMessages[1].Header.MessageType);
+            Assert.IsTrue(channel.msgs[0].Contains("Starting debug session"));
+            Assert.IsTrue(channel.msgs[1].Contains("Finished debug session"));
         }
 
         [TestMethod]

--- a/src/Tests/IQsharpEngineTests.cs
+++ b/src/Tests/IQsharpEngineTests.cs
@@ -30,6 +30,8 @@ namespace Tests.IQSharp
         public IQSharpEngine Init(string workspace = "Workspace")
         {
             var engine = Startup.Create<IQSharpEngine>(workspace);
+            engine.Start();
+            engine.Initialized.Wait();
             engine.Workspace.Initialization.Wait();
             return engine;
         }

--- a/src/Tests/IQsharpEngineTests.cs
+++ b/src/Tests/IQsharpEngineTests.cs
@@ -52,7 +52,6 @@ namespace Tests.IQSharp
             var response = await engine.ExecuteMundane(source, channel);
             PrintResult(response, channel);
             Assert.AreEqual(ExecuteStatus.Ok, response.Status);
-            Assert.AreEqual(0, channel.msgs.Count);
             CollectionAssert.AreEquivalent(expectedOps, response.Output as string[]);
 
             return response.Output?.ToString();

--- a/src/Tests/NugetPackagesTests.cs
+++ b/src/Tests/NugetPackagesTests.cs
@@ -36,7 +36,7 @@ namespace Tests.IQSharp
         {
             var mgr = Init();
 
-            async Task TestOne(string pkg, string version)
+            async Task TestOne(string pkg, string? version)
             {
                 var actual = await mgr.GetLatestVersion(pkg);
 

--- a/src/Tests/SerializationTests.cs
+++ b/src/Tests/SerializationTests.cs
@@ -36,9 +36,9 @@ namespace Tests.IQSharp
         {
             var complex = new Complex((12.0, 1.4));
             var token = JToken.Parse(JsonConvert.SerializeObject(complex, JsonConverters.TupleConverters));
-            Assert.AreEqual(typeof(Complex).FullName, token["@type"].Value<string>());
-            Assert.AreEqual(12, token["Item1"].Value<double>());
-            Assert.AreEqual(1.4, token["Item2"].Value<double>());
+            Assert.AreEqual(typeof(Complex).FullName, token?["@type"]?.Value<string>());
+            Assert.AreEqual(12, token?["Item1"]?.Value<double>());
+            Assert.AreEqual(1.4, token?["Item2"]?.Value<double>());
         }
 
         [TestMethod]
@@ -62,13 +62,13 @@ namespace Tests.IQSharp
             var jsonData = JsonConvert.SerializeObject(testValue, JsonConverters.TupleConverters);
             System.Console.WriteLine(jsonData);
             var token = JToken.Parse(jsonData);
-            Assert.AreEqual(typeof(QubitState).FullName, token["@type"].Value<string>());
-            Assert.AreEqual(typeof(Complex).FullName, token["Item1"]["@type"].Value<string>());
-            Assert.AreEqual(0.1, token["Item1"]["Item1"].Value<double>());
-            Assert.AreEqual(0.2, token["Item1"]["Item2"].Value<double>());
-            Assert.AreEqual(typeof(Complex).FullName, token["Item2"]["@type"].Value<string>());
-            Assert.AreEqual(0.3, token["Item2"]["Item1"].Value<double>());
-            Assert.AreEqual(0.4, token["Item2"]["Item2"].Value<double>());
+            Assert.AreEqual(typeof(QubitState).FullName, token?["@type"]?.Value<string>());
+            Assert.AreEqual(typeof(Complex).FullName, token?["Item1"]?["@type"]?.Value<string>());
+            Assert.AreEqual(0.1, token?["Item1"]?["Item1"]?.Value<double>());
+            Assert.AreEqual(0.2, token?["Item1"]?["Item2"]?.Value<double>());
+            Assert.AreEqual(typeof(Complex).FullName, token?["Item2"]?["@type"]?.Value<string>());
+            Assert.AreEqual(0.3, token?["Item2"]?["Item1"]?.Value<double>());
+            Assert.AreEqual(0.4, token?["Item2"]?["Item2"]?.Value<double>());
         }
 
         [TestMethod]

--- a/src/Tests/SnippetsControllerTests.cs
+++ b/src/Tests/SnippetsControllerTests.cs
@@ -174,7 +174,7 @@ namespace Tests.IQSharp
             // Run:
             var results = await AssertSimulate(controller, "DependsOnWorkspace", "Hello Foo again!") as QArray<Result>;
             Assert.IsNotNull(results);
-            Assert.AreEqual(5, results.Length);
+            Assert.AreEqual(5, results!.Length);
         }
 
         [TestMethod]

--- a/src/Tests/TelemetryTests.cs
+++ b/src/Tests/TelemetryTests.cs
@@ -39,6 +39,16 @@ namespace Tests.IQSharp
     {
         public static readonly Type TelemetryServiceType = typeof(MockTelemetryService);
 
+        public IQSharpEngine Init(IServiceProvider services)
+        {
+            var engine = services.GetService<IExecutionEngine>() as IQSharpEngine;
+            engine.Start();
+            engine.Initialized.Wait();
+            Assert.IsNotNull(engine.Workspace);
+            engine.Workspace!.Initialization.Wait();
+            return engine;
+        }
+
         [TestMethod]
         public void MockTelemetryService()
         {
@@ -249,7 +259,7 @@ namespace Tests.IQSharp
             var services = Startup.CreateServiceProvider(workspace);
             var logger = GetAppLogger(services);
 
-            var engine = services.GetService<IExecutionEngine>() as IQSharpEngine;
+            var engine = Init(services);
             var channel = new MockChannel();
 
             logger.Events.Clear();

--- a/src/Tests/Tests.IQsharp.csproj
+++ b/src/Tests/Tests.IQsharp.csproj
@@ -5,6 +5,7 @@
     <PlatformTarget>x64</PlatformTarget>
     <IsPackable>false</IsPackable>
     <NoWarn>1701</NoWarn>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Tests/WorkspaceTests.cs
+++ b/src/Tests/WorkspaceTests.cs
@@ -59,10 +59,10 @@ namespace Tests.IQSharp
             var fileName = Path.Combine(Path.GetFullPath("Workspace"), "BasicOps.qs");
             File.SetLastWriteTimeUtc(fileName, DateTime.UtcNow);
             ws.Reload();
-            op = ws.AssemblyInfo.Operations.FirstOrDefault(o => o.FullName == "Tests.qss.NoOp");
+            op = ws.AssemblyInfo?.Operations.FirstOrDefault(o => o.FullName == "Tests.qss.NoOp");
+            Assert.IsNotNull(op);
             Assert.IsFalse(ws.HasErrors);
             Assert.AreNotSame(originalAssembly, ws.AssemblyInfo);
-            Assert.IsNotNull(op);
         }
 
         [TestMethod]


### PR DESCRIPTION
This PR delays starting services required by `IQSharpEngine` until the `Engine.Start` method is called, so as to not block proper handling of shell messages for reporting startup status to the client. This PR also follows the advice of @cesarzc, and initializes Bond protocol serialization and deserialization in the engine, so that the Q# compilation loader is ready earlier.

(Marked as draft until a dependency on https://github.com/microsoft/jupyter-core/pull/71 can be taken.)