### PR TITLE
Fix incorrect construction of magic command azure.quotas

### DIFF
--- a/src/AzureClient/Magic/QuotaMagic.cs
+++ b/src/AzureClient/Magic/QuotaMagic.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
         public QuotaMagic(IAzureClient azureClient)
             : base(
                 azureClient,
-                "azure.jobs",
+                "azure.quotas",
                 new Microsoft.Jupyter.Core.Documentation
                 {
                     Summary = "Displays a list of quotas for the current Azure Quantum workspace.",


### PR DESCRIPTION
Quotas command was constructed using an incorrect name.

Updating to the intended name.