### PR TITLE
Fix issues in %azure.connect.

### DIFF
--- a/src/AzureClient/AzureClient.cs
+++ b/src/AzureClient/AzureClient.cs
@@ -72,6 +72,8 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
                 baseEngine.RegisterDisplayEncoder(new HistogramToTextEncoder());
                 baseEngine.RegisterDisplayEncoder(new AzureClientErrorToHtmlEncoder());
                 baseEngine.RegisterDisplayEncoder(new AzureClientErrorToTextEncoder());
+                baseEngine.RegisterDisplayEncoder(new DeviceCodeResultToHtmlEncoder());
+                baseEngine.RegisterDisplayEncoder(new DeviceCodeResultToTextEncoder());
             }
         }
 
@@ -118,7 +120,7 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
             bool refreshCredentials,
             CancellationToken? cancellationToken = null)
         {
-            var azureEnvironment = AzureEnvironment.Create(subscriptionId);
+            var azureEnvironment = AzureEnvironment.Create(subscriptionId, Logger);
             IAzureWorkspace? workspace = null;
             try
             {

--- a/src/AzureClient/AzureClient.cs
+++ b/src/AzureClient/AzureClient.cs
@@ -82,9 +82,10 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
             string workspaceName,
             string storageAccountConnectionString,
             string location,
-            bool refreshCredentials = false)
+            bool refreshCredentials = false,
+            CancellationToken? cancellationToken = null)
         {
-            var connectionResult = await ConnectToWorkspaceAsync(channel, subscriptionId, resourceGroupName, workspaceName, location, refreshCredentials);
+            var connectionResult = await ConnectToWorkspaceAsync(channel, subscriptionId, resourceGroupName, workspaceName, location, refreshCredentials, cancellationToken);
             if (connectionResult.Status != ExecuteStatus.Ok)
             {
                 return connectionResult;
@@ -114,13 +115,18 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
             string resourceGroupName,
             string workspaceName,
             string location,
-            bool refreshCredentials)
+            bool refreshCredentials,
+            CancellationToken? cancellationToken = null)
         {
             var azureEnvironment = AzureEnvironment.Create(subscriptionId);
             IAzureWorkspace? workspace = null;
             try
             {
-                workspace = await azureEnvironment.GetAuthenticatedWorkspaceAsync(channel, Logger, resourceGroupName, workspaceName, location, refreshCredentials);
+                workspace = await azureEnvironment.GetAuthenticatedWorkspaceAsync(channel, Logger, resourceGroupName, workspaceName, location, refreshCredentials, cancellationToken);
+            }
+            catch (TaskCanceledException tce)
+            {
+                throw tce;
             }
             catch (Exception e)
             {
@@ -148,7 +154,7 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
             return ExecuteStatus.Ok.ToExecutionResult();
         }
 
-        private async Task<ExecutionResult> RefreshConnectionAsync(IChannel channel)
+        private async Task<ExecutionResult> RefreshConnectionAsync(IChannel channel, CancellationToken? cancellationToken = null)
         {
             if (ActiveWorkspace == null)
             {
@@ -161,7 +167,8 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
                 ActiveWorkspace.ResourceGroup ?? string.Empty,
                 ActiveWorkspace.Name ?? string.Empty,
                 ActiveWorkspace.Location ?? string.Empty,
-                refreshCredentials: false);
+                refreshCredentials: false,
+                cancellationToken: cancellationToken);
         }
 
         /// <inheritdoc/>

--- a/src/AzureClient/IAzureClient.cs
+++ b/src/AzureClient/IAzureClient.cs
@@ -29,7 +29,8 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
             string workspaceName,
             string storageAccountConnectionString,
             string location,
-            bool refreshCredentials = false);
+            bool refreshCredentials = false,
+            CancellationToken? cancellationToken = null);
 
         /// <summary>
         /// Gets the current connection status to an Azure Quantum workspace.

--- a/src/AzureClient/Magic/ConnectMagic.cs
+++ b/src/AzureClient/Magic/ConnectMagic.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
         /// <param name="azureClient">
         /// The <see cref="IAzureClient"/> object to use for Azure functionality.
         /// </param>
-        public ConnectMagic(IExecutionEngine engine, IAzureClient azureClient)
+        public ConnectMagic(IAzureClient azureClient)
             : base(
                 azureClient,
                 "azure.connect",
@@ -139,13 +139,7 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
                         ".Dedent(),
                     },
                 })
-        {
-            if (engine is BaseEngine baseEngine)
-            {
-                baseEngine.RegisterDisplayEncoder(new DeviceCodeResultToTextEncoder());
-                baseEngine.RegisterDisplayEncoder(new DeviceCodeResultToHtmlEncoder());
-            }
-        }
+        { }
 
         /// <summary>
         ///     Connects to an Azure workspace given a subscription ID, resource group name,

