### PR TITLE
Allow using arrays from %azure.execute

### DIFF
--- a/build/test-selenium.py
+++ b/build/test-selenium.py
@@ -58,9 +58,9 @@ def get_sample_operation():
     # closing braces from the string that we enter.
     return '''
         operation DoNothing() : Unit {
-            using (q = Qubit()) {
-                H(q);
-                H(q);
+            use q = Qubit();
+            H(q);
+            H(q);
     '''
     
 def test_kernel_startup():

--- a/src/AzureClient/AzureClient.csproj
+++ b/src/AzureClient/AzureClient.csproj
@@ -13,7 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Quantum.Client" Version="0.14.2011120240" />
+    <PackageReference Include="Microsoft.Azure.Quantum.Client" Version="0.15.2101125897" />
     <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.21" />
     <PackageReference Include="Microsoft.Rest.ClientRuntime.Azure" Version="3.3.19" />
     <PackageReference Include="System.Reactive" Version="4.3.2" />

--- a/src/AzureClient/AzureEnvironment.cs
+++ b/src/AzureClient/AzureEnvironment.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
         ///     A map from subscription IDs to authorities used to log in to
         ///     the tenant for each subscription. If a subscription ID is
         ///     missing from this cache, it can be looked up using
-        ///     <see cref="GetAuthorityForSubscription(string, string)"/>.
+        ///     <see cref="GetAuthorityForSubscription(string, string, ILogger?)"/>.
         /// </summary>
         private static Dictionary<string, string> SubscriptionAuthorityCache = new Dictionary<string, string>();
 

--- a/src/AzureClient/AzureSubmissionContext.cs
+++ b/src/AzureClient/AzureSubmissionContext.cs
@@ -74,10 +74,6 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
             var timeout = inputParameters.DecodeParameter<int>(ParameterNameTimeout, defaultValue: DefaultExecutionTimeoutInSeconds);
             var pollingInterval = inputParameters.DecodeParameter<int>(ParameterNamePollingInterval, defaultValue: DefaultExecutionPollingIntervalInSeconds);
 
-            // var decodedParameters = inputParameters.ToDictionary(
-            //     item => item.Key,
-            //     item => inputParameters.DecodeParameter<string>(item.Key));
-
             return new AzureSubmissionContext()
             {
                 FriendlyName = jobName,

--- a/src/AzureClient/AzureSubmissionContext.cs
+++ b/src/AzureClient/AzureSubmissionContext.cs
@@ -74,16 +74,16 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
             var timeout = inputParameters.DecodeParameter<int>(ParameterNameTimeout, defaultValue: DefaultExecutionTimeoutInSeconds);
             var pollingInterval = inputParameters.DecodeParameter<int>(ParameterNamePollingInterval, defaultValue: DefaultExecutionPollingIntervalInSeconds);
 
-            var decodedParameters = inputParameters.ToDictionary(
-                item => item.Key,
-                item => inputParameters.DecodeParameter<string>(item.Key));
+            // var decodedParameters = inputParameters.ToDictionary(
+            //     item => item.Key,
+            //     item => inputParameters.DecodeParameter<string>(item.Key));
 
             return new AzureSubmissionContext()
             {
                 FriendlyName = jobName,
                 Shots = shots,
                 OperationName = operationName,
-                InputParameters = decodedParameters,
+                InputParameters = inputParameters,
                 ExecutionTimeout = timeout,
                 ExecutionPollingInterval = pollingInterval,
             };

--- a/src/AzureClient/EntryPoint/EntryPoint.cs
+++ b/src/AzureClient/EntryPoint/EntryPoint.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.Quantum.IQSharp.Jupyter;
 using Microsoft.Quantum.Runtime;
 using Microsoft.Quantum.Simulation.Core;
 
@@ -54,7 +55,7 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
                 object? parameterValue = null;
                 try
                 {
-                    parameterValue = System.Convert.ChangeType(rawParameterValue, parameter.ParameterType);
+                    parameterValue = submissionContext.InputParameters.DecodeParameter(parameter.Name, type: parameter.ParameterType);
                 }
                 catch (Exception e)
                 {

--- a/src/AzureClient/Magic/AzureClientMagicBase.cs
+++ b/src/AzureClient/Magic/AzureClientMagicBase.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using Microsoft.Jupyter.Core;
 using Microsoft.Quantum.IQSharp.Jupyter;
 // NB: The name `Documentation` can be ambiguous in this context,
@@ -38,8 +39,9 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
         /// <param name="azureClient">The <see cref="IAzureClient"/> object used to interact with Azure.</param>
         /// <param name="keyword">The name used to invoke the magic command.</param>
         /// <param name="docs">Documentation describing the usage of this magic command.</param>
-        public AzureClientMagicBase(IAzureClient azureClient, string keyword, JupyterDocumentation docs):
-            base(keyword, docs)
+        /// <param name="logger">Logger to be used for reporting issues from this magic command.</param>
+        public AzureClientMagicBase(IAzureClient azureClient, string keyword, JupyterDocumentation docs, ILogger logger):
+            base(keyword, docs, logger)
         {
             this.AzureClient = azureClient;
         }

--- a/src/AzureClient/Magic/ConnectMagic.cs
+++ b/src/AzureClient/Magic/ConnectMagic.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using Microsoft.Jupyter.Core;
 using Microsoft.Quantum.IQSharp.Jupyter;
 
@@ -39,7 +40,7 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
         /// <param name="azureClient">
         /// The <see cref="IAzureClient"/> object to use for Azure functionality.
         /// </param>
-        public ConnectMagic(IAzureClient azureClient)
+        public ConnectMagic(IAzureClient azureClient, ILogger<ConnectMagic> logger)
             : base(
                 azureClient,
                 "azure.connect",
@@ -138,7 +139,8 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
                             ```
                         ".Dedent(),
                     },
-                })
+                },
+                logger)
         { }
 
         /// <summary>

--- a/src/AzureClient/Magic/ExecuteMagic.cs
+++ b/src/AzureClient/Magic/ExecuteMagic.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Jupyter.Core;
+using Microsoft.Extensions.Logging;
 using Microsoft.Quantum.IQSharp.Jupyter;
 
 namespace Microsoft.Quantum.IQSharp.AzureClient
@@ -23,7 +24,7 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
         /// <param name="azureClient">
         /// The <see cref="IAzureClient"/> object to use for Azure functionality.
         /// </param>
-        public ExecuteMagic(IAzureClient azureClient)
+        public ExecuteMagic(IAzureClient azureClient, ILogger<ExecuteMagic> logger)
             : base(
                 azureClient,
                 "azure.execute",
@@ -106,7 +107,7 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
                             ```
                         ".Dedent(),
                     },
-                })
+                }, logger)
         { }
 
         /// <summary>

--- a/src/AzureClient/Magic/JobsMagic.cs
+++ b/src/AzureClient/Magic/JobsMagic.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using Microsoft.Jupyter.Core;
 using Microsoft.Quantum.IQSharp.Jupyter;
 
@@ -26,7 +27,7 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
         /// <param name="azureClient">
         /// The <see cref="IAzureClient"/> object to use for Azure functionality.
         /// </param>
-        public JobsMagic(IAzureClient azureClient)
+        public JobsMagic(IAzureClient azureClient, ILogger<JobsMagic> logger)
             : base(
                 azureClient,
                 "azure.jobs",
@@ -69,7 +70,7 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
                             ```
                         ".Dedent(),
                     },
-                }) {}
+                }, logger) {}
 
         /// <summary>
         ///     Lists all jobs in the active workspace, optionally filtered by a provided parameter.

--- a/src/AzureClient/Magic/OutputMagic.cs
+++ b/src/AzureClient/Magic/OutputMagic.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using Microsoft.Jupyter.Core;
 using Microsoft.Quantum.IQSharp.Jupyter;
 
@@ -26,7 +27,7 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
         /// <param name="azureClient">
         /// The <see cref="IAzureClient"/> object to use for Azure functionality.
         /// </param>
-        public OutputMagic(IAzureClient azureClient)
+        public OutputMagic(IAzureClient azureClient, ILogger<OutputMagic> logger)
             : base(
                 azureClient,
                 "azure.output",
@@ -73,7 +74,7 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
                             ```
                         ".Dedent(),
                     },
