### PR TITLE
fixing a bug in json noise model import

### DIFF
--- a/src/Python/qsharp-core/qsharp/clients/iqsharp.py
+++ b/src/Python/qsharp-core/qsharp/clients/iqsharp.py
@@ -205,7 +205,7 @@ class IQSharpClient(object):
     def _get_noise_model(self) -> str:
         return self._execute('%experimental.noise_model')
 
-    def _set_noise_model(self, op, json_data : str) -> None:
+    def _set_noise_model(self, json_data : str) -> None:
         # We assume json_data is already serialized, so that we skip the support
         # provided by _execute_magic and call directly.
         return self._execute(f'%experimental.noise_model {json_data}')

--- a/src/Python/qsharp-core/qsharp/experimental.py
+++ b/src/Python/qsharp-core/qsharp/experimental.py
@@ -22,6 +22,7 @@
 
 import qsharp
 from qsharp.loader import QSharpCallable
+import json
 
 ## EXPORTS ##
 


### PR DESCRIPTION
I ran into a bug when trying to import a noise model from QuTiP where it was basically just missing an import of the `json` package. This seemed to fix it on my system!