### PR TITLE
%connect support for credential parameter

### DIFF
--- a/images/iqsharp-base/Dockerfile
+++ b/images/iqsharp-base/Dockerfile
@@ -126,7 +126,7 @@ ENV PATH=$PATH:${HOME}/dotnet:${HOME}/.dotnet/tools \
 # Install IQ# and the project templates, using the NuGet packages from the
 # build context.
 ARG IQSHARP_VERSION
-RUN dotnet new -i "Microsoft.Quantum.ProjectTemplates::0.17.2106145994-alpha" && \
+RUN dotnet new -i "Microsoft.Quantum.ProjectTemplates::0.17.2106146936-beta" && \
     dotnet tool install \
            --global \
            Microsoft.Quantum.IQSharp \

--- a/src/AzureClient/AzureClient.cs
+++ b/src/AzureClient/AzureClient.cs
@@ -95,7 +95,7 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
             Azure.Quantum.Authentication.CredentialType credentialType,
             CancellationToken? cancellationToken = null)
         {
-            var credential = CredentialFactory.CreateCredential(credentialType);
+            var credential = CredentialFactory.CreateCredential(credentialType, subscriptionId);
 
             var connectionResult = await ConnectToWorkspaceAsync(channel, subscriptionId, resourceGroupName, workspaceName, location, credential);
             if (connectionResult.Status != ExecuteStatus.Ok)
@@ -239,7 +239,7 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
                 return AzureClientError.NotConnected.ToExecutionResult();
             }
 
-            if (ActiveTarget == null)
+            if (ActiveTarget?.TargetId == null)
             {
                 channel.Stderr($"Please call {GetCommandDisplayName("target")} before submitting a job.");
                 return AzureClientError.NoTarget.ToExecutionResult();

--- a/src/AzureClient/AzureClient.cs
+++ b/src/AzureClient/AzureClient.cs
@@ -17,6 +17,7 @@ using Microsoft.Azure.Quantum.Authentication;
 using Microsoft.Extensions.Logging;
 using Microsoft.Jupyter.Core;
 using Microsoft.Quantum.IQSharp.Common;
+using Microsoft.Quantum.IQSharp.Jupyter;
 using Microsoft.Quantum.Simulation.Common;
 
 namespace Microsoft.Quantum.IQSharp.AzureClient
@@ -92,45 +93,57 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
             string workspaceName,
             string storageAccountConnectionString,
             string location,
-            Azure.Quantum.Authentication.CredentialType credentialType,
+            CredentialType credentialType,
             CancellationToken? cancellationToken = null)
         {
-            var credential = CredentialFactory.CreateCredential(credentialType, subscriptionId);
 
-            var connectionResult = await ConnectToWorkspaceAsync(channel, subscriptionId, resourceGroupName, workspaceName, location, credential);
-            if (connectionResult.Status != ExecuteStatus.Ok)
+            // Capture the console output, specifically for the case the user is trying to use DeviceCode credentials
+            // so they can get the message for auth.
+            var currentOut = channel?.CaptureConsole();            
+            try
             {
-                return connectionResult;
+                var credential = CredentialFactory.CreateCredential(credentialType, subscriptionId);
+                
+                var connectionResult = await ConnectToWorkspaceAsync(channel, subscriptionId, resourceGroupName, workspaceName, location, credential);
+                if (connectionResult.Status != ExecuteStatus.Ok)
+                {
+                    return connectionResult;
+                }
+
+                if (ActiveWorkspace == null)
+                {
+                    return AzureClientError.WorkspaceNotFound.ToExecutionResult();
+                }
+
+                Credential = credential;
+            }
+            finally
+            {
+                System.Console.SetOut(currentOut);
             }
 
-            if (ActiveWorkspace == null)
-            {
-                return AzureClientError.WorkspaceNotFound.ToExecutionResult();
-            }
-
-            Credential = credential;
 
             StorageConnectionString = storageAccountConnectionString;
             ActiveTarget = null;
             MostRecentJobId = string.Empty;
 
-            channel.Stdout($"Connected to Azure Quantum workspace {ActiveWorkspace.WorkspaceName} in location {ActiveWorkspace.Location}.");
+            channel?.Stdout($"Connected to Azure Quantum workspace {ActiveWorkspace.WorkspaceName} in location {ActiveWorkspace.Location}.");
 
             if (ValidExecutionTargets.Count() == 0)
             {
-                channel.Stderr($"No valid Q# execution targets found in Azure Quantum workspace {ActiveWorkspace.WorkspaceName}.");
+                channel?.Stderr($"No valid Q# execution targets found in Azure Quantum workspace {ActiveWorkspace.WorkspaceName}.");
             }
 
             return ValidExecutionTargets.ToExecutionResult();
         }
 
-        private string GetNormalizedLocation(string location, IChannel channel)
+        private string GetNormalizedLocation(string location, IChannel? channel)
         {
             // Default to "westus" if no location was specified.
             var defaultLocation = "westus";
             if (string.IsNullOrWhiteSpace(location))
             {
-                channel.Stdout($"[WARN]: location parameter is missing. Will try to connect to a workspace in region `{defaultLocation}`.");
+                channel?.Stdout($"[WARN]: location parameter is missing. Will try to connect to a workspace in region `{defaultLocation}`.");
                 location = defaultLocation;
             }
 
@@ -141,18 +154,18 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
             {
                 // If provided location is invalid, "westus" is used.
                 normalizedLocation = defaultLocation;
-                channel.Stdout($"Invalid location {location} specified. Falling back to location {normalizedLocation}.");
+                channel?.Stdout($"Invalid location {location} specified. Falling back to location {normalizedLocation}.");
             }
 
             return normalizedLocation;
         }
 