--- a/src/AzureClient/Magic/ConnectMagic.cs
+++ b/src/AzureClient/Magic/ConnectMagic.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
         /// <param name="azureClient">
         /// The <see cref="IAzureClient"/> object to use for Azure functionality.
         /// </param>
-        public ConnectMagic(IAzureClient azureClient)
+        public ConnectMagic(IExecutionEngine engine, IAzureClient azureClient)
             : base(
                 azureClient,
                 "azure.connect",
@@ -138,7 +138,14 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
                             ```
                         ".Dedent(),
                     },
-                }) {}
+                })
+        {
+            if (engine is BaseEngine baseEngine)
+            {
+                baseEngine.RegisterDisplayEncoder(new DeviceCodeResultToTextEncoder());
+                baseEngine.RegisterDisplayEncoder(new DeviceCodeResultToHtmlEncoder());
+            }
+        }
 
         /// <summary>
         ///     Connects to an Azure workspace given a subscription ID, resource group name,
@@ -201,7 +208,8 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
                 workspaceName,
                 storageAccountConnectionString,
                 location,
-                refreshCredentials);
+                refreshCredentials,
+                cancellationToken);
         }
     }
 }

--- a/src/AzureClient/Visualization/DeviceCodeResultEncoders.cs
+++ b/src/AzureClient/Visualization/DeviceCodeResultEncoders.cs
@@ -1,0 +1,67 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using Microsoft.Azure.Quantum;
+using Microsoft.Identity.Client;
+using Microsoft.Jupyter.Core;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.Quantum.IQSharp.AzureClient
+{
+    /// <summary>
+    /// Encodes a <see cref="DeviceCodeResult"/> object as HTML.
+    /// </summary>
+    public class DeviceCodeResultToHtmlEncoder : IResultEncoder
+    {
+        private static readonly IResultEncoder tableEncoder = new TableToHtmlDisplayEncoder();
+
+        /// <inheritdoc/>
+        public string MimeType => MimeTypes.Html;
+
+        /// <inheritdoc/>
+        public EncodedData? Encode(object displayable)
+        {
+            if (displayable is DeviceCodeResult deviceCode)
+            {
+                var guid = Guid.NewGuid();
+                var htmlMessage = deviceCode.Message
+                    .Replace(deviceCode.VerificationUrl, $"<a href=\"{deviceCode.VerificationUrl}\"><code>{deviceCode.VerificationUrl}</code></a>")
+                    .Replace(
+                        deviceCode.UserCode,
+                        $@"<span id=""{guid}"" style=""background-color: #e0e0e0;"">
+                            <i class=""fa fa-clipboard"" aria-hidden=""true""></i>
+                            <strong style=""padding-right: 0.2em"">{deviceCode.UserCode.Trim()}</strong></span>"
+                    );
+                var attach = $@"<script>
+                    window.iqsharp.addCopyListener(""{guid}"", ""{deviceCode.UserCode}"");
+                </script>";
+                return (htmlMessage + "\n" + attach).ToEncodedData();
+            } else return null;
+        }
+    }
+
+    /// <summary>
+    /// Encodes a <see cref="DeviceCodeResult"/> object as plain text.
+    /// </summary>
+    public class DeviceCodeResultToTextEncoder : IResultEncoder
+    {
+        private static readonly IResultEncoder tableEncoder = new TableToHtmlDisplayEncoder();
+
+        /// <inheritdoc/>
+        public string MimeType => MimeTypes.PlainText;
+
+        /// <inheritdoc/>
+        public EncodedData? Encode(object displayable) =>
+            displayable is DeviceCodeResult deviceCode
+                ? deviceCode.Message.ToEncodedData()
+                : null as EncodedData?;
+    }
+}

--- a/src/Jupyter/Jupyter.csproj
+++ b/src/Jupyter/Jupyter.csproj
@@ -35,7 +35,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Jupyter.Core" Version="1.5.124810" />
+    <PackageReference Include="Microsoft.Jupyter.Core" Version="1.5.125583" />
     <PackageReference Include="System.Reactive" Version="4.3.2" />
   </ItemGroup>
 

--- a/src/Jupyter/Magic/AbstractMagic.cs
+++ b/src/Jupyter/Magic/AbstractMagic.cs
@@ -52,6 +52,12 @@ namespace Microsoft.Quantum.IQSharp.Jupyter
                     {
                         return await Task.Run(() => magic(input, channel, cancellationToken));
                     }
+                    catch (TaskCanceledException tce)
+                    {
+                        // Rethrow so that the jupyter-core library can
+                        // properly handle the task cancellation.
+                        throw tce;
+                    }
                     catch (InvalidWorkspaceException ws)
                     {
                         foreach (var m in ws.Errors) channel.Stderr(m);

--- a/src/Kernel/client/kernel.ts
+++ b/src/Kernel/client/kernel.ts
@@ -11,6 +11,12 @@ import { defineQSharpMode } from "./syntax";
 import { Visualizer } from "./visualizer";
 import { Circuit, StyleConfig, STYLES } from "./ExecutionPathVisualizer";
 
+declare global {
+    interface Window {
+        iqsharp: Kernel
+    }
+}
+
 class Kernel {
     hostingEnvironment: string | undefined;
     iqsharpVersion: string | undefined;
@@ -251,6 +257,12 @@ class Kernel {
         Telemetry.initAsync();
     }
 
+    addCopyListener(elementId: string, data: string) {
+        document.getElementById(elementId).onclick = async (ev: MouseEvent) => {
+            await navigator.clipboard.writeText(data);
+        };
+    }
+
     initExecutionPathVisualizer() {
         IPython.notebook.kernel.register_iopub_handler(
             "render_execution_path",
@@ -275,6 +287,6 @@ class Kernel {
 
 export function onload() {
     defineQSharpMode();
-    let kernel = new Kernel();
+    window.iqsharp = new Kernel();
     console.log("Loaded IQ# kernel-specific extension!");
 }

--- a/src/Tests/AzureClientMagicTests.cs
+++ b/src/Tests/AzureClientMagicTests.cs
@@ -305,7 +305,14 @@ namespace Tests.IQSharp
             return ExecuteStatus.Ok.ToExecutionResult();
         }
 
-        public async Task<ExecutionResult> ConnectAsync(IChannel channel, string subscriptionId, string resourceGroupName, string workspaceName, string storageAccountConnectionString, string location, bool refreshCredentials, CancellationToken cancellationToken)
+        public async Task<ExecutionResult> ConnectAsync(IChannel channel,
+            string subscriptionId,
+            string resourceGroupName,
+            string workspaceName,
+            string storageAccountConnectionString,
+            string location,
+            bool refreshCredentials = false,
+            CancellationToken? cancellationToken = null)
         {
             LastAction = AzureClientAction.Connect;
             SubscriptionId = subscriptionId;

--- a/src/Tests/AzureClientMagicTests.cs
+++ b/src/Tests/AzureClientMagicTests.cs
@@ -305,7 +305,7 @@ namespace Tests.IQSharp
             return ExecuteStatus.Ok.ToExecutionResult();
         }
 
-        public async Task<ExecutionResult> ConnectAsync(IChannel channel, string subscriptionId, string resourceGroupName, string workspaceName, string storageAccountConnectionString, string location, bool refreshCredentials)
+        public async Task<ExecutionResult> ConnectAsync(IChannel channel, string subscriptionId, string resourceGroupName, string workspaceName, string storageAccountConnectionString, string location, bool refreshCredentials, CancellationToken cancellationToken)
         {
             LastAction = AzureClientAction.Connect;
             SubscriptionId = subscriptionId;

--- a/src/Tests/AzureClientTests.cs
+++ b/src/Tests/AzureClientTests.cs
@@ -76,9 +76,13 @@ namespace Tests.IQSharp
             var environment = AzureEnvironment.Create("TEST_SUBSCRIPTION_ID");
             Assert.AreEqual(AzureEnvironmentType.Production, environment.Type);
 
-            // Dogfood environment cannot be created in test because it requires a service call
+            // Dogfood environment
+            // NB: This used to intentionally throw an exception when mocked,
+            //     due to requiring a service call, but that service call has
+            //     been moved to ConnectAsync instead of Create.
             Environment.SetEnvironmentVariable(AzureEnvironment.EnvironmentVariableName, AzureEnvironmentType.Dogfood.ToString());
-            Assert.ThrowsException<InvalidOperationException>(() => AzureEnvironment.Create("TEST_SUBSCRIPTION_ID"));
+            environment = AzureEnvironment.Create("TEST_SUBSCRIPTION_ID");
+            Assert.AreEqual(AzureEnvironmentType.Dogfood, environment.Type);
 
             // Canary environment
             Environment.SetEnvironmentVariable(AzureEnvironment.EnvironmentVariableName, AzureEnvironmentType.Canary.ToString());


### PR DESCRIPTION
This PR fixes miscellaneous minor issues in the `%azure.connect` magic command:

- Propagate cancellation tokens through to provide `CancellableMagic` support.
- Ensure that task cancellation exceptions caught in Azure-related magic commands are not reported as errors (see https://github.com/microsoft/jupyter-core/pull/73).
- [enh] Provide copy button for code in device auth flow.
