### PR TITLE
Handle nullability of diagnostic severities.

### DIFF
--- a/src/Core/Loggers/QsharpLogger.cs
+++ b/src/Core/Loggers/QsharpLogger.cs
@@ -25,6 +25,8 @@ namespace Microsoft.Quantum.IQSharp.Common
         public List<QsCompiler.Diagnostics.ErrorCode> ErrorCodesToIgnore { get; } = new List<QsCompiler.Diagnostics.ErrorCode>();
         public List<QsCompiler.Diagnostics.WarningCode> WarningCodesToIgnore { get; } = new List<QsCompiler.Diagnostics.WarningCode>();
 
+        private static readonly LSP.Range EmptyRange = new LSP.Range { Start = new LSP.Position(0, 0), End = new LSP.Position(0, 0) };
+
         public QSharpLogger(ILogger logger, int lineNrOffset = 0) :
             base(lineNrOffset : lineNrOffset)
         {
@@ -90,7 +92,8 @@ namespace Microsoft.Quantum.IQSharp.Common
             Log(new LSP.Diagnostic
             {
                 Severity = LSP.DiagnosticSeverity.Information,
-                Message = message
+                Message = message,
+                Range = EmptyRange
             });
         }
 
@@ -99,7 +102,8 @@ namespace Microsoft.Quantum.IQSharp.Common
             Log(new LSP.Diagnostic
             {
                 Severity = LSP.DiagnosticSeverity.Hint,
-                Message = message
+                Message = message,
+                Range = EmptyRange
             });
         }
 
@@ -109,7 +113,8 @@ namespace Microsoft.Quantum.IQSharp.Common
             {
                 Code = code,
                 Severity = LSP.DiagnosticSeverity.Warning,
-                Message = message
+                Message = message,
+                Range = EmptyRange
             });
         }
 
@@ -119,7 +124,8 @@ namespace Microsoft.Quantum.IQSharp.Common
             {
                 Code = code,
                 Severity = LSP.DiagnosticSeverity.Error,
-                Message = message
+                Message = message,
+                Range = EmptyRange
             });
         }
 

--- a/src/Core/Loggers/QsharpLogger.cs
+++ b/src/Core/Loggers/QsharpLogger.cs
@@ -25,8 +25,6 @@ namespace Microsoft.Quantum.IQSharp.Common
         public List<QsCompiler.Diagnostics.ErrorCode> ErrorCodesToIgnore { get; } = new List<QsCompiler.Diagnostics.ErrorCode>();
         public List<QsCompiler.Diagnostics.WarningCode> WarningCodesToIgnore { get; } = new List<QsCompiler.Diagnostics.WarningCode>();
 
-        private static readonly LSP.Range EmptyRange = new LSP.Range { Start = new LSP.Position(0, 0), End = new LSP.Position(0, 0) };
-
         public QSharpLogger(ILogger logger, int lineNrOffset = 0) :
             base(lineNrOffset : lineNrOffset)
         {
@@ -92,8 +90,7 @@ namespace Microsoft.Quantum.IQSharp.Common
             Log(new LSP.Diagnostic
             {
                 Severity = LSP.DiagnosticSeverity.Information,
-                Message = message,
-                Range = EmptyRange
+                Message = message
             });
         }
 
@@ -102,8 +99,7 @@ namespace Microsoft.Quantum.IQSharp.Common
             Log(new LSP.Diagnostic
             {
                 Severity = LSP.DiagnosticSeverity.Hint,
-                Message = message,
-                Range = EmptyRange
+                Message = message
             });
         }
 
@@ -113,8 +109,7 @@ namespace Microsoft.Quantum.IQSharp.Common
             {
                 Code = code,
                 Severity = LSP.DiagnosticSeverity.Warning,
-                Message = message,
-                Range = EmptyRange
+                Message = message
             });
         }
 
@@ -124,8 +119,7 @@ namespace Microsoft.Quantum.IQSharp.Common
             {
                 Code = code,
                 Severity = LSP.DiagnosticSeverity.Error,
-                Message = message,
-                Range = EmptyRange
+                Message = message
             });
         }
 

--- a/src/Core/Loggers/QsharpLogger.cs
+++ b/src/Core/Loggers/QsharpLogger.cs
@@ -32,22 +32,24 @@ namespace Microsoft.Quantum.IQSharp.Common
             this.Logs = new List<LSP.Diagnostic>();
         }
 
-        public static LogLevel MapLevel(LSP.DiagnosticSeverity original)
-        {
-            switch (original)
+        // NB: We define both a method which takes a
+        //     Nullable<DiagnosticSeverity> and a plain DiagnosticSeverity
+        //     value directly, as different versions of the LSP client API
+        //     vary in their handling of nullablity of diagnostic severity.
+        //     This allows IQ# to build with both different versions.
+        //     At some point, the non-nullable overload should be removed.
+        public static LogLevel MapLevel(LSP.DiagnosticSeverity? original) =>
+            original switch
             {
-                case LSP.DiagnosticSeverity.Error:
-                    return LogLevel.Error;
-                case LSP.DiagnosticSeverity.Warning:
-                    return LogLevel.Warning;
-                case LSP.DiagnosticSeverity.Information:
-                    return LogLevel.Information;
-                case LSP.DiagnosticSeverity.Hint:
-                    return LogLevel.Debug;
-                default:
-                    return LogLevel.Trace;
-            }
-        }
+                LSP.DiagnosticSeverity.Error => LogLevel.Error,
+                LSP.DiagnosticSeverity.Warning => LogLevel.Warning,
+                LSP.DiagnosticSeverity.Information => LogLevel.Information,
+                LSP.DiagnosticSeverity.Hint => LogLevel.Debug,
+                _ => LogLevel.Trace
+            };
+
+        public static LogLevel MapLevel(LSP.DiagnosticSeverity original) =>
+            MapLevel((LSP.DiagnosticSeverity?)original);
 
         public bool HasErrors =>
             Logs


### PR DESCRIPTION
This PR adds a new method overload to QSharpLogger that allows `MapLevel` to accept either diagnostic severities or nullable diagnostic severities. This is required due to changes in the language server protocol client API, as in the new version of that API, diagnostic severities are allowed to be absent (represented by `null`). As a result, this change is required by https://github.com/microsoft/qsharp-compiler/pull/886, and in turn by https://github.com/microsoft/qsharp-compiler/issues/885.