-                }) {}
+                }, logger) {}
 
         /// <summary>
         ///     Displays the output of a given completed job ID, if provided,

--- a/src/AzureClient/Magic/QuotaMagic.cs
+++ b/src/AzureClient/Magic/QuotaMagic.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using Microsoft.Jupyter.Core;
 using Microsoft.Quantum.IQSharp.Jupyter;
 
@@ -24,7 +25,7 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
         /// <param name="azureClient">
         /// The <see cref="IAzureClient"/> object to use for Azure functionality.
         /// </param>
-        public QuotaMagic(IAzureClient azureClient)
+        public QuotaMagic(IAzureClient azureClient, ILogger<QuotaMagic> logger)
             : base(
                 azureClient,
                 "azure.quotas",
@@ -52,7 +53,7 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
                             ```
                         ".Dedent()
                     },
-                }) {}
+                }, logger) {}
 
         /// <summary>
         ///     Lists all jobs in the active workspace, optionally filtered by a provided parameter.

--- a/src/AzureClient/Magic/StatusMagic.cs
+++ b/src/AzureClient/Magic/StatusMagic.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using Microsoft.Jupyter.Core;
 using Microsoft.Quantum.IQSharp.Jupyter;
 
@@ -26,7 +27,7 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
         /// <param name="azureClient">
         /// The <see cref="IAzureClient"/> object to use for Azure functionality.
         /// </param>
-        public StatusMagic(IAzureClient azureClient)
+        public StatusMagic(IAzureClient azureClient, ILogger<StatusMagic> logger)
             : base(
                 azureClient,
                 "azure.status",
@@ -69,7 +70,8 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
                             ```
                         ".Dedent(),
                     },
-                }) {}
+                },
+                logger) {}
 
         /// <summary>
         ///     Displays the status corresponding to a given job ID, if provided,

--- a/src/AzureClient/Magic/SubmitMagic.cs
+++ b/src/AzureClient/Magic/SubmitMagic.cs
@@ -6,6 +6,7 @@
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using Microsoft.Jupyter.Core;
 using Microsoft.Quantum.IQSharp.Jupyter;
 
@@ -22,7 +23,7 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
         /// <param name="azureClient">
         /// The <see cref="IAzureClient"/> object to use for Azure functionality.
         /// </param>
-        public SubmitMagic(IAzureClient azureClient)
+        public SubmitMagic(IAzureClient azureClient, ILogger<SubmitMagic> logger)
             : base(
                 azureClient,
                 "azure.submit",
@@ -90,7 +91,8 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
                             ```
                         ".Dedent(),
                     },
-                })
+                },
+                logger)
         { }
 
         /// <summary>

--- a/src/AzureClient/Magic/TargetMagic.cs
+++ b/src/AzureClient/Magic/TargetMagic.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using Microsoft.Jupyter.Core;
 using Microsoft.Quantum.IQSharp.Jupyter;
 
@@ -26,7 +27,7 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
         /// <param name="azureClient">
         /// The <see cref="IAzureClient"/> object to use for Azure functionality.
         /// </param>
-        public TargetMagic(IAzureClient azureClient)
+        public TargetMagic(IAzureClient azureClient, ILogger<TargetMagic> logger)
             : base(
                 azureClient,
                 "azure.target",
@@ -73,7 +74,8 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
                             ```
                         ".Dedent(),
                     },
-                })
+                },
+                logger)
         { }
 
         /// <summary>

--- a/src/Core/Core.csproj
+++ b/src/Core/Core.csproj
@@ -38,10 +38,10 @@
     <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="3.0.0" />
-    <PackageReference Include="Microsoft.Quantum.Compiler" Version="0.14.2011120240" />
-    <PackageReference Include="Microsoft.Quantum.CsharpGeneration" Version="0.14.2011120240" />
-    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.14.2011120240" />
-    <PackageReference Include="Microsoft.Quantum.QSharp.Core" Version="0.14.2011120240" />
+    <PackageReference Include="Microsoft.Quantum.Compiler" Version="0.15.2101125897" />
+    <PackageReference Include="Microsoft.Quantum.CsharpGeneration" Version="0.15.2101125897" />
+    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.15.2101125897" />
+    <PackageReference Include="Microsoft.Quantum.QSharp.Core" Version="0.15.2101125897" />
     <PackageReference Include="NuGet.Resolver" Version="5.1.0" />
     <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
   </ItemGroup>

--- a/src/Core/Extensions/Qsharp.cs
+++ b/src/Core/Extensions/Qsharp.cs
@@ -18,19 +18,13 @@ namespace Microsoft.Quantum.IQSharp
         /// <summary>
         /// Returns the source of the given QsNamespaceElement (either QsCallable or QsCustomTypes)
         /// </summary>
-        public static string SourceFile(this QsNamespaceElement e)
-        {
-            if (e is QsNamespaceElement.QsCallable c)
+        public static string SourceFile(this QsNamespaceElement e) =>
+            (e switch
             {
-                return c.Item.SourceFile;
-            }
-            else if (e is QsNamespaceElement.QsCustomType t)
-            {
-                return t.Item.SourceFile;
-            }
-
-            return "[Unknown]";
-        }
+                QsNamespaceElement.QsCallable { Item: var callable } => callable.Source,
+                QsNamespaceElement.QsCustomType { Item: var type } => type.Source,
+                _ => null
+            })?.AssemblyOrCodeFile ?? "[Unknown]";
 
         /// <summary>
         /// Returns the name of the given QsNamespaceElement (either QsCallable or QsCustomTypes)

--- a/src/ExecutionPathTracer/ExecutionPathTracer.csproj
+++ b/src/ExecutionPathTracer/ExecutionPathTracer.csproj
@@ -32,7 +32,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.14.2011120240" />
+    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.15.2101125897" />
   </ItemGroup>
 
 </Project>

--- a/src/Jupyter/Extensions.cs
+++ b/src/Jupyter/Extensions.cs
@@ -201,7 +201,16 @@ namespace Microsoft.Quantum.IQSharp.Jupyter
             {
                 return defaultValue;
             }
-            return (T)System.Convert.ChangeType(JsonConvert.DeserializeObject(parameterValue), typeof(T)) ?? defaultValue;
+            return JsonConvert.DeserializeObject<T>(parameterValue) ?? defaultValue;
+        }
+
+        public static object DecodeParameter(this Dictionary<string, string> parameters, string parameterName, Type type, object defaultValue = default)
+        {
+            if (!parameters.TryGetValue(parameterName, out string parameterValue))
+            {
+                return defaultValue;
+            }
+            return JsonConvert.DeserializeObject(parameterValue, type) ?? defaultValue;
         }
     }
 }

--- a/src/Jupyter/Extensions.cs
+++ b/src/Jupyter/Extensions.cs
@@ -195,16 +195,46 @@ namespace Microsoft.Quantum.IQSharp.Jupyter
         /// <summary>
         ///      Retrieves and JSON-decodes the value for the given parameter name.
         /// </summary>
