### PR TITLE
Expose trace as a command of a Q# operation

### DIFF
--- a/src/Python/qsharp-core/qsharp/clients/iqsharp.py
+++ b/src/Python/qsharp-core/qsharp/clients/iqsharp.py
@@ -178,6 +178,9 @@ class IQSharpClient(object):
             counts[row["Metric"]] = int(row["Sum"])
         return counts
 
+    def trace(self, op, **kwargs) -> Any:
+        return self._execute_callable_magic('trace', op, _quiet_ = True, **kwargs)
+
     def component_versions(self, **kwargs) -> Dict[str, LooseVersion]:
         """
         Returns a dictionary from components of the IQ# kernel to their
@@ -242,9 +245,11 @@ class IQSharpClient(object):
 
         def log_error(msg):
             errors.append(msg)
-
+        
         handlers = {
-            'execute_result': (lambda msg: results.append(msg))
+            'execute_result': (lambda msg: results.append(msg)),
+            'render_execution_path':  (lambda msg: results.append(msg)),
+            'display_data': lambda msg: ...
         }
         if not _quiet_:
             handlers['display_data'] = (
@@ -279,7 +284,9 @@ class IQSharpClient(object):
         if results:
             assert len(results) == 1
             content = results[0]['content']
-            if 'application/json' in content['data']:
+            if 'executionPath' in content:
+                obj = content['executionPath']
+            elif 'application/json' in content['data']:
                 obj = unmap_tuples(json.loads(content['data']['application/json']))
             else:
                 obj = None

--- a/src/Python/qsharp-core/qsharp/loader.py
+++ b/src/Python/qsharp-core/qsharp/loader.py
@@ -100,6 +100,14 @@ class QSharpCallable(object):
     def estimate_resources(self, **kwargs) -> Dict[str, int]:
         return qsharp.client.estimate(self, **kwargs)
 
+    def trace(self, **kwargs) -> Any:
+        """
+        Returns a structure representing the set of gates and qubits
+        used to execute this operation.
+        """
+        return qsharp.client.trace(self, **kwargs)
+
+
 class QSharpModule(ModuleType):
     _qs_name : str
 

--- a/src/Python/qsharp-core/qsharp/tests/test_iqsharp.py
+++ b/src/Python/qsharp-core/qsharp/tests/test_iqsharp.py
@@ -145,6 +145,22 @@ def test_estimate():
     assert r['BorrowedWidth'] == 0
 
 
+
+def test_trace():
+    """
+    Verifies that resource estimation works.
+    """
+    from Microsoft.Quantum.SanityTests import HelloAgain
+    r = HelloAgain.trace(count=1, name="trace test")
+    print(r)
+    assert len(r['qubits']) == 1
+    assert len(r['operations']) == 1
+    assert len(r['operations'][0]['children']) == 2
+    assert r['operations'][0]['gate'] == 'HelloAgain'
+    assert r['operations'][0]['children'][0]['gate'] == 'M'
+    assert r['operations'][0]['children'][1]['gate'] == 'Reset'
+
+
 def test_simple_compile():
     """
     Verifies that compile works

--- a/src/Python/qsharp-core/qsharp/tests/test_iqsharp.py
+++ b/src/Python/qsharp-core/qsharp/tests/test_iqsharp.py
@@ -148,7 +148,7 @@ def test_estimate():
 
 def test_trace():
     """
-    Verifies that resource estimation works.
+    Verifies the trace commands works.
     """
     from Microsoft.Quantum.SanityTests import HelloAgain
     r = HelloAgain.trace(count=1, name="trace test")


### PR DESCRIPTION
Working on migrating our execution trace visualizer to its own repo so it can be a stand-alone tool.
These changes expose the response of the `%trace` magic as a `trace` method on a Q# operation. This makes it trivial to get the trace output needed by the tool:

```python
import qsharp
from Teleport import TeleportCircuit
result = TeleportCircuit.trace()
print(json.dumps(result))
```