-        private async Task<ExecutionResult> ConnectToWorkspaceAsync(IChannel channel,
+        private async Task<ExecutionResult> ConnectToWorkspaceAsync(IChannel? channel,
             string subscriptionId,
             string resourceGroupName,
             string workspaceName,
             string location,
-            TokenCredential? credential,
+            TokenCredential credential,
             CancellationToken cancellationToken = default)
         {
             location = GetNormalizedLocation(location, channel);
@@ -184,17 +197,17 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
             }
             catch (Exception e)
             {
-                channel.Stderr($"The Azure Quantum workspace {workspaceName} in location {location} could not be reached. " +
+                channel?.Stderr($"The Azure Quantum workspace {workspaceName} in location {location} could not be reached. " +
                     "Please check the provided parameters and try again.");
-                channel.Stderr($"Error details: {e.Message}");
+                channel?.Stderr($"Error details: {e.Message}");
 
                 return AzureClientError.WorkspaceNotFound.ToExecutionResult();
             }
         }
 
-        private async Task<ExecutionResult> RefreshConnectionAsync(IChannel channel, CancellationToken? cancellationToken = null)
+        private async Task<ExecutionResult> RefreshConnectionAsync(IChannel? channel, CancellationToken? cancellationToken = null)
         {
-            if (ActiveWorkspace == null)
+            if (ActiveWorkspace == null || Credential == null)
             {
                 return AzureClientError.NotConnected.ToExecutionResult();
             }
@@ -209,7 +222,7 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
         }
 
         /// <inheritdoc/>
-        public async Task<ExecutionResult> GetConnectionStatusAsync(IChannel channel, CancellationToken? cancellationToken = default)
+        public async Task<ExecutionResult> GetConnectionStatusAsync(IChannel? channel, CancellationToken? cancellationToken = default)
         {
             if (ActiveWorkspace == null || AvailableProviders == null)
             {
@@ -222,32 +235,32 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
                 return connectionResult;
             }
 
-            channel.Stdout($"Connected to Azure Quantum workspace {ActiveWorkspace.WorkspaceName} in location {ActiveWorkspace.Location}.");
+            channel?.Stdout($"Connected to Azure Quantum workspace {ActiveWorkspace.WorkspaceName} in location {ActiveWorkspace.Location}.");
 
             return ValidExecutionTargets.ToExecutionResult();
         }
 
         private async Task<ExecutionResult> SubmitOrExecuteJobAsync(
-            IChannel channel,
+            IChannel? channel,
             AzureSubmissionContext submissionContext,
             bool execute,
             CancellationToken cancellationToken)
         {
             if (ActiveWorkspace == null)
             {
-                channel.Stderr($"Please call {GetCommandDisplayName("connect")} before submitting a job.");
+                channel?.Stderr($"Please call {GetCommandDisplayName("connect")} before submitting a job.");
                 return AzureClientError.NotConnected.ToExecutionResult();
             }
 
             if (ActiveTarget?.TargetId == null)
             {
-                channel.Stderr($"Please call {GetCommandDisplayName("target")} before submitting a job.");
+                channel?.Stderr($"Please call {GetCommandDisplayName("target")} before submitting a job.");
                 return AzureClientError.NoTarget.ToExecutionResult();
             }
 
             if (string.IsNullOrEmpty(submissionContext.OperationName))
             {
-                channel.Stderr($"Please pass a valid Q# operation name to {GetCommandDisplayName(execute ? "execute" : "submit")}.");
+                channel?.Stderr($"Please pass a valid Q# operation name to {GetCommandDisplayName(execute ? "execute" : "submit")}.");
                 return AzureClientError.NoOperationName.ToExecutionResult();
             }
 
@@ -261,11 +274,11 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
             if (machine == null)
             {
                 // We should never get here, since ActiveTarget should have already been validated at the time it was set.
-                channel.Stderr($"Unexpected error while preparing job for execution on target {ActiveTarget.TargetId}.");
+                channel?.Stderr($"Unexpected error while preparing job for execution on target {ActiveTarget.TargetId}.");
                 return AzureClientError.InvalidTarget.ToExecutionResult();
             }
 
-            channel.Stdout($"Submitting {submissionContext.OperationName} to target {ActiveTarget.TargetId}...");
+            channel?.Stdout($"Submitting {submissionContext.OperationName} to target {ActiveTarget.TargetId}...");
 
             IEntryPoint? entryPoint;
             try
@@ -278,22 +291,22 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
             }
             catch (UnsupportedOperationException)
             {
-                channel.Stderr($"{submissionContext.OperationName} is not a recognized Q# operation name.");
+                channel?.Stderr($"{submissionContext.OperationName} is not a recognized Q# operation name.");
                 return AzureClientError.UnrecognizedOperationName.ToExecutionResult();
             }
             catch (CompilationErrorsException e)
             {
-                channel.Stderr($"The Q# operation {submissionContext.OperationName} could not be compiled as an entry point for job execution.");
-                foreach (var message in e.Errors) channel.Stderr(message);
+                channel?.Stderr($"The Q# operation {submissionContext.OperationName} could not be compiled as an entry point for job execution.");
+                foreach (var message in e.Errors) channel?.Stderr(message);
                 return AzureClientError.InvalidEntryPoint.ToExecutionResult();
             }
 
             try
             {
                 var job = await entryPoint.SubmitAsync(machine, submissionContext);
-                channel.Stdout($"Job successfully submitted for {submissionContext.Shots} shots.");
-                channel.Stdout($"   Job name: {submissionContext.FriendlyName}");
-                channel.Stdout($"   Job ID: {job.Id}");
+                channel?.Stdout($"Job successfully submitted for {submissionContext.Shots} shots.");
+                channel?.Stdout($"   Job name: {submissionContext.FriendlyName}");
+                channel?.Stdout($"   Job ID: {job.Id}");
                 MostRecentJobId = job.Id;
             }
             catch (TaskCanceledException tce)
@@ -302,14 +315,14 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
             }
             catch (ArgumentException e)
             {
-                channel.Stderr($"Failed to parse all expected parameters for Q# operation {submissionContext.OperationName}.");
-                channel.Stderr(e.Message);
+                channel?.Stderr($"Failed to parse all expected parameters for Q# operation {submissionContext.OperationName}.");
+                channel?.Stderr(e.Message);
                 return AzureClientError.JobSubmissionFailed.ToExecutionResult();
             }
             catch (Exception e)
             {
-                channel.Stderr($"Failed to submit Q# operation {submissionContext.OperationName} for execution.");
-                channel.Stderr(e.InnerException?.Message ?? e.Message);
+                channel?.Stderr($"Failed to submit Q# operation {submissionContext.OperationName} for execution.");
+                channel?.Stderr(e.InnerException?.Message ?? e.Message);
                 return AzureClientError.JobSubmissionFailed.ToExecutionResult();
             }
 