+        /// <typeparam name="T">
+        ///      The expected type of the decoded parameter.
+        /// </typeparam>
+        /// <param name="parameters">
+        ///     Dictionary from parameter names to JSON-encoded values.
+        /// </param>
+        /// <param name="parameterName">
+        ///     The name of the parameter to be decoded.
+        /// </param>
+        /// <param name="defaultValue">
+        ///      The default value to be returned if no parameter with the
+        ///      name <paramref name="parameterName"/> is present in the
+        ///      dictionary.
+        /// </param>
         public static T DecodeParameter<T>(this Dictionary<string, string> parameters, string parameterName, T defaultValue = default)
-        {
-            if (!parameters.TryGetValue(parameterName, out string parameterValue))
-            {
-                return defaultValue;
-            }
-            return JsonConvert.DeserializeObject<T>(parameterValue) ?? defaultValue;
-        }
+        where T: notnull =>
+            // NB: We can assert that this is not null here, since the where
+            //     clause ensures that T is not a nullable type, such that
+            //     defaultValue cannot be null. This is not tracked by the
+            //     return type of `object?`, such that we need to null-forgive.
+            (T)(parameters.DecodeParameter(parameterName, typeof(T), defaultValue)!);
 
-        public static object DecodeParameter(this Dictionary<string, string> parameters, string parameterName, Type type, object defaultValue = default)
+        /// <summary>
+        ///      Retrieves and JSON-decodes the value for the given parameter name.
+        /// </summary>
+        /// <param name="parameters">
+        ///     Dictionary from parameter names to JSON-encoded values.
+        /// </param>
+        /// <param name="parameterName">
+        ///     The name of the parameter to be decoded.
+        /// </param>
+        /// <param name="type">
+        ///      The expected type of the decoded parameter.
+        /// </param>
+        /// <param name="defaultValue">
+        ///      The default value to be returned if no parameter with the
+        ///      name <paramref name="parameterName"/> is present in the
+        ///      dictionary.
+        /// </param>
+        public static object? DecodeParameter(this Dictionary<string, string> parameters, string parameterName, Type type, object? defaultValue = default)
         {
             if (!parameters.TryGetValue(parameterName, out string parameterValue))
             {

--- a/src/Jupyter/Extensions.cs
+++ b/src/Jupyter/Extensions.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
 using System.Text.RegularExpressions;
 using Microsoft.Jupyter.Core;
 using Microsoft.Quantum.Simulation.Common;
@@ -190,6 +191,38 @@ namespace Microsoft.Quantum.IQSharp.Jupyter
             // out common indenting.
             var leftTrimRegex = new Regex(@$"^[ \t]{{{minWhitespace}}}", RegexOptions.Multiline);
             return leftTrimRegex.Replace(text, "");
+        }
+
+        /// <summary>
+        ///      Retrieves and JSON-decodes the value for the given parameter name.
+        /// </summary>
+        /// <typeparam name="T">
+        ///      The expected type of the decoded parameter.
+        /// </typeparam>
+        /// <param name="parameters">
+        ///     Dictionary from parameter names to JSON-encoded values.
+        /// </param>
+        /// <param name="parameterName">
+        ///     The name of the parameter to be decoded.
+        /// </param>
+        /// <param name="defaultValue">
+        ///      The default value to be returned if no parameter with the
+        ///      name <paramref name="parameterName"/> is present in the
+        ///      dictionary.
+        /// </param>
+        public static bool TryDecodeParameter<T>(this Dictionary<string, string> parameters, string parameterName, out T decoded, T defaultValue = default)
+        where T: struct
+        {
+            try
+            {
+                decoded = (T)(parameters.DecodeParameter(parameterName, typeof(T), defaultValue)!);
+                return true;
+            }
+            catch
+            {
+                decoded = default;
+                return false;
+            }
         }
 
         /// <summary>

--- a/src/Jupyter/Magic/AbstractMagic.cs
+++ b/src/Jupyter/Magic/AbstractMagic.cs
@@ -1,5 +1,7 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+
+#nullable enable
 
 using System;
 using System.Collections.Generic;
@@ -8,6 +10,7 @@ using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using Microsoft.Jupyter.Core;
 using Microsoft.Quantum.IQSharp.Common;
 using Microsoft.Quantum.QsCompiler.Serialization;
@@ -23,16 +26,20 @@ namespace Microsoft.Quantum.IQSharp.Jupyter
     /// </summary>
     public abstract class AbstractMagic : CancellableMagicSymbol
     {
+        private ILogger? Logger;
+
         /// <summary>
         ///     Constructs a new magic symbol given its name and documentation.
         /// </summary>
-        public AbstractMagic(string keyword, JupyterDocumentation docs)
+        public AbstractMagic(string keyword, JupyterDocumentation docs, ILogger? logger)
         {
             this.Name = $"%{keyword}";
             this.Documentation = docs;
 
             this.Kind = SymbolKind.Magic;
             this.ExecuteCancellable = this.SafeExecute(this.RunCancellable);
+
+            this.Logger = logger;
         }
 
         /// <summary>
@@ -70,6 +77,7 @@ namespace Microsoft.Quantum.IQSharp.Jupyter
                     }
                     catch (Exception e)
                     {
+                        Logger?.LogWarning(e, "Unhandled exception in magic command {Magic}, printing as stderr.", this.Name);
                         channel.Stderr(e.Message);
                         return ExecuteStatus.Error.ToExecutionResult();
                     }

--- a/src/Jupyter/Magic/AbstractMagic.cs
+++ b/src/Jupyter/Magic/AbstractMagic.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Quantum.IQSharp.Jupyter
         /// <summary>
         ///     Constructs a new magic symbol given its name and documentation.
         /// </summary>
-        public AbstractMagic(string keyword, JupyterDocumentation docs, ILogger? logger)
+        public AbstractMagic(string keyword, JupyterDocumentation docs, ILogger? logger = null)
         {
             this.Name = $"%{keyword}";
             this.Documentation = docs;

--- a/src/Jupyter/Magic/AbstractMagic.cs
+++ b/src/Jupyter/Magic/AbstractMagic.cs
@@ -72,6 +72,7 @@ namespace Microsoft.Quantum.IQSharp.Jupyter
                     }
                     catch (AggregateException agg)
                     {
+                        Logger?.LogWarning(agg, "Unhandled aggregate exception in magic command {Magic}, printing as stderr.", this.Name);
                         foreach (var e in agg.InnerExceptions) channel.Stderr(e?.Message);
                         return ExecuteStatus.Error.ToExecutionResult();
                     }

--- a/src/Kernel/Magic/ConfigMagic.cs
+++ b/src/Kernel/Magic/ConfigMagic.cs
@@ -4,7 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-
+using Microsoft.Extensions.Logging;
 using Microsoft.Jupyter.Core;
 using Microsoft.Quantum.IQSharp.Jupyter;
 using Newtonsoft.Json;
@@ -21,7 +21,7 @@ namespace Microsoft.Quantum.IQSharp.Kernel
         ///     Constructs a magic command that sets or queries configuration
         ///     options using a given configuration source.
         /// </summary>
-        public ConfigMagic(IConfigurationSource configurationSource) : base(
+        public ConfigMagic(IConfigurationSource configurationSource, ILogger<ConfigMagic> logger) : base(
             "config",
             new Microsoft.Jupyter.Core.Documentation
             {
@@ -140,7 +140,7 @@ namespace Microsoft.Quantum.IQSharp.Kernel
                         directory is loaded.
                     ".Dedent()
                 }
-            })
+            }, logger)
         {
             this.ConfigurationSource = configurationSource;
         }

