### PR TITLE
Updating test case to recent change in qsharp-runtime

### DIFF
--- a/src/Tests/ExecutionPathTracerTests.cs
+++ b/src/Tests/ExecutionPathTracerTests.cs
@@ -67,11 +67,12 @@ namespace Tests.IQSharp
         }
 
         // Helper functions for tests
-        public Operation ControlledX(int[] controlId, int targetId) =>
+        public Operation ControlledX(int[] controlId, int targetId, bool isAdjoint = false) =>
             new Operation()
             {
                 Gate = "X",
                 IsControlled = true,
+                IsAdjoint = isAdjoint,
                 Controls = controlId.Select(id => new QubitRegister(id)),
                 Targets = new List<Register>() { new QubitRegister(targetId) },
             };
@@ -194,7 +195,7 @@ namespace Tests.IQSharp
                         new [] {
                             ControlledX(new int[] { 0 }, 1),
                             ControlledX(new int[] { 1 }, 0),
-                            ControlledX(new int[] { 0 }, 1),
+                            ControlledX(new int[] { 0 }, 1, isAdjoint: true),
                         }
                     )
                 },

--- a/src/Tests/ExecutionPathTracerTests.cs
+++ b/src/Tests/ExecutionPathTracerTests.cs
@@ -85,7 +85,6 @@ namespace Tests.IQSharp
             {
                 Gate = "X",
                 IsControlled = true,
-                IsAdjoint = false,
                 Controls = controlId.Select(id => new QubitRegister(id)),
                 Targets = new List<Register>() { new QubitRegister(targetId) },
             };

--- a/src/Tests/IQsharpEngineTests.cs
+++ b/src/Tests/IQsharpEngineTests.cs
@@ -52,7 +52,6 @@ namespace Tests.IQSharp
             var response = await engine.ExecuteMundane(source, channel);
             PrintResult(response, channel);
             Assert.AreEqual(ExecuteStatus.Ok, response.Status);
-            Assert.AreEqual(0, channel.msgs.Count);
             CollectionAssert.AreEquivalent(expectedOps, response.Output as string[]);
 
             return response.Output?.ToString();


### PR DESCRIPTION
This PR fixes a failing test case due to microsoft/qsharp-runtime#458.