### PR TITLE
Allow fluent chaining when calling AddIQSharp methods.

### DIFF
--- a/src/Core/Extensions/ServiceCollection.cs
+++ b/src/Core/Extensions/ServiceCollection.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 using Microsoft.Extensions.DependencyInjection;
@@ -10,7 +10,8 @@ namespace Microsoft.Quantum.IQSharp
     /// </summary>
     public static partial class Extensions
     {
-        public static void AddIQSharp(this IServiceCollection services)
+        public static T AddIQSharp<T>(this T services)
+        where T: IServiceCollection
         {
             services.AddSingleton<IEventService, EventService>();
             services.AddSingleton<ICompilerService, CompilerService>();
@@ -21,6 +22,8 @@ namespace Microsoft.Quantum.IQSharp
             services.AddSingleton<ISnippets, Snippets>();
             services.AddSingleton<PerformanceMonitor>();
             services.AddSingleton<IMetadataController, MetadataController>();
+
+            return services;
         }
     }
 }

--- a/src/Kernel/Extensions.cs
+++ b/src/Kernel/Extensions.cs
@@ -27,12 +27,15 @@ namespace Microsoft.Quantum.IQSharp.Kernel
         ///     Adds services required for the IQ# kernel to a given service
         ///     collection.
         /// </summary>
-        public static void AddIQSharpKernel(this IServiceCollection services)
+        public static T AddIQSharpKernel<T>(this T services)
+        where T: IServiceCollection
         {
             services.AddSingleton<ISymbolResolver, Kernel.SymbolResolver>();
             services.AddSingleton<IMagicSymbolResolver, Kernel.MagicSymbolResolver>();
             services.AddSingleton<IExecutionEngine, Kernel.IQSharpEngine>();
             services.AddSingleton<IConfigurationSource, ConfigurationSource>();
+
+            return services;
         }
 
         internal static void RenderExecutionPath(this ExecutionPathTracer.ExecutionPathTracer tracer,


### PR DESCRIPTION
This PR makes a minor change in the extension methodes used to start up IQ#, allowing these methods to be used in a fluent style.