--- a/src/Kernel/Magic/DebugMagic.cs
+++ b/src/Kernel/Magic/DebugMagic.cs
@@ -90,7 +90,7 @@ namespace Microsoft.Quantum.IQSharp.Kernel
                         ```
                     ".Dedent(),
                 }
-            })
+            }, logger)
         {
             this.SymbolResolver = resolver;
             this.ConfigurationSource = configurationSource;

--- a/src/Kernel/Magic/EstimateMagic.cs
+++ b/src/Kernel/Magic/EstimateMagic.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using Microsoft.Jupyter.Core;
 using Microsoft.Quantum.IQSharp.Common;
 using Microsoft.Quantum.IQSharp.Jupyter;
@@ -26,7 +27,7 @@ namespace Microsoft.Quantum.IQSharp.Kernel
         ///     constructs a new magic command that performs resource estimation
         ///     on resolved operations.
         /// </summary>
-        public EstimateMagic(ISymbolResolver resolver) : base(
+        public EstimateMagic(ISymbolResolver resolver, ILogger<EstimateMagic> logger) : base(
             "estimate",
             new Microsoft.Jupyter.Core.Documentation
             {
@@ -82,7 +83,7 @@ namespace Microsoft.Quantum.IQSharp.Kernel
                         ```
                     ".Dedent(),
                 }
-            })
+            }, logger)
         {
             this.SymbolResolver = resolver;
         }

--- a/src/Kernel/Magic/LsMagicMagic.cs
+++ b/src/Kernel/Magic/LsMagicMagic.cs
@@ -3,7 +3,7 @@
 
 using System;
 using System.Linq;
-
+using Microsoft.Extensions.Logging;
 using Microsoft.Jupyter.Core;
 using Microsoft.Quantum.IQSharp;
 using Microsoft.Quantum.IQSharp.Jupyter;
@@ -32,7 +32,7 @@ namespace Microsoft.Quantum.IQSharp.Kernel
         ///     Given a given snippets collection, constructs a new magic command
         ///     that queries callables defined in that snippets collection.
         /// </summary>
-        public LsMagicMagic(IMagicSymbolResolver resolver, IExecutionEngine engine) : base(
+        public LsMagicMagic(IMagicSymbolResolver resolver, IExecutionEngine engine, ILogger<LsMagicMagic> logger) : base(
             "lsmagic",
             new Microsoft.Jupyter.Core.Documentation
             {
@@ -52,7 +52,7 @@ namespace Microsoft.Quantum.IQSharp.Kernel
                         ```
                     ".Dedent(),
                 }
-            })
+            }, logger)
         {
             this.resolver = resolver;
             if (engine is IQSharpEngine iQSharpEngine)

--- a/src/Kernel/Magic/LsOpenMagic.cs
+++ b/src/Kernel/Magic/LsOpenMagic.cs
@@ -6,7 +6,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-
+using Microsoft.Extensions.Logging;
 using Microsoft.Jupyter.Core;
 using Microsoft.Quantum.IQSharp.Jupyter;
 
@@ -21,7 +21,7 @@ namespace Microsoft.Quantum.IQSharp.Kernel
         ///     Constructs an instance of %lsopen given an instance of the
         ///     compiler service.
         /// </summary>
-        public LsOpenMagic(ICompilerService compiler) : base(
+        public LsOpenMagic(ICompilerService compiler, ILogger<LsOpenMagic> logger) : base(
             "lsopen",
             new Microsoft.Jupyter.Core.Documentation
             {
@@ -45,7 +45,7 @@ namespace Microsoft.Quantum.IQSharp.Kernel
                         ```
                     ".Dedent()
                 }
-            })
+            }, logger)
         {
             this.Compiler = compiler;
         }

--- a/src/Kernel/Magic/PackageMagic.cs
+++ b/src/Kernel/Magic/PackageMagic.cs
@@ -5,6 +5,7 @@ using System;
 using System.Linq;
 using System.Reactive.Linq;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using Microsoft.Jupyter.Core;
 using Microsoft.Quantum.IQSharp.Jupyter;
 using Microsoft.Quantum.IQSharp.Kernel;
@@ -23,7 +24,7 @@ namespace Microsoft.Quantum.IQSharp.Kernel
         ///     Constructs a new magic command that adds package references to
         ///     a given references collection.
         /// </summary>
-        public PackageMagic(IReferences references) : base(
+        public PackageMagic(IReferences references, ILogger<PackageMagic> logger) : base(
             "package",
             new Microsoft.Jupyter.Core.Documentation
             {
@@ -71,7 +72,7 @@ namespace Microsoft.Quantum.IQSharp.Kernel
                         ```
                     ".Dedent(),
                 }
-            })
+            }, logger)
         {
             this.References = references;
         }

--- a/src/Kernel/Magic/PerformanceMagic.cs
+++ b/src/Kernel/Magic/PerformanceMagic.cs
@@ -5,7 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-
+using Microsoft.Extensions.Logging;
 using Microsoft.Jupyter.Core;
 using Microsoft.Quantum.IQSharp;
 using Microsoft.Quantum.IQSharp.Jupyter;
@@ -24,7 +24,7 @@ namespace Microsoft.Quantum.IQSharp.Kernel
         /// <summary>
         ///     Constructs a new performance command.
         /// </summary>
-        public PerformanceMagic() : base(
+        public PerformanceMagic(ILogger<PerformanceMagic> logger) : base(
             "performance",
             new Microsoft.Jupyter.Core.Documentation {
                 Summary = "Reports current performance metrics for this kernel.",
@@ -53,7 +53,7 @@ namespace Microsoft.Quantum.IQSharp.Kernel
                         ```
                     ".Dedent(),
                 }
-            })
+            }, logger)
         {
         }
 

--- a/src/Kernel/Magic/ProjectMagic.cs
+++ b/src/Kernel/Magic/ProjectMagic.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Linq;
 using System.Reactive.Linq;
+using Microsoft.Extensions.Logging;
 using Microsoft.Jupyter.Core;
 using Microsoft.Quantum.IQSharp.Jupyter;
 
@@ -23,7 +24,7 @@ namespace Microsoft.Quantum.IQSharp.Kernel
         ///     Constructs a new magic command that adds Q# project references to
         ///     the current IQ# session.
         /// </summary>