@@ -320,7 +333,7 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
             }
 
             // If the command was %azure.execute, wait for the job to complete and return the job output.
-            channel.Stdout($"Waiting up to {submissionContext.ExecutionTimeout} seconds for Azure Quantum job to complete...");
+            channel?.Stdout($"Waiting up to {submissionContext.ExecutionTimeout} seconds for Azure Quantum job to complete...");
 
             using var executionTimeoutTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(submissionContext.ExecutionTimeout));
             using var executionCancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(executionTimeoutTokenSource.Token, cancellationToken);
@@ -333,7 +346,7 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
                         executionCancellationTokenSource.Token.ThrowIfCancellationRequested();
                         await Task.Delay(TimeSpan.FromSeconds(submissionContext.ExecutionPollingInterval), executionCancellationTokenSource.Token);
                         cloudJob = await ActiveWorkspace.GetJobAsync(MostRecentJobId, executionTimeoutTokenSource.Token);
-                        channel.Stdout($"[{DateTime.Now.ToLongTimeString()}] Current job status: {cloudJob?.Status ?? "Unknown"}");
+                        channel?.Stdout($"[{DateTime.Now.ToLongTimeString()}] Current job status: {cloudJob?.Status ?? "Unknown"}");
                     }
                 }
                 catch (Exception e) when (e is TaskCanceledException || e is OperationCanceledException)
@@ -342,8 +355,8 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
                 }
                 catch (Exception e)
                 {
-                    channel.Stderr($"Unexpected error while waiting for the results of the Q# operation.");
-                    channel.Stderr(e.InnerException?.Message ?? e.Message);
+                    channel?.Stderr($"Unexpected error while waiting for the results of the Q# operation.");
+                    channel?.Stderr(e.InnerException?.Message ?? e.Message);
                     return AzureClientError.JobSubmissionFailed.ToExecutionResult();
                 }
             }
@@ -364,14 +377,14 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
         {
             if (AvailableProviders == null)
             {
-                channel.Stderr($"Please call {GetCommandDisplayName("connect")} before getting the execution target.");
+                channel?.Stderr($"Please call {GetCommandDisplayName("connect")} before getting the execution target.");
                 return AzureClientError.NotConnected.ToExecutionResult();
             }
 
             if (ActiveTarget == null)
             {
-                channel.Stderr($"No execution target has been specified. To specify one, call {GetCommandDisplayName("target")} with the target ID.");
-                channel.Stdout($"Available execution targets: {ValidExecutionTargetsDisplayText}");
+                channel?.Stderr($"No execution target has been specified. To specify one, call {GetCommandDisplayName("target")} with the target ID.");
+                channel?.Stdout($"Available execution targets: {ValidExecutionTargetsDisplayText}");
                 return AzureClientError.NoTarget.ToExecutionResult();
             }
 
@@ -381,8 +394,8 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
                 return connectionResult;
             }
 
-            channel.Stdout($"Current execution target: {ActiveTarget.TargetId}");
-            channel.Stdout($"Available execution targets: {ValidExecutionTargetsDisplayText}");
+            channel?.Stdout($"Current execution target: {ActiveTarget.TargetId}");
+            channel?.Stdout($"Available execution targets: {ValidExecutionTargetsDisplayText}");
 
             return AvailableTargets.First(target => target.TargetId == ActiveTarget.TargetId).ToExecutionResult();
         }
