### PR TITLE
Update S.T.Json dependency to 5.0.1.

### DIFF
--- a/src/Tool/Tool.csproj
+++ b/src/Tool/Tool.csproj
@@ -53,6 +53,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.0.0" />
     <PackageReference Include="Microsoft.NETCore.Portable.Compatibility" Version="1.0.1" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
+    <PackageReference Include="System.Text.Json" Version="5.0.1" />
     <PackageReference Include="Serilog.Extensions.Logging.File" Version="2.0.0-dev-00039" />
   </ItemGroup>
 


### PR DESCRIPTION
This PR explicitly adds a dependency from the Microsoft.Quantum.IQSharp tool package to System.Text.Json 5.0.1, making sure that the version of this dependency is up to date, even if packages added at runtime via `%package` depend on System.Text.Json. This fixes a problem observed where assemblies may not be found correctly if `%package` dependencies themselves depend on System.Text.Json. See https://stackoverflow.com/questions/67411006/python-calling-q-file-on-ionq-qpu-results-in-error-about-a-system-text-json-ve for an example of such an error.