### PR TITLE
Update to 0.16.2105140472.

### DIFF
--- a/src/Core/Core.csproj
+++ b/src/Core/Core.csproj
@@ -38,10 +38,10 @@
     <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="3.0.0" />
-    <PackageReference Include="Microsoft.Quantum.Compiler" Version="0.16.2105140327-beta" />
-    <PackageReference Include="Microsoft.Quantum.CsharpGeneration" Version="0.16.2105140327-beta" />
-    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.16.2105140327-beta" />
-    <PackageReference Include="Microsoft.Quantum.QSharp.Core" Version="0.16.2105140327-beta" />
+    <PackageReference Include="Microsoft.Quantum.Compiler" Version="0.16.2105140472" />
+    <PackageReference Include="Microsoft.Quantum.CsharpGeneration" Version="0.16.2105140472" />
+    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.16.2105140472" />
+    <PackageReference Include="Microsoft.Quantum.QSharp.Core" Version="0.16.2105140472" />
     <PackageReference Include="NuGet.Resolver" Version="5.1.0" />
     <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
   </ItemGroup>

--- a/src/Core/Core.csproj
+++ b/src/Core/Core.csproj
@@ -39,7 +39,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="3.0.0" />
     <PackageReference Include="Microsoft.Quantum.Compiler" Version="0.16.2105140472" />
-    <PackageReference Include="Microsoft.Quantum.CsharpGeneration" Version="0.16.2105140472" />
+    <PackageReference Include="Microsoft.Quantum.CSharpGeneration" Version="0.16.2105140472" />
     <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.16.2105140472" />
     <PackageReference Include="Microsoft.Quantum.QSharp.Core" Version="0.16.2105140472" />
     <PackageReference Include="NuGet.Resolver" Version="5.1.0" />

--- a/src/ExecutionPathTracer/ExecutionPathTracer.csproj
+++ b/src/ExecutionPathTracer/ExecutionPathTracer.csproj
@@ -32,7 +32,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.16.2105140327-beta" />
+    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.16.2105140472" />
   </ItemGroup>
 
 </Project>

--- a/src/MockLibraries/Mock.Chemistry/Mock.Chemistry.csproj
+++ b/src/MockLibraries/Mock.Chemistry/Mock.Chemistry.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.16.2105140327-beta">
+<Project Sdk="Microsoft.Quantum.Sdk/0.16.2105140472">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
@@ -6,6 +6,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.16.2105140327-beta" />
+    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.16.2105140472" />
   </ItemGroup>
 </Project>

--- a/src/MockLibraries/Mock.Standard/Mock.Standard.csproj
+++ b/src/MockLibraries/Mock.Standard/Mock.Standard.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.16.2105140327-beta">
+<Project Sdk="Microsoft.Quantum.Sdk/0.16.2105140472">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
@@ -6,6 +6,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.16.2105140327-beta" />
+    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.16.2105140472" />
   </ItemGroup>
 </Project>

--- a/src/Tests/Workspace.ProjectReferences.ProjectA/ProjectA.csproj
+++ b/src/Tests/Workspace.ProjectReferences.ProjectA/ProjectA.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.16.2105140327-beta">
+<Project Sdk="Microsoft.Quantum.Sdk/0.16.2105140472">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>

--- a/src/Tests/Workspace.ProjectReferences.ProjectB/ProjectB.csproj
+++ b/src/Tests/Workspace.ProjectReferences.ProjectB/ProjectB.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.16.2105140327-beta">
+<Project Sdk="Microsoft.Quantum.Sdk/0.16.2105140472">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>

--- a/src/Tests/Workspace.ProjectReferences/Workspace.ProjectReferences.csproj
+++ b/src/Tests/Workspace.ProjectReferences/Workspace.ProjectReferences.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.16.2105140327-beta">
+<Project Sdk="Microsoft.Quantum.Sdk/0.16.2105140472">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.16.2105140327-beta" />
+    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.16.2105140472" />
   </ItemGroup>
     
   <ItemGroup>

--- a/src/Tool/appsettings.json
+++ b/src/Tool/appsettings.json
@@ -6,26 +6,26 @@
     },
     "AllowedHosts": "*",
   "DefaultPackageVersions": [
-    "Microsoft.Quantum.Compiler::0.16.2105140327-beta",
+    "Microsoft.Quantum.Compiler::0.16.2105140472",
 
-    "Microsoft.Quantum.CsharpGeneration::0.16.2105140327-beta",
-    "Microsoft.Quantum.Development.Kit::0.16.2105140327-beta",
-    "Microsoft.Quantum.Simulators::0.16.2105140327-beta",
-    "Microsoft.Quantum.Xunit::0.16.2105140327-beta",
+    "Microsoft.Quantum.CsharpGeneration::0.16.2105140472",
+    "Microsoft.Quantum.Development.Kit::0.16.2105140472",
+    "Microsoft.Quantum.Simulators::0.16.2105140472",
+    "Microsoft.Quantum.Xunit::0.16.2105140472",
 
-    "Microsoft.Quantum.Standard::0.16.2105140327-beta",
-    "Microsoft.Quantum.Standard.Visualization::0.16.2105140327-beta",
-    "Microsoft.Quantum.Chemistry::0.16.2105140327-beta",
-    "Microsoft.Quantum.Chemistry.Jupyter::0.16.2105140327-beta",
-    "Microsoft.Quantum.MachineLearning::0.16.2105140327-beta",
-    "Microsoft.Quantum.Numerics::0.16.2105140327-beta",
+    "Microsoft.Quantum.Standard::0.16.2105140472",
+    "Microsoft.Quantum.Standard.Visualization::0.16.2105140472",
+    "Microsoft.Quantum.Chemistry::0.16.2105140472",
+    "Microsoft.Quantum.Chemistry.Jupyter::0.16.2105140472",
+    "Microsoft.Quantum.MachineLearning::0.16.2105140472",
+    "Microsoft.Quantum.Numerics::0.16.2105140472",
 
-    "Microsoft.Quantum.Katas::0.16.2105140327-beta",
+    "Microsoft.Quantum.Katas::0.16.2105140472",
 
-    "Microsoft.Quantum.Research::0.16.2105140327-beta",
+    "Microsoft.Quantum.Research::0.16.2105140472",
 
-    "Microsoft.Quantum.Providers.IonQ::0.16.2105140327-beta",
-    "Microsoft.Quantum.Providers.Honeywell::0.16.2105140327-beta",
-    "Microsoft.Quantum.Providers.QCI::0.16.2105140327-beta"
+    "Microsoft.Quantum.Providers.IonQ::0.16.2105140472",
+    "Microsoft.Quantum.Providers.Honeywell::0.16.2105140472",
+    "Microsoft.Quantum.Providers.QCI::0.16.2105140472"
   ]
 }


### PR DESCRIPTION
This PR updates IQ# to use the latest release of the Quantum Development Kit, 0.16.2105140472. Please see https://github.com/microsoft/qsharp-runtime/issues/680 for details.