@@ -392,7 +405,7 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
         {
             if (ActiveWorkspace == null || AvailableProviders == null)
             {
-                channel.Stderr($"Please call {GetCommandDisplayName("connect")} before setting an execution target.");
+                channel?.Stderr($"Please call {GetCommandDisplayName("connect")} before setting an execution target.");
                 return AzureClientError.NotConnected.ToExecutionResult();
             }
 
@@ -406,8 +419,8 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
             var target = AvailableTargets.FirstOrDefault(t => targetId == t.TargetId);
             if (target == null)
             {
-                channel.Stderr($"Target {targetId} is not available in the current Azure Quantum workspace.");
-                channel.Stdout($"Available execution targets: {ValidExecutionTargetsDisplayText}");
+                channel?.Stderr($"Target {targetId} is not available in the current Azure Quantum workspace.");
+                channel?.Stdout($"Available execution targets: {ValidExecutionTargetsDisplayText}");
                 return AzureClientError.InvalidTarget.ToExecutionResult();
             }
 
@@ -415,18 +428,18 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
             var executionTarget = AzureExecutionTarget.Create(target);
             if (executionTarget == null)
             {
-                channel.Stderr($"Target {targetId} does not support executing Q# jobs.");
-                channel.Stdout($"Available execution targets: {ValidExecutionTargetsDisplayText}");
+                channel?.Stderr($"Target {targetId} does not support executing Q# jobs.");
+                channel?.Stdout($"Available execution targets: {ValidExecutionTargetsDisplayText}");
                 return AzureClientError.InvalidTarget.ToExecutionResult();
             }
 
             // Set the active target and load the package.
             ActiveTarget = executionTarget;
 
-            channel.Stdout($"Loading package {ActiveTarget.PackageName} and dependencies...");
+            channel?.Stdout($"Loading package {ActiveTarget.PackageName} and dependencies...");
             await References.AddPackage(ActiveTarget.PackageName);
 
-            channel.Stdout($"Active target is now {ActiveTarget.TargetId}");
+            channel?.Stdout($"Active target is now {ActiveTarget.TargetId}");
 
             return AvailableTargets.First(target => target.TargetId == ActiveTarget.TargetId).ToExecutionResult();
         }
