### PR TITLE
Adding explicit reference to Qsharp.Core package

### DIFF
--- a/src/Core/Core.csproj
+++ b/src/Core/Core.csproj
@@ -41,6 +41,7 @@
     <PackageReference Include="Microsoft.Quantum.Compiler" Version="0.14.2011120240" />
     <PackageReference Include="Microsoft.Quantum.CsharpGeneration" Version="0.14.2011120240" />
     <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.14.2011120240" />
+    <PackageReference Include="Microsoft.Quantum.QSharp.Core" Version="0.14.2011120240" />
     <PackageReference Include="NuGet.Resolver" Version="5.1.0" />
     <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
   </ItemGroup>


### PR DESCRIPTION
With the ongoing refactor of the qsharp-runtime repo to support target packages, the Microsoft.Quantum.Simulators package no longer automatically brings in the Microsoft.Quantum.QSharp.Core package, so projects need to explicitly add that reference if they are not using the QDK. See https://github.com/microsoft/qsharp-runtime/pull/476, which this change will help unblock.