-        public ProjectMagic(IWorkspace workspace) : base(
+        public ProjectMagic(IWorkspace workspace, ILogger<ProjectMagic> logger) : base(
             "project",
             new Microsoft.Jupyter.Core.Documentation
             {
@@ -62,7 +63,7 @@ namespace Microsoft.Quantum.IQSharp.Kernel
                         ```
                     ".Dedent(),
                 }
-            })
+            }, logger)
         {
             this.Workspace = workspace;
         }

--- a/src/Kernel/Magic/Simulate.cs
+++ b/src/Kernel/Magic/Simulate.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using Microsoft.Jupyter.Core;
 using Microsoft.Quantum.IQSharp.Common;
 using Microsoft.Quantum.IQSharp.Jupyter;
@@ -25,7 +26,7 @@ namespace Microsoft.Quantum.IQSharp.Kernel
         ///     operations and functions, and a configuration source used to set
         ///     configuration options.
         /// </summary>
-        public SimulateMagic(ISymbolResolver resolver, IConfigurationSource configurationSource) : base(
+        public SimulateMagic(ISymbolResolver resolver, IConfigurationSource configurationSource, ILogger<SimulateMagic> logger) : base(
             "simulate",
             new Microsoft.Jupyter.Core.Documentation
             {
@@ -60,7 +61,7 @@ namespace Microsoft.Quantum.IQSharp.Kernel
                         ```
                     ".Dedent(),
                 }
-            })
+            }, logger)
         {
             this.SymbolResolver = resolver;
             this.ConfigurationSource = configurationSource;

--- a/src/Kernel/Magic/ToffoliMagic.cs
+++ b/src/Kernel/Magic/ToffoliMagic.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using Microsoft.Jupyter.Core;
 using Microsoft.Quantum.IQSharp.Common;
 using Microsoft.Quantum.IQSharp.Jupyter;
@@ -21,7 +22,7 @@ namespace Microsoft.Quantum.IQSharp.Kernel
         /// <summary>
         /// Default constructor.
         /// </summary>
-        public ToffoliMagic(ISymbolResolver resolver) : base(
+        public ToffoliMagic(ISymbolResolver resolver, ILogger<ToffoliMagic> logger) : base(
             "toffoli",
             new Microsoft.Jupyter.Core.Documentation
             {
@@ -58,7 +59,7 @@ namespace Microsoft.Quantum.IQSharp.Kernel
                         ```
                     ".Dedent(),
                 }
-            })
+            }, logger)
         {
             this.SymbolResolver = resolver;
         }

--- a/src/Kernel/Magic/TraceMagic.cs
+++ b/src/Kernel/Magic/TraceMagic.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using Microsoft.Jupyter.Core;
 using Microsoft.Jupyter.Core.Protocol;
 using Microsoft.Quantum.IQSharp.ExecutionPathTracer;
@@ -82,7 +83,7 @@ namespace Microsoft.Quantum.IQSharp.Kernel
         ///     operations and functions, and a configuration source used to set
         ///     configuration options.
         /// </summary>
-        public TraceMagic(ISymbolResolver resolver, IConfigurationSource configurationSource) : base(
+        public TraceMagic(ISymbolResolver resolver, IConfigurationSource configurationSource, ILogger<TraceMagic> logger) : base(
             "trace",
             new Microsoft.Jupyter.Core.Documentation
             {
@@ -127,7 +128,7 @@ namespace Microsoft.Quantum.IQSharp.Kernel
                         ```
                     ".Dedent(),
                 }
-            })
+            }, logger)
         {
             this.SymbolResolver = resolver;
             this.ConfigurationSource = configurationSource;

--- a/src/Kernel/Magic/TraceMagic.cs
+++ b/src/Kernel/Magic/TraceMagic.cs
@@ -163,11 +163,21 @@ namespace Microsoft.Quantum.IQSharp.Kernel
             var symbol = SymbolResolver.Resolve(name) as IQSharpSymbol;
             if (symbol == null) throw new InvalidOperationException($"Invalid operation name: {name}");
 
-            var depth = inputParameters.DecodeParameter<int>(
+            if (!inputParameters.TryDecodeParameter<int>(
                 ParameterNameDepth,
+                out var depth,
                 defaultValue: this.ConfigurationSource.TraceVisualizationDefaultDepth
-            );
-            if (depth <= 0) throw new ArgumentOutOfRangeException($"Invalid depth: {depth}. Must be >= 1.");
+            ))
+            {
+                channel.Stderr($"Expected {ParameterNameDepth} to be an integer, but got {inputParameters[ParameterNameDepth]}.");
+                return ExecuteStatus.Error.ToExecutionResult();
+            }
+
+            if (depth <= 0)
+            {
+                channel.Stderr($"Expected {ParameterNameDepth} to be >= 1, but got {depth}.");
+                return ExecuteStatus.Error.ToExecutionResult();
+            }
 
             var tracer = new ExecutionPathTracer.ExecutionPathTracer();
 

--- a/src/Kernel/Magic/WhoMagic.cs
+++ b/src/Kernel/Magic/WhoMagic.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 using System.Linq;
-
+using Microsoft.Extensions.Logging;
 using Microsoft.Jupyter.Core;
 using Microsoft.Quantum.IQSharp;
 using Microsoft.Quantum.IQSharp.Jupyter;
@@ -19,7 +19,7 @@ namespace Microsoft.Quantum.IQSharp.Kernel
         ///     Given a given snippets collection, constructs a new magic command
         ///     that queries callables defined in that snippets collection.
         /// </summary>
-        public WhoMagic(ISnippets snippets) : base(
+        public WhoMagic(ISnippets snippets, ILogger<WhoMagic> logger) : base(
             "who",
             new Microsoft.Jupyter.Core.Documentation
             {
@@ -43,7 +43,7 @@ namespace Microsoft.Quantum.IQSharp.Kernel
                         ```
                     ".Dedent(),
                 }
-            })
+            }, logger)
         {
             this.Snippets = snippets;
         }

--- a/src/Kernel/Magic/WorkspaceMagic.cs
+++ b/src/Kernel/Magic/WorkspaceMagic.cs
@@ -5,6 +5,7 @@ using System;
 using System.Linq;
 using System.Reactive.Linq;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using Microsoft.Jupyter.Core;
 using Microsoft.Quantum.IQSharp.Common;
 using Microsoft.Quantum.IQSharp.Jupyter;
@@ -22,7 +23,7 @@ namespace Microsoft.Quantum.IQSharp.Kernel
         ///      Given a workspace, constructs a new magic symbol to control
         ///      that workspace.
         /// </summary>
-        public WorkspaceMagic(IWorkspace workspace) : base(
+        public WorkspaceMagic(IWorkspace workspace, ILogger<WorkspaceMagic> logger) : base(
             "workspace", 
             new Microsoft.Jupyter.Core.Documentation
             {
@@ -60,7 +61,7 @@ namespace Microsoft.Quantum.IQSharp.Kernel
                         ```
                     ".Dedent(),
                 }
-            })
+            }, logger)
         {
             this.Workspace = workspace;
         }

--- a/src/Kernel/SymbolResolver.cs
+++ b/src/Kernel/SymbolResolver.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Quantum.IQSharp.Kernel
         ///     symbol was defined.
         /// </summary>
         [JsonProperty("source")]
-        public string Source => Operation.Header.SourceFile;
+        public string Source => Operation.Header.Source.AssemblyOrCodeFile;
 
         /// <summary>
         ///     The documentation for this symbol, as provided by its API

--- a/src/MockLibraries/Mock.Chemistry/Mock.Chemistry.csproj
+++ b/src/MockLibraries/Mock.Chemistry/Mock.Chemistry.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Quantum.Sdk/0.14.2011120240">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.15.2101125897">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
@@ -6,6 +6,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.14.2011120240" />
+    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.15.2101125897" />
   </ItemGroup>
 </Project>