@@ -436,7 +449,7 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
         {
             if (ActiveWorkspace == null)
             {
-                channel.Stderr($"Please call {GetCommandDisplayName("connect")} before getting job results.");
+                channel?.Stderr($"Please call {GetCommandDisplayName("connect")} before getting job results.");
                 return AzureClientError.NotConnected.ToExecutionResult();
             }
 
@@ -444,7 +457,7 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
             {
                 if (string.IsNullOrEmpty(MostRecentJobId))
                 {
-                    channel.Stderr("No job ID was specified. Please submit a job first or specify a job ID.");
+                    channel?.Stderr("No job ID was specified. Please submit a job first or specify a job ID.");
                     return AzureClientError.JobNotFound.ToExecutionResult();
                 }
 
@@ -460,18 +473,18 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
             var job = await ActiveWorkspace.GetJobAsync(jobId, cancellationToken ?? CancellationToken.None);
             if (job == null)
             {
-                channel.Stderr($"Job ID {jobId} not found in current Azure Quantum workspace.");
+                channel?.Stderr($"Job ID {jobId} not found in current Azure Quantum workspace.");
                 return AzureClientError.JobNotFound.ToExecutionResult();
             }
 
             if (!job.Succeeded || job.OutputDataUri == null)
             {
-                channel.Stderr($"Job ID {jobId} has not completed. To check the status, call {GetCommandDisplayName("status")} with the job ID.");
+                channel?.Stderr($"Job ID {jobId} has not completed. To check the status, call {GetCommandDisplayName("status")} with the job ID.");
                 return AzureClientError.JobNotCompleted.ToExecutionResult();
             }
             else if (job.Failed)
             {
-                channel.Stderr($"Job ID {jobId} failed or was cancelled with the message: {job.Details.ErrorData.Message}");
+                channel?.Stderr($"Job ID {jobId} failed or was cancelled with the message: {job.Details.ErrorData.Message}");
                 return AzureClientError.JobFailedOrCancelled.ToExecutionResult();
             }
 
@@ -483,7 +496,7 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
             }
             catch (Exception e)
             {
-                channel.Stderr($"Failed to retrieve results for job ID {jobId}.");
+                channel?.Stderr($"Failed to retrieve results for job ID {jobId}.");
                 Logger?.LogError(e, $"Failed to download the job output for the specified Azure Quantum job: {e.Message}");
                 return AzureClientError.JobOutputDownloadFailed.ToExecutionResult();
             }
@@ -494,7 +507,7 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
         {
             if (ActiveWorkspace == null)
             {
-                channel.Stderr($"Please call {GetCommandDisplayName("connect")} before getting job status.");
+                channel?.Stderr($"Please call {GetCommandDisplayName("connect")} before getting job status.");
                 return AzureClientError.NotConnected.ToExecutionResult();
             }
 
@@ -502,7 +515,7 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
             {
                 if (string.IsNullOrEmpty(MostRecentJobId))
                 {
-                    channel.Stderr("No job ID was specified. Please submit a job first or specify a job ID.");
+                    channel?.Stderr("No job ID was specified. Please submit a job first or specify a job ID.");
                     return AzureClientError.JobNotFound.ToExecutionResult();
                 }
 
@@ -518,7 +531,7 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
             var job = await ActiveWorkspace.GetJobAsync(jobId);
             if (job == null)
             {
-                channel.Stderr($"Job ID {jobId} not found in current Azure Quantum workspace.");
+                channel?.Stderr($"Job ID {jobId} not found in current Azure Quantum workspace.");
                 return AzureClientError.JobNotFound.ToExecutionResult();
             }
 
@@ -530,7 +543,7 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
         {
             if (ActiveWorkspace == null)
             {
-                channel.Stderr($"Please call {GetCommandDisplayName("connect")} before listing jobs.");
+                channel?.Stderr($"Please call {GetCommandDisplayName("connect")} before listing jobs.");
                 return AzureClientError.NotConnected.ToExecutionResult();
             }
 
@@ -553,11 +566,11 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
             {
                 if (string.IsNullOrEmpty(filter))
                 {
-                    channel.Stderr("No jobs found in current Azure Quantum workspace.");
+                    channel?.Stderr("No jobs found in current Azure Quantum workspace.");
                 }
                 else
                 {
-                    channel.Stderr($"No jobs matching \"{filter}\" found in current Azure Quantum workspace.");
+                    channel?.Stderr($"No jobs matching \"{filter}\" found in current Azure Quantum workspace.");
                 }
             }
 
@@ -569,7 +582,7 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
         {
             if (ActiveWorkspace == null)
             {
-                channel.Stderr($"Please call {GetCommandDisplayName("connect")} before reading quota information.");
+                channel?.Stderr($"Please call {GetCommandDisplayName("connect")} before reading quota information.");
                 return AzureClientError.NotConnected.ToExecutionResult();
             }
 
@@ -587,7 +600,7 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
 
             if (quotas.Count() == 0)
             {
-                channel.Stdout("No quota information found in current Azure Quantum workspace.");
+                channel?.Stdout("No quota information found in current Azure Quantum workspace.");
             }
 
             return quotas.ToExecutionResult();

--- a/src/AzureClient/AzureClient.csproj
+++ b/src/AzureClient/AzureClient.csproj
@@ -13,7 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Quantum.Client" Version="0.17.2106145994-alpha" />
+    <PackageReference Include="Microsoft.Azure.Quantum.Client" Version="0.17.2106146936-beta" />
     <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.21" />
     <PackageReference Include="Microsoft.Rest.ClientRuntime.Azure" Version="3.3.19" />
     <PackageReference Include="System.Reactive" Version="4.3.2" />

--- a/src/AzureClient/AzureExecutionTarget.cs
+++ b/src/AzureClient/AzureExecutionTarget.cs
@@ -34,6 +34,7 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
         /// <summary>
         /// Returns true, if the provider for the given target is a known provider 
         /// capable of running Q# applications.
+        /// </summary>
         public static bool IsValid(TargetStatusInfo target) => GetProvider(target?.TargetId) != null;
 
         /// <summary>

--- a/src/AzureClient/AzureFactory.cs
+++ b/src/AzureClient/AzureFactory.cs
@@ -1,4 +1,9 @@
-﻿using Azure.Core;
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#nullable enable
+
+using Azure.Core;
 
 using Microsoft.Azure.Quantum;
 using Microsoft.Quantum.Runtime;
@@ -18,7 +23,7 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
                     credential: credential);
 
         /// <inheritdoc />
-        public IQuantumMachine CreateMachine(Azure.Quantum.IWorkspace workspace, string targetName, string storageConnectionString) =>
+        public IQuantumMachine? CreateMachine(Azure.Quantum.IWorkspace workspace, string targetName, string storageConnectionString) =>
             QuantumMachineFactory.CreateMachine(workspace, targetName, storageConnectionString);
     }
 }

--- a/src/AzureClient/AzureFactory.cs
+++ b/src/AzureClient/AzureFactory.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.Azure.Quantum;
+﻿using Azure.Core;
+
+using Microsoft.Azure.Quantum;
 using Microsoft.Quantum.Runtime;
 
 namespace Microsoft.Quantum.IQSharp.AzureClient
@@ -7,12 +9,13 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
     public class AzureFactory : IAzureFactory
     {
         /// <inheritdoc />
-        public Azure.Quantum.IWorkspace CreateWorkspace(string subscriptionId, string resourceGroup, string workspaceName, string location) =>
+        public Azure.Quantum.IWorkspace CreateWorkspace(string subscriptionId, string resourceGroup, string workspaceName, string location, TokenCredential credential) =>
              new Azure.Quantum.Workspace(
                     subscriptionId: subscriptionId,
                     resourceGroupName: resourceGroup,
                     workspaceName: workspaceName,
-                    location: location);
+                    location: location,
+                    credential: credential);
 
         /// <inheritdoc />
         public IQuantumMachine CreateMachine(Azure.Quantum.IWorkspace workspace, string targetName, string storageConnectionString) =>

--- a/src/AzureClient/IAzureClient.cs
+++ b/src/AzureClient/IAzureClient.cs
@@ -29,6 +29,7 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
             string workspaceName,
             string storageAccountConnectionString,
             string location,
+            Azure.Quantum.Authentication.CredentialType credentialType,
             CancellationToken? cancellationToken = null);
 
         /// <summary>

--- a/src/AzureClient/IAzureFactory.cs
+++ b/src/AzureClient/IAzureFactory.cs
@@ -1,4 +1,8 @@
-﻿
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#nullable enable
+
 using Azure.Core;
 
 namespace Microsoft.Quantum.IQSharp.AzureClient
@@ -17,6 +21,6 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
         /// <summary>
         /// Creates an instance of an Azure Quantum Machine
         /// </summary>
-        Runtime.IQuantumMachine CreateMachine(Azure.Quantum.IWorkspace workspace, string targetName, string storageConnectionString);
+        Runtime.IQuantumMachine? CreateMachine(Azure.Quantum.IWorkspace workspace, string targetName, string storageConnectionString);
     }
 }