--- a/src/MockLibraries/Mock.Standard/Arrays.qs
+++ b/src/MockLibraries/Mock.Standard/Arrays.qs
@@ -34,7 +34,7 @@ namespace Mock.Standard {
     operation ForEach<'T, 'U> (action : ('T => 'U), array : 'T[]) : 'U[] {
         mutable resultArray = new 'U[Length(array)];
 
-        for (idxElement in IndexRange(array)) {
+        for idxElement in IndexRange(array) {
             set resultArray w/= idxElement <- action(array[idxElement]);
         }
 

--- a/src/MockLibraries/Mock.Standard/Canon.qs
+++ b/src/MockLibraries/Mock.Standard/Canon.qs
@@ -35,8 +35,7 @@ namespace Mock.Standard {
     /// - Microsoft.Quantum.Canon.ApplyToEachCA
     operation ApplyToEach<'T> (singleElementOperation : ('T => Unit), register : 'T[]) : Unit
     {
-        for (idxQubit in IndexRange(register))
-        {
+        for idxQubit in IndexRange(register) {
             singleElementOperation(register[idxQubit]);
         }
     }

--- a/src/MockLibraries/Mock.Standard/Mock.Standard.csproj
+++ b/src/MockLibraries/Mock.Standard/Mock.Standard.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Quantum.Sdk/0.14.2011120240">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.15.2101125897">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
@@ -6,6 +6,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.14.2011120240" />
+    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.15.2101125897" />
   </ItemGroup>
 </Project>

--- a/src/Python/qsharp-core/qsharp/tests/test_azure.py
+++ b/src/Python/qsharp-core/qsharp/tests/test_azure.py
@@ -127,7 +127,7 @@ def _test_workspace_job_execution():
         qsharp.azure.execute(op)
     assert exception_info.value.error_name == "JobSubmissionFailed"
 
-    histogram = qsharp.azure.execute(op, count=3, name="test", timeout=3, poll=0.5)
+    histogram = qsharp.azure.execute(op, count=3, name="test", timeout=3, poll=2)
     assert isinstance(histogram, dict)
 
     retrieved_histogram = qsharp.azure.output()

--- a/src/Tests/AzureClientEntryPointTests.cs
+++ b/src/Tests/AzureClientEntryPointTests.cs
@@ -11,6 +11,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Quantum.IQSharp;
 using Microsoft.Quantum.IQSharp.AzureClient;
 using Microsoft.Quantum.IQSharp.Common;
+using Microsoft.Quantum.IQSharp.Jupyter;
 using Microsoft.Quantum.Simulation.Common;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -62,7 +63,11 @@ namespace Tests.IQSharp
 
             var job = await entryPoint.SubmitAsync(
                 new MockQuantumMachine(),
-                new AzureSubmissionContext() { InputParameters = new Dictionary<string, string>() { ["count"] = "2", ["name"] = "test" } });
+                new AzureSubmissionContext()
+                {
+                    InputParameters = AbstractMagic.ParseInputParameters("count=2 name=\"test\"")
+                }
+            );
             Assert.IsNotNull(job);
         }
 

--- a/src/Tests/AzureClientMagicTests.cs
+++ b/src/Tests/AzureClientMagicTests.cs
@@ -41,7 +41,8 @@ namespace Tests.IQSharp
         public void TestConnectMagic()
         {
             var azureClient = new MockAzureClient();
-            var connectMagic = new ConnectMagic(azureClient);
+            var logger = new UnitTestLogger<ConnectMagic>();
+            var connectMagic = new ConnectMagic(azureClient, logger);
 
             // no input
             connectMagic.Test(string.Empty);
@@ -144,19 +145,19 @@ namespace Tests.IQSharp
         {
             // no arguments - should print job status of most recent job
             var azureClient = new MockAzureClient();
-            var statusMagic = new StatusMagic(azureClient);
+            var statusMagic = new StatusMagic(azureClient, new UnitTestLogger<StatusMagic>());
             statusMagic.Test(string.Empty);
             Assert.AreEqual(AzureClientAction.GetJobStatus, azureClient.LastAction);
 
             // single argument - should print job status
             azureClient = new MockAzureClient();
-            statusMagic = new StatusMagic(azureClient);
+            statusMagic = new StatusMagic(azureClient, new UnitTestLogger<StatusMagic>());
             statusMagic.Test($"{jobId}");
             Assert.AreEqual(AzureClientAction.GetJobStatus, azureClient.LastAction);
 
             // single argument with quotes - should print job status
             azureClient = new MockAzureClient();
-            statusMagic = new StatusMagic(azureClient);
+            statusMagic = new StatusMagic(azureClient, new UnitTestLogger<StatusMagic>());
             statusMagic.Test($"\"{jobId}\"");
             Assert.AreEqual(AzureClientAction.GetJobStatus, azureClient.LastAction);
         }
@@ -166,7 +167,7 @@ namespace Tests.IQSharp
         {
             // no arguments
             var azureClient = new MockAzureClient();
-            var submitMagic = new SubmitMagic(azureClient);
+            var submitMagic = new SubmitMagic(azureClient, new UnitTestLogger<SubmitMagic>());
             submitMagic.Test(string.Empty);
             Assert.AreEqual(AzureClientAction.SubmitJob, azureClient.LastAction);
 
@@ -181,7 +182,8 @@ namespace Tests.IQSharp
         {
             // no arguments
             var azureClient = new MockAzureClient();
-            var executeMagic = new ExecuteMagic(azureClient);
+            var logger = new UnitTestLogger<ExecuteMagic>();
+            var executeMagic = new ExecuteMagic(azureClient, logger);
             executeMagic.Test(string.Empty);
             Assert.AreEqual(AzureClientAction.ExecuteJob, azureClient.LastAction);
 
@@ -196,19 +198,19 @@ namespace Tests.IQSharp
         {
             // no arguments - should print job result of most recent job
             var azureClient = new MockAzureClient();
-            var outputMagic = new OutputMagic(azureClient);
+            var outputMagic = new OutputMagic(azureClient, new UnitTestLogger<OutputMagic>());
             outputMagic.Test(string.Empty);
             Assert.AreEqual(AzureClientAction.GetJobResult, azureClient.LastAction);
 
             // single argument - should print job result
             azureClient = new MockAzureClient();
-            outputMagic = new OutputMagic(azureClient);
+            outputMagic = new OutputMagic(azureClient, new UnitTestLogger<OutputMagic>());
             outputMagic.Test($"{jobId}");
             Assert.AreEqual(AzureClientAction.GetJobResult, azureClient.LastAction);
 
             // single argument with quotes - should print job result
             azureClient = new MockAzureClient();
-            outputMagic = new OutputMagic(azureClient);
+            outputMagic = new OutputMagic(azureClient, new UnitTestLogger<OutputMagic>());
             outputMagic.Test($"'{jobId}'");
             Assert.AreEqual(AzureClientAction.GetJobResult, azureClient.LastAction);
         }
@@ -218,13 +220,13 @@ namespace Tests.IQSharp
         {
             // no arguments - should print job status of all jobs
             var azureClient = new MockAzureClient();
-            var jobsMagic = new JobsMagic(azureClient);
+            var jobsMagic = new JobsMagic(azureClient, new UnitTestLogger<JobsMagic>());
             jobsMagic.Test(string.Empty);
             Assert.AreEqual(AzureClientAction.GetJobList, azureClient.LastAction);
 
             // with arguments - should still print job status
             azureClient = new MockAzureClient();
-            jobsMagic = new JobsMagic(azureClient);
+            jobsMagic = new JobsMagic(azureClient, new UnitTestLogger<JobsMagic>());
             jobsMagic.Test($"{jobId}");
             Assert.AreEqual(AzureClientAction.GetJobList, azureClient.LastAction);
         }
@@ -234,18 +236,18 @@ namespace Tests.IQSharp
         {
             // single argument - should set active target
             var azureClient = new MockAzureClient();
-            var targetMagic = new TargetMagic(azureClient);
+            var targetMagic = new TargetMagic(azureClient, new UnitTestLogger<TargetMagic>());
             targetMagic.Test(targetId);
             Assert.AreEqual(AzureClientAction.SetActiveTarget, azureClient.LastAction);
 
             // single argument with quotes - should set active target
-            targetMagic = new TargetMagic(azureClient);
+            targetMagic = new TargetMagic(azureClient, new UnitTestLogger<TargetMagic>());
             targetMagic.Test($"\"{targetId}\"");
             Assert.AreEqual(AzureClientAction.SetActiveTarget, azureClient.LastAction);
 
             // no arguments - should print active target
             azureClient = new MockAzureClient();
-            targetMagic = new TargetMagic(azureClient);
+            targetMagic = new TargetMagic(azureClient, new UnitTestLogger<TargetMagic>());
             targetMagic.Test(string.Empty);
             Assert.AreEqual(AzureClientAction.GetActiveTarget, azureClient.LastAction);
         }

--- a/src/Tests/AzureClientTests.cs
+++ b/src/Tests/AzureClientTests.cs
@@ -14,6 +14,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Jupyter.Core;
 using Microsoft.Quantum.IQSharp;
 using Microsoft.Quantum.IQSharp.AzureClient;
+using Microsoft.Quantum.IQSharp.Jupyter;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Tests.IQSharp
@@ -244,7 +245,7 @@ namespace Tests.IQSharp
             ExpectError(AzureClientError.JobSubmissionFailed, azureClient.SubmitJobAsync(new MockChannel(), submissionContext, CancellationToken.None));
 
             // specify input parameters and verify that the job was submitted
-            submissionContext.InputParameters = new Dictionary<string, string>() { ["count"] = "3", ["name"] = "testing" };
+            submissionContext.InputParameters = AbstractMagic.ParseInputParameters("count=3 name=\"testing\"");
             var job = ExpectSuccess<CloudJob>(azureClient.SubmitJobAsync(new MockChannel(), submissionContext, CancellationToken.None));
             var retrievedJob = ExpectSuccess<CloudJob>(azureClient.GetJobStatusAsync(new MockChannel(), job.Id));
             Assert.AreEqual(job.Id, retrievedJob.Id);
@@ -273,7 +274,38 @@ namespace Tests.IQSharp
             var submissionContext = new AzureSubmissionContext()
             {
                 OperationName = "Tests.qss.HelloAgain",
-                InputParameters = new Dictionary<string, string>() { ["count"] = "3", ["name"] = "testing" },
+                InputParameters = AbstractMagic.ParseInputParameters("count=3 name=\"testing\""),
+                ExecutionTimeout = 5,
+                ExecutionPollingInterval = 1,
+            };
+            var histogram = ExpectSuccess<Histogram>(azureClient.ExecuteJobAsync(new MockChannel(), submissionContext, CancellationToken.None));
+            Assert.IsNotNull(histogram);
+        }
+
+        [TestMethod]
+        public void TestJobExecutionWithArrayInput()
+        {
+            var services = Startup.CreateServiceProvider("Workspace");
+            var azureClient = (AzureClient)services.GetService<IAzureClient>();
+
+            // connect
+            var targets = ExpectSuccess<IEnumerable<TargetStatus>>(ConnectToWorkspaceAsync(azureClient));
+            Assert.IsFalse(targets.Any());
+
+            // add a target
+            var azureWorkspace = azureClient.ActiveWorkspace as MockAzureWorkspace;
+            Assert.IsNotNull(azureWorkspace);
+            MockAzureWorkspace.MockTargetIds = new string[] { "ionq.simulator" };
+
+            // set the active target
+            var target = ExpectSuccess<TargetStatus>(azureClient.SetActiveTargetAsync(new MockChannel(), "ionq.simulator"));
+            Assert.AreEqual("ionq.simulator", target.Id);
+
+            // execute the job and verify that the results are retrieved successfully
+            var submissionContext = new AzureSubmissionContext()
+            {
+                OperationName = "Tests.qss.SayHelloWithArray",
+                InputParameters = AbstractMagic.ParseInputParameters("{\"names\": [\"foo\", \"bar\"]}"),
                 ExecutionTimeout = 5,
                 ExecutionPollingInterval = 1,
             };

--- a/src/Tests/IQsharpEngineTests.cs
+++ b/src/Tests/IQsharpEngineTests.cs
@@ -470,7 +470,7 @@ namespace Tests.IQSharp
             var result = response.Output as string[];
             PrintResult(response, channel);
             Assert.AreEqual(ExecuteStatus.Ok, response.Status);
-            Assert.AreEqual(5, result?.Length);
+            Assert.AreEqual(6, result?.Length);
             Assert.AreEqual("HelloQ", result?[0]);
             Assert.AreEqual("Tests.qss.NoOp", result?[4]);
         }

--- a/src/Tests/IQsharpEngineTests.cs
+++ b/src/Tests/IQsharpEngineTests.cs
@@ -75,7 +75,8 @@ namespace Tests.IQSharp
             await engine.Initialized;
             var configSource = new ConfigurationSource(skipLoading: true);
 
-            var simMagic = new SimulateMagic(engine.SymbolsResolver!, configSource);
+            var simMagic = new SimulateMagic(engine.SymbolsResolver!, configSource,
+                new UnitTestLogger<SimulateMagic>());
             var channel = new MockChannel();
             var response = await simMagic.Execute(snippetName, channel);
             PrintResult(response, channel);
@@ -91,7 +92,7 @@ namespace Tests.IQSharp
             Assert.IsNotNull(engine.SymbolsResolver);
 
             var channel = new MockChannel();
-            var estimateMagic = new EstimateMagic(engine.SymbolsResolver!);
+            var estimateMagic = new EstimateMagic(engine.SymbolsResolver!, new UnitTestLogger<EstimateMagic>());
             var response = await estimateMagic.Execute(snippetName, channel);
             var result = response.Output as DataTable;
             PrintResult(response, channel);
@@ -114,9 +115,9 @@ namespace Tests.IQSharp
             Assert.IsNotNull(engine.SymbolsResolver);
             var configSource = new ConfigurationSource(skipLoading: true);
 
-            var wsMagic = new WorkspaceMagic(snippets!.Workspace);
-            var pkgMagic = new PackageMagic(snippets.GlobalReferences);
-            var traceMagic = new TraceMagic(engine.SymbolsResolver!, configSource);
+            var wsMagic = new WorkspaceMagic(snippets!.Workspace, new UnitTestLogger<WorkspaceMagic>());
+            var pkgMagic = new PackageMagic(snippets.GlobalReferences, new UnitTestLogger<PackageMagic>());
+            var traceMagic = new TraceMagic(engine.SymbolsResolver!, configSource, new UnitTestLogger<TraceMagic>());
 
             var channel = new MockChannel();
 
@@ -161,7 +162,7 @@ namespace Tests.IQSharp
             var engine = await Init();
             Assert.IsNotNull(engine.SymbolsResolver);
             var configSource = new ConfigurationSource(skipLoading: true);
-            var simMagic = new SimulateMagic(engine.SymbolsResolver!, configSource);
+            var simMagic = new SimulateMagic(engine.SymbolsResolver!, configSource, new UnitTestLogger<SimulateMagic>());
             var channel = new MockChannel();
 
             // Try running without compiling it, fails:
@@ -255,7 +256,7 @@ namespace Tests.IQSharp
             await AssertCompile(engine, SNIPPETS.HelloQ, "HelloQ");
 
             // Run with toffoli simulator:
-            var toffoliMagic = new ToffoliMagic(engine.SymbolsResolver!);
+            var toffoliMagic = new ToffoliMagic(engine.SymbolsResolver!, new UnitTestLogger<ToffoliMagic>());
             var response = await toffoliMagic.Execute("HelloQ", channel);
             var result = response.Output as Dictionary<string, double>;
             PrintResult(response, channel);
@@ -391,7 +392,7 @@ namespace Tests.IQSharp
             var snippets = engine.Snippets as Snippets;
             Assert.IsNotNull(snippets);
 
-            var pkgMagic = new PackageMagic(snippets!.GlobalReferences);
+            var pkgMagic = new PackageMagic(snippets!.GlobalReferences, new UnitTestLogger<PackageMagic>());
             var references = ((References)pkgMagic.References);
             var packageCount = references.AutoLoadPackages.Count;
             var channel = new MockChannel();
@@ -428,7 +429,7 @@ namespace Tests.IQSharp
             var engine = await Init();
             var snippets = engine.Snippets as Snippets;
             Assert.IsNotNull(snippets);
-            var pkgMagic = new PackageMagic(snippets!.GlobalReferences);
+            var pkgMagic = new PackageMagic(snippets!.GlobalReferences, new UnitTestLogger<PackageMagic>());
             var channel = new MockChannel();
 
             var response = await pkgMagic.Execute("microsoft.invalid.quantum", channel);
@@ -446,7 +447,7 @@ namespace Tests.IQSharp
             var engine = await Init();
             var snippets = engine.Snippets as Snippets;
             Assert.IsNotNull(snippets);
-            var projectMagic = new ProjectMagic(snippets!.Workspace);
+            var projectMagic = new ProjectMagic(snippets!.Workspace, new UnitTestLogger<ProjectMagic>());
             var channel = new MockChannel();
 
             var response = await projectMagic.Execute("../Workspace.ProjectReferences/Workspace.ProjectReferences.csproj", channel);
@@ -462,7 +463,7 @@ namespace Tests.IQSharp
             await snippets.Workspace.Initialization;
             snippets.Compile(SNIPPETS.HelloQ);
 
-            var whoMagic = new WhoMagic(snippets);
+            var whoMagic = new WhoMagic(snippets, new UnitTestLogger<WhoMagic>());
             var channel = new MockChannel();
 
             // Check the workspace, it should be in error state:
@@ -482,8 +483,8 @@ namespace Tests.IQSharp
             var snippets = engine.Snippets as Snippets;
             Assert.IsNotNull(snippets);
 
-            var wsMagic = new WorkspaceMagic(snippets!.Workspace);
-            var pkgMagic = new PackageMagic(snippets!.GlobalReferences);
+            var wsMagic = new WorkspaceMagic(snippets!.Workspace, new UnitTestLogger<WorkspaceMagic>());
+            var pkgMagic = new PackageMagic(snippets!.GlobalReferences, new UnitTestLogger<PackageMagic>());
 
             var channel = new MockChannel();
             var result = new string[0];

--- a/src/Tests/Logging.cs
+++ b/src/Tests/Logging.cs
@@ -1,0 +1,118 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#nullable enable
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Jupyter.Core;
+using Microsoft.Quantum.IQSharp;
+using Microsoft.Quantum.IQSharp.AzureClient;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using Microsoft.Extensions.Logging;
+
+using static Microsoft.VisualStudio.TestTools.UnitTesting.Logging.Logger;
+using System.Collections.Concurrent;
+
+namespace Tests.IQSharp
+{
+
+    public class UnitTestLoggerConfiguration
+    {
+        public int? EventIdFilter { get; set; } = null;
+        public LogLevel LogLevel { get; set; } = LogLevel.Information;
+    }
+
+    internal class ActionDisposer : IDisposable
+    {
+        private readonly Action OnDispose;
+        public ActionDisposer(Action onDispose)
+        {
+            this.OnDispose = onDispose;
+        }
+
+        public void Dispose() =>
+            OnDispose();
+    }
+
+    /// <summary>
+    ///      Forwards ASP.NET Core logging information to the unit testing
+    ///      harness.
+    /// </summary>
+    public class UnitTestLogger : ILogger
+    {
+        private UnitTestLoggerConfiguration Config;
+        private string CategoryName;
+        private string? CurrentScope = null;
+        public UnitTestLogger(string categoryName, UnitTestLoggerConfiguration? config = default)
+        {
+            this.CategoryName = categoryName;
+            this.Config = config ?? new UnitTestLoggerConfiguration();
+        }
+
+        public IDisposable BeginScope<TState>(TState state)
+        {
+            var oldScope = CurrentScope;
+            CurrentScope = state?.ToString();
+            return new ActionDisposer(() => CurrentScope = oldScope);
+        }
+
+        public bool IsEnabled(LogLevel logLevel) =>
+            logLevel == Config.LogLevel;
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+        {
+            if (!IsEnabled(logLevel))
+            {
+                return;
+            }
+
+            if (Config.EventIdFilter == null || Config.EventIdFilter == eventId)
+            {
+                if (CurrentScope != null)
+                {
+                    LogMessage(
+                        $"[{CurrentScope} | {eventId}: {logLevel} // {CategoryName}] {formatter(state, exception)}"
+                    );
+                }
+                else
+                {
+                    LogMessage(
+                        $"[{eventId}: {logLevel} // {CategoryName}] {formatter(state, exception)}"
+                    );
+                }
+            }
+        }
+
+    }
+
+    public class UnitTestLogger<T> : UnitTestLogger, ILogger<T>
+    {
+        public UnitTestLogger(string? categoryName = null, UnitTestLoggerConfiguration? config = null)
+        : base(categoryName ?? typeof(T).Name, config)
+        {
+        }
+    }
+
+    public sealed class UnitTestLoggerProvider : ILoggerProvider
+    {
+        private readonly UnitTestLoggerConfiguration Config;
+        private readonly ConcurrentDictionary<string, UnitTestLogger> Loggers =
+            new ConcurrentDictionary<string, UnitTestLogger>();
+
+        public UnitTestLoggerProvider(UnitTestLoggerConfiguration config)
+        {
+            this.Config = config;
+        }
+
+        public ILogger CreateLogger(string categoryName) =>
+            Loggers.GetOrAdd(categoryName, name => new UnitTestLogger(name, Config));
+
+        public void Dispose() => Loggers.Clear();
+    }
+
+}

--- a/src/Tests/Startup.cs
+++ b/src/Tests/Startup.cs
@@ -6,6 +6,7 @@ using System.IO;
 
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.Jupyter.Core;
 using Microsoft.Quantum.IQSharp;
@@ -31,7 +32,17 @@ namespace Tests.IQSharp
             services.Configure<Workspace.Settings>(config);
             services.Configure<NugetPackages.Settings>(config);
 
-            services.AddLogging();
+            services.AddLogging(builder =>
+            {
+                builder.AddProvider(
+                    new UnitTestLoggerProvider(
+                        new UnitTestLoggerConfiguration
+                        {
+                            LogLevel = LogLevel.Information
+                        }
+                    )
+                );
+            });
             services.AddTelemetry();
             services.AddIQSharp();
             services.AddIQSharpKernel();

--- a/src/Tests/Workspace.ProjectReferences.ProjectA/ProjectA.csproj
+++ b/src/Tests/Workspace.ProjectReferences.ProjectA/ProjectA.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Quantum.Sdk/0.14.2011120240">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.15.2101125897">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>

--- a/src/Tests/Workspace.ProjectReferences.ProjectB/ProjectB.csproj
+++ b/src/Tests/Workspace.ProjectReferences.ProjectB/ProjectB.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Quantum.Sdk/0.14.2011120240">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.15.2101125897">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>

--- a/src/Tests/Workspace.ProjectReferences/Workspace.ProjectReferences.csproj
+++ b/src/Tests/Workspace.ProjectReferences/Workspace.ProjectReferences.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Quantum.Sdk/0.14.2011120240">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.15.2101125897">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.14.2011120240" />
+    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.15.2101125897" />
   </ItemGroup>
     
   <ItemGroup>

--- a/src/Tests/Workspace/BasicOps.qs
+++ b/src/Tests/Workspace/BasicOps.qs
@@ -17,9 +17,9 @@ namespace Tests.qss {
         Message($"Hello from quantum world!"); 
     }
 
-    /// # Summary: 
-    ///     A more sophisticated program that shows how to 
-    ///     specify parameters, instantiate qubits, and return values.
+    /// # Summary:
+    /// A more sophisticated program that shows how to 
+    /// specify parameters, instantiate qubits, and return values.
     @EntryPoint()
     operation HelloAgain(count: Int, name: String) : Result[]
     {
@@ -35,6 +35,16 @@ namespace Tests.qss {
         }
 
         return r;
+    }
+
+    /// # Summary:
+    /// A more sophisticated program that shows how to 
+    /// specify parameters, instantiate qubits, and return values.
+    @EntryPoint()
+    operation SayHelloWithArray(names: String[]) : Unit {
+        for name in names {
+            Message($"Hello {name} again!"); 
+        }
     }
     
     operation CCNOTDriver(applyT : Bool) : Unit {


### PR DESCRIPTION
This PR allows for arrays to be sent as arguments to the `%azure.execute` magic command, and to the `qsharp.azure.execute` function by extension. This PR also adds a new test to prevent regression, and updates to QDK 0.15 packages.