--- a/src/AzureClient/IAzureFactory.cs
+++ b/src/AzureClient/IAzureFactory.cs
@@ -1,6 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿
+using Azure.Core;
 
 namespace Microsoft.Quantum.IQSharp.AzureClient
 {
@@ -13,7 +12,7 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
         /// <summary>
         /// Creates an instance of an Azure Quantum Workspace client
         /// </summary>
-        Azure.Quantum.IWorkspace CreateWorkspace(string subscriptionId, string resourceGroup, string workspaceName, string location);
+        Azure.Quantum.IWorkspace CreateWorkspace(string subscriptionId, string resourceGroup, string workspaceName, string location, TokenCredential credential);
 
         /// <summary>
         /// Creates an instance of an Azure Quantum Machine

--- a/src/AzureClient/Magic/ConnectMagic.cs
+++ b/src/AzureClient/Magic/ConnectMagic.cs
@@ -9,6 +9,8 @@ using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
+
+using Microsoft.Azure.Quantum.Authentication;
 using Microsoft.Extensions.Logging;
 using Microsoft.Jupyter.Core;
 using Microsoft.Quantum.IQSharp.Jupyter;
@@ -27,7 +29,8 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
         private const string ParameterNameWorkspaceName = "workspace";
         private const string ParameterNameResourceId = "resourceId";
         private const string ParameterNameLocation = "location";
-        
+        private const string ParameterNameCredential = "credential";
+
         // A valid resource ID looks like:
         // /subscriptions/f846b2bd-d0e2-4a1d-8141-4c6944a9d387/resourceGroups/RESOURCE_GROUP_NAME/providers/Microsoft.Quantum/Workspaces/WORKSPACE_NAME
         private readonly static Regex ResourceIdRegex = new Regex(
@@ -79,6 +82,28 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
                         - `{ParameterNameLocation}=<string>`: The Azure region where the Azure Quantum workspace is provisioned.
                         This may be specified as a region name such as `""East US""` or a location name such as `""eastus""`.
                         If no valid value is specified, defaults to `""westus""`.
+                        - `{ParameterNameCredential}=<CredentialType>`: The type of credentials to use to authenticate with Azure.
+                        NOTE: to authenticate we leverage the [Azure Identity library](https://docs.microsoft.com/en-us/dotnet/api/overview/azure/identity-readme),
+                        based on this parameter we will create an instance of a Credential Class.
+                        Possible options are:
+                          * [Default](https://docs.microsoft.com/en-us/dotnet/api/azure.identity.defaultazurecredential):
+                             Provides a simplified authentication experience to quickly start developing applications run in the Azure cloud.
+                          * [Environment](https://docs.microsoft.com/en-us/dotnet/api/azure.identity.environmentcredential):
+                             Authenticates a service principal or user via credential information specified in environment variables.
+                          * [ManagedIdentity](https://docs.microsoft.com/en-us/dotnet/api/azure.identity.managedidentitycredential):
+                             Authenticates the managed identity of an azure resource.
+                          * [CLI](https://docs.microsoft.com/en-us/dotnet/api/azure.identity.azureclicredential):
+                             Authenticate in a development environment with the Azure CLI.
+                          * [SharedToken](https://docs.microsoft.com/en-us/dotnet/api/azure.identity.sharedtokencachecredential):
+                             Authenticate using tokens in the local cache shared between Microsoft applications.
+                          * [VisualStudio](https://docs.microsoft.com/en-us/dotnet/api/azure.identity.visualstudiocredential):
+                             Authenticate using data from Visual Studio.
+                          * [VisualStudioCode](https://docs.microsoft.com/en-us/dotnet/api/azure.identity.visualstudiocodecredential):
+                             Authenticate in a development environment with Visual Studio Code.
+                          * [Interactive](https://docs.microsoft.com/en-us/dotnet/api/azure.identity.interactivebrowsercredential):
+                             A TokenCredential implementation which opens a new browser window to interactively authenticate a user,
+                             and obtain an access token.
+                        If not provided, we'll use `Default` credentials.
                         
                         #### Possible errors
 
@@ -197,6 +222,7 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
 
             var storageAccountConnectionString = inputParameters.DecodeParameter<string>(ParameterNameStorageAccountConnectionString, defaultValue: string.Empty);
             var location = inputParameters.DecodeParameter<string>(ParameterNameLocation, defaultValue: string.Empty);
+            var credentialType = inputParameters.DecodeParameter<CredentialType>(ParameterNameCredential, defaultValue: CredentialType.Default);
             return await AzureClient.ConnectAsync(
                 channel,
                 subscriptionId,
@@ -204,6 +230,7 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
                 workspaceName,
                 storageAccountConnectionString,
                 location,
+                credentialType,
                 cancellationToken);
         }
     }

--- a/src/AzureClient/Magic/ConnectMagic.cs
+++ b/src/AzureClient/Magic/ConnectMagic.cs
@@ -83,8 +83,8 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
                         This may be specified as a region name such as `""East US""` or a location name such as `""eastus""`.
                         If no valid value is specified, defaults to `""westus""`.
                         - `{ParameterNameCredential}=<CredentialType>`: The type of credentials to use to authenticate with Azure.
-                        NOTE: to authenticate we leverage the [Azure Identity library](https://docs.microsoft.com/en-us/dotnet/api/overview/azure/identity-readme),
-                        based on this parameter we will create an instance of a Credential Class.
+                        NOTE: to authenticate we leverage the [Azure Identity library](https://docs.microsoft.com/en-us/dotnet/api/overview/azure/identity-readme), 
+                        based on this parameter we will create an instance of a Credential Class. 
                         Possible options are:
                           * [Default](https://docs.microsoft.com/en-us/dotnet/api/azure.identity.defaultazurecredential):
                              Provides a simplified authentication experience to quickly start developing applications run in the Azure cloud.

--- a/src/AzureClient/Mocks/MockCloudJob.cs
+++ b/src/AzureClient/Mocks/MockCloudJob.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
 
         public MockCloudJob(string? id = null)
             : base(
-                new Azure.Quantum.Workspace("mockSubscriptionId", "mockResourceGroupName", "mockWorkspaceName", "mockLocation"),
+                new MockAzureWorkspace("mockSubscriptionId", "mockResourceGroupName", "mockWorkspaceName", "mockLocation"),
                 new JobDetails(
                     containerUri: string.Empty,
                     inputDataFormat: string.Empty,

--- a/src/AzureClient/Mocks/MocksAzureFactory.cs
+++ b/src/AzureClient/Mocks/MocksAzureFactory.cs
@@ -1,8 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using Azure.Core;
 
-using Microsoft.Azure.Quantum;
 using Microsoft.Quantum.Runtime;
 
 namespace Microsoft.Quantum.IQSharp.AzureClient
@@ -14,7 +14,7 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
     public class MocksAzureFactory : IAzureFactory
     {
         /// <inheritdoc />
-        public Azure.Quantum.IWorkspace CreateWorkspace(string subscriptionId, string resourceGroup, string workspaceName, string location) =>
+        public Azure.Quantum.IWorkspace CreateWorkspace(string subscriptionId, string resourceGroup, string workspaceName, string location, TokenCredential credential) =>
              new MockAzureWorkspace(
                     subscriptionId: subscriptionId,
                     resourceGroup: resourceGroup,

--- a/src/Core/Core.csproj
+++ b/src/Core/Core.csproj
@@ -38,10 +38,10 @@
     <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="3.0.0" />
-    <PackageReference Include="Microsoft.Quantum.Compiler" Version="0.17.2106145994-alpha" />
-    <PackageReference Include="Microsoft.Quantum.CSharpGeneration" Version="0.17.2106145994-alpha" />
-    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.17.2106145994-alpha" />
-    <PackageReference Include="Microsoft.Quantum.QSharp.Core" Version="0.17.2106145994-alpha" />
+    <PackageReference Include="Microsoft.Quantum.Compiler" Version="0.17.2106146936-beta" />
+    <PackageReference Include="Microsoft.Quantum.CSharpGeneration" Version="0.17.2106146936-beta" />
+    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.17.2106146936-beta" />
+    <PackageReference Include="Microsoft.Quantum.QSharp.Core" Version="0.17.2106146936-beta" />
     <PackageReference Include="NuGet.Resolver" Version="5.1.0" />
     <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
   </ItemGroup>

--- a/src/ExecutionPathTracer/ExecutionPathTracer.csproj
+++ b/src/ExecutionPathTracer/ExecutionPathTracer.csproj
@@ -32,7 +32,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.17.2106145994-alpha" />
+    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.17.2106146936-beta" />
   </ItemGroup>
 
 </Project>

--- a/src/Jupyter/ChannelWriter.cs
+++ b/src/Jupyter/ChannelWriter.cs
@@ -1,0 +1,32 @@
+﻿using System.Text;
+
+using Microsoft.Jupyter.Core;
+
+#nullable enable
+
+namespace Microsoft.Quantum.IQSharp
+{
+    /// <summary>
+    /// A simpler wrapper to be able to use ChannelWriter as a TextWriter.
+    /// </summary>
+    public class ChannelWriter : System.IO.TextWriter
+    {
+        private IChannel? Channel { get; }
+
+        /// <summary>
+        /// The default constructor.
+        /// </summary>
+        /// <param name="channel">The channel to write output to.</param>
+        public ChannelWriter(IChannel? channel)
+        {
+            Channel = channel;
+        }
+
+        /// <inheritdoc/>
+        public override Encoding Encoding => Encoding.UTF8;
+
+        /// <inheritdoc/>
+        public override void Write(string message) =>
+            Channel?.Stdout(message);
+    }
+}

--- a/src/Jupyter/Extensions.cs
+++ b/src/Jupyter/Extensions.cs
@@ -6,7 +6,6 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Diagnostics.CodeAnalysis;
 using System.Text.RegularExpressions;
 using Microsoft.Jupyter.Core;
 using Microsoft.Quantum.Simulation.Common;
@@ -277,6 +276,19 @@ namespace Microsoft.Quantum.IQSharp.Jupyter
                 return defaultValue;
             }
             return JsonConvert.DeserializeObject(parameterValue, type) ?? defaultValue;
+        }
+
+        /// <summary>
+        /// Makes the channel to start capturing the Console Output.
+        /// Returns the current TextWriter in the Console so callers can set it back.
+        /// </summary>
+        /// <param name="channel">The channel to redirect console output to.</param>
+        /// <returns>The current System.Console.Out</returns>
+        public static System.IO.TextWriter? CaptureConsole(this IChannel channel)
+        {
+            var current = System.Console.Out;
+            System.Console.SetOut(new ChannelWriter(channel));
+            return current;
         }
     }
 }

--- a/src/MockLibraries/Mock.Chemistry/Mock.Chemistry.csproj
+++ b/src/MockLibraries/Mock.Chemistry/Mock.Chemistry.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.17.2106145994-alpha">
+<Project Sdk="Microsoft.Quantum.Sdk/0.17.2106146936-beta">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
@@ -6,6 +6,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.17.2106145994-alpha" />
+    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.17.2106146936-beta" />
   </ItemGroup>
 </Project>

--- a/src/MockLibraries/Mock.Standard/Mock.Standard.csproj
+++ b/src/MockLibraries/Mock.Standard/Mock.Standard.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.17.2106145994-alpha">
+<Project Sdk="Microsoft.Quantum.Sdk/0.17.2106146936-beta">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
@@ -6,6 +6,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.17.2106145994-alpha" />
+    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.17.2106146936-beta" />
   </ItemGroup>
 </Project>

--- a/src/Tests/AzureClientTests.cs
+++ b/src/Tests/AzureClientTests.cs
@@ -8,15 +8,14 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+
 using Microsoft.Azure.Quantum;
-using Azure.Quantum.Jobs.Models;
+using Microsoft.Azure.Quantum.Authentication;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Jupyter.Core;
-using Microsoft.Quantum.IQSharp;
 using Microsoft.Quantum.IQSharp.AzureClient;
 using Microsoft.Quantum.IQSharp.Jupyter;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Extensions = Microsoft.Quantum.IQSharp.AzureClient.Extensions;
 
 namespace Tests.IQSharp
 {
@@ -54,7 +53,8 @@ namespace Tests.IQSharp
                 "TEST_RESOURCE_GROUP_NAME",
                 workspaceName,
                 "TEST_CONNECTION_STRING",
-                locationName);
+                locationName,
+                CredentialType.Environment);
         }
 
         [TestMethod]
@@ -168,7 +168,7 @@ namespace Tests.IQSharp
             // set each target, which will load the corresponding package
             foreach (var target in targets)
             {
-                var returnedTarget = ExpectSuccess<TargetStatusInfo>(azureClient.SetActiveTargetAsync(new MockChannel(), target.TargetId));
+                var returnedTarget = ExpectSuccess<TargetStatusInfo>(azureClient.SetActiveTargetAsync(new MockChannel(), target.TargetId ?? string.Empty));
                 Assert.AreEqual(target.TargetId, returnedTarget.TargetId);
             }
         }

--- a/src/Tests/Workspace.ProjectReferences.ProjectA/ProjectA.csproj
+++ b/src/Tests/Workspace.ProjectReferences.ProjectA/ProjectA.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.17.2106145994-alpha">
+<Project Sdk="Microsoft.Quantum.Sdk/0.17.2106146936-beta">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>

--- a/src/Tests/Workspace.ProjectReferences.ProjectB/ProjectB.csproj
+++ b/src/Tests/Workspace.ProjectReferences.ProjectB/ProjectB.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.17.2106145994-alpha">
+<Project Sdk="Microsoft.Quantum.Sdk/0.17.2106146936-beta">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>

--- a/src/Tests/Workspace.ProjectReferences/Workspace.ProjectReferences.csproj
+++ b/src/Tests/Workspace.ProjectReferences/Workspace.ProjectReferences.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.17.2106145994-alpha">
+<Project Sdk="Microsoft.Quantum.Sdk/0.17.2106146936-beta">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.17.2106145994-alpha" />
+    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.17.2106146936-beta" />
   </ItemGroup>
     
   <ItemGroup>

--- a/src/Tool/appsettings.json
+++ b/src/Tool/appsettings.json
@@ -6,26 +6,26 @@
     },
     "AllowedHosts": "*",
   "DefaultPackageVersions": [
-    "Microsoft.Quantum.Compiler::0.17.2106145994-alpha",
+    "Microsoft.Quantum.Compiler::0.17.2106146936-beta",
 
-    "Microsoft.Quantum.CSharpGeneration::0.17.2106145994-alpha",
-    "Microsoft.Quantum.Development.Kit::0.17.2106145994-alpha",
-    "Microsoft.Quantum.Simulators::0.17.2106145994-alpha",
-    "Microsoft.Quantum.Xunit::0.17.2106145994-alpha",
+    "Microsoft.Quantum.CSharpGeneration::0.17.2106146936-beta",
+    "Microsoft.Quantum.Development.Kit::0.17.2106146936-beta",
+    "Microsoft.Quantum.Simulators::0.17.2106146936-beta",
+    "Microsoft.Quantum.Xunit::0.17.2106146936-beta",
 
-    "Microsoft.Quantum.Standard::0.17.2106145994-alpha",
-    "Microsoft.Quantum.Standard.Visualization::0.17.2106145994-alpha",
-    "Microsoft.Quantum.Chemistry::0.17.2106145994-alpha",
-    "Microsoft.Quantum.Chemistry.Jupyter::0.17.2106145994-alpha",
-    "Microsoft.Quantum.MachineLearning::0.17.2106145994-alpha",
-    "Microsoft.Quantum.Numerics::0.17.2106145994-alpha",
+    "Microsoft.Quantum.Standard::0.17.2106146936-beta",
+    "Microsoft.Quantum.Standard.Visualization::0.17.2106146936-beta",
+    "Microsoft.Quantum.Chemistry::0.17.2106146936-beta",
+    "Microsoft.Quantum.Chemistry.Jupyter::0.17.2106146936-beta",
+    "Microsoft.Quantum.MachineLearning::0.17.2106146936-beta",
+    "Microsoft.Quantum.Numerics::0.17.2106146936-beta",
 
-    "Microsoft.Quantum.Katas::0.17.2106145994-alpha",
+    "Microsoft.Quantum.Katas::0.17.2106146936-beta",
 
-    "Microsoft.Quantum.Research::0.17.2106145994-alpha",
+    "Microsoft.Quantum.Research::0.17.2106146936-beta",
 
-    "Microsoft.Quantum.Providers.IonQ::0.17.2106145994-alpha",
-    "Microsoft.Quantum.Providers.Honeywell::0.17.2106145994-alpha",
-    "Microsoft.Quantum.Providers.QCI::0.17.2106145994-alpha"
+    "Microsoft.Quantum.Providers.IonQ::0.17.2106146936-beta",
+    "Microsoft.Quantum.Providers.Honeywell::0.17.2106146936-beta",
+    "Microsoft.Quantum.Providers.QCI::0.17.2106146936-beta"
   ]
 }


### PR DESCRIPTION
Based on the guideline we received from the Azure SDK, automatically using `DefaultCredential` is not the recommended approach, instead the user should create their own credentials and pass it the API, as such we changed the `Workspace` interface to make `credential` a required parameter.
To accommodate for this change, the `%connect` magic will now accept a new `credential` parameter, that takes an enumeration of possible credential classes to use to authenticate; this gives the user a lot more control and help us mitigates any problems the user might find with a specific credential type.
By default, it still uses `DefaultCredential` with interactive login.