### PR TITLE
Adding telemetry to %azure.connect

### DIFF
--- a/src/AzureClient/AzureClient.cs
+++ b/src/AzureClient/AzureClient.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Net;
 using System.Threading;
@@ -87,6 +88,9 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
         }
 
         /// <inheritdoc/>
+        public event EventHandler<ConnectedToWorkspaceEventArgs>? ConnectedToWorkspace;
+
+        /// <inheritdoc/>
         public async Task<ExecutionResult> ConnectAsync(IChannel channel,
             string subscriptionId,
             string resourceGroupName,
@@ -97,44 +101,62 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
             CancellationToken? cancellationToken = null)
         {
 
-            // Capture the console output, specifically for the case the user is trying to use DeviceCode credentials
-            // so they can get the message for auth.
-            var currentOut = channel?.CaptureConsole();            
+            var duration = Stopwatch.StartNew();
+            ExecutionResult? result = null;
+
             try
             {
-                var credential = CredentialFactory.CreateCredential(credentialType, subscriptionId);
-                
-                var connectionResult = await ConnectToWorkspaceAsync(channel, subscriptionId, resourceGroupName, workspaceName, location, credential);
-                if (connectionResult.Status != ExecuteStatus.Ok)
+                // Capture the console output, specifically for the case the user is trying to use DeviceCode credentials
+                // so they can get the message for auth.
+                var currentOut = channel?.CaptureConsole();
+                try
                 {
-                    return connectionResult;
+                    var credential = CredentialFactory.CreateCredential(credentialType, subscriptionId);
+
+                    var connectionResult = await ConnectToWorkspaceAsync(channel, subscriptionId, resourceGroupName, workspaceName, location, credential);
+                    if (connectionResult.Status != ExecuteStatus.Ok)
+                    {
+                        result = connectionResult;
+                        return result.Value;
+                    }
+
+                    if (ActiveWorkspace == null)
+                    {
+                        result = AzureClientError.WorkspaceNotFound.ToExecutionResult();
+                        return result.Value;
+                    }
+
+                    Credential = credential;
+                }
+                finally
+                {
+                    System.Console.SetOut(currentOut);
                 }
 
-                if (ActiveWorkspace == null)
+                StorageConnectionString = storageAccountConnectionString;
+                ActiveTarget = null;
+                MostRecentJobId = string.Empty;
+
+                channel?.Stdout($"Connected to Azure Quantum workspace {ActiveWorkspace.WorkspaceName} in location {ActiveWorkspace.Location}.");
+
+                if (ValidExecutionTargets.Count() == 0)
                 {
-                    return AzureClientError.WorkspaceNotFound.ToExecutionResult();
+                    channel?.Stderr($"No valid Q# execution targets found in Azure Quantum workspace {ActiveWorkspace.WorkspaceName}.");
                 }
 
-                Credential = credential;
+                result = ValidExecutionTargets.ToExecutionResult();
+                return result.Value;
             }
             finally
             {
-                System.Console.SetOut(currentOut);
+                duration.Stop();
+
+                ExecuteStatus status = result?.Status ?? ExecuteStatus.Error;
+                AzureClientError? error = result?.Output as AzureClientError?;
+                bool useCustomStorage = !string.IsNullOrWhiteSpace(StorageConnectionString);
+                
+                ConnectedToWorkspace?.Invoke(this, new ConnectedToWorkspaceEventArgs(status, error, location, useCustomStorage, credentialType, duration.Elapsed));
             }
-
-
-            StorageConnectionString = storageAccountConnectionString;
-            ActiveTarget = null;
-            MostRecentJobId = string.Empty;
-
-            channel?.Stdout($"Connected to Azure Quantum workspace {ActiveWorkspace.WorkspaceName} in location {ActiveWorkspace.Location}.");
-
-            if (ValidExecutionTargets.Count() == 0)
-            {
-                channel?.Stderr($"No valid Q# execution targets found in Azure Quantum workspace {ActiveWorkspace.WorkspaceName}.");
-            }
-
-            return ValidExecutionTargets.ToExecutionResult();
         }
 
         private string GetNormalizedLocation(string location, IChannel? channel)
@@ -445,7 +467,7 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
         }
 
         /// <inheritdoc/>
-        public async Task<ExecutionResult> GetJobResultAsync(IChannel channel, string jobId, CancellationToken? cancellationToken = default)
+        public async Task<ExecutionResult> GetJobResultAsync(IChannel? channel, string jobId, CancellationToken? cancellationToken = default)
         {
             if (ActiveWorkspace == null)
             {
@@ -503,7 +525,7 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
         }
 
         /// <inheritdoc/>
-        public async Task<ExecutionResult> GetJobStatusAsync(IChannel channel, string jobId, CancellationToken? cancellationToken = default)
+        public async Task<ExecutionResult> GetJobStatusAsync(IChannel? channel, string jobId, CancellationToken? cancellationToken = default)
         {
             if (ActiveWorkspace == null)
             {

--- a/src/AzureClient/AzureClient.cs
+++ b/src/AzureClient/AzureClient.cs
@@ -88,7 +88,7 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
         }
 
         /// <inheritdoc/>
-        public event EventHandler<ConnectedToWorkspaceEventArgs>? ConnectedToWorkspace;
+        public event EventHandler<ConnectToWorkspaceEventArgs>? ConnectToWorkspace;
 
         /// <inheritdoc/>
         public async Task<ExecutionResult> ConnectAsync(IChannel channel,
@@ -155,7 +155,7 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
                 AzureClientError? error = result?.Output as AzureClientError?;
                 bool useCustomStorage = !string.IsNullOrWhiteSpace(StorageConnectionString);
                 
-                ConnectedToWorkspace?.Invoke(this, new ConnectedToWorkspaceEventArgs(status, error, location, useCustomStorage, credentialType, duration.Elapsed));
+                ConnectToWorkspace?.Invoke(this, new ConnectToWorkspaceEventArgs(status, error, location, useCustomStorage, credentialType, duration.Elapsed));
             }
         }
 

--- a/src/AzureClient/IAzureClient.cs
+++ b/src/AzureClient/IAzureClient.cs
@@ -3,20 +3,84 @@
 
 #nullable enable
 
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Threading;
 using System.Threading.Tasks;
+
+using Microsoft.Azure.Quantum.Authentication;
 using Microsoft.Jupyter.Core;
 
 namespace Microsoft.Quantum.IQSharp.AzureClient
 {
+    /// <summary>
+    /// List of arguments for the event that is triggered when the user tries 
+    /// to connect to an Azure Quantum Workspace
+    /// </summary>
+    public class ConnectedToWorkspaceEventArgs : EventArgs
+    {
+        /// <summary>
+        /// Default contructor.
+        /// </summary>
+        /// <param name="status">The status of the connection after calling Connect</param>
+        /// <param name="error">If an error happen, the error code.</param>
+        /// <param name="location">Location of the workspace connecting to.</param>
+        /// <param name="useCustomStorage">True if the user provides a custom storage connection.</param>
+        /// <param name="credentialType">The type of credentials used to authenticate with Azure.</param>
+        /// <param name="duration">How long the action took.</param>
+        public ConnectedToWorkspaceEventArgs(ExecuteStatus status, AzureClientError? error, string location, bool useCustomStorage, CredentialType credentialType, TimeSpan duration)
+        {
+            this.Status = status;
+            this.Error = error;
+            this.Location =location;
+            this.UseCustomStorage = useCustomStorage;
+            this.CredentialType = credentialType;
+            this.Duration = duration;
+        }
+
+        /// <summary>
+        /// The connection status. Can be "success" or "error"
+        /// </summary>
+        public ExecuteStatus Status { get; }
+
+        /// <summary>
+        /// If an error happened during connection, the error code.
+        /// </summary>
+        public AzureClientError? Error { get; }
+
+        /// <summary>
+        /// The Region (location) we tried to connect.
+        /// </summary>
+        public string Location { get; }
+
+        /// <summary>
+        /// True if the user provides a custom storage connection.
+        /// </summary>
+        public bool UseCustomStorage { get; }
+
+        /// <summary>
+        /// The type of credentials used to authenticate with Azure.
+        /// </summary>
+        public CredentialType CredentialType { get; }
+
+        /// <summary>
+        /// The total time it took to connect.
+        /// </summary>
+        public TimeSpan Duration { get; }
+    }
+
     /// <summary>
     /// This service is capable of connecting to Azure Quantum workspaces
     /// and submitting jobs.
     /// </summary>
     public interface IAzureClient
     {
+        /// <summary>
+        /// This event is triggered when a user connects to an Azure Quantum Workspace.
+        /// </summary>
+        event EventHandler<ConnectedToWorkspaceEventArgs> ConnectedToWorkspace;
+
         /// <summary>
         /// Connects to the specified Azure Quantum workspace, first logging into Azure if necessary.
         /// </summary>
@@ -29,7 +93,7 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
             string workspaceName,
             string storageAccountConnectionString,
             string location,
-            Azure.Quantum.Authentication.CredentialType credentialType,
+            CredentialType credentialType,
             CancellationToken? cancellationToken = null);
 
         /// <summary>

--- a/src/AzureClient/IAzureClient.cs
+++ b/src/AzureClient/IAzureClient.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
     /// List of arguments for the event that is triggered when the user tries 
     /// to connect to an Azure Quantum Workspace
     /// </summary>
-    public class ConnectedToWorkspaceEventArgs : EventArgs
+    public class ConnectToWorkspaceEventArgs : EventArgs
     {
         /// <summary>
         /// Default contructor.
@@ -29,7 +29,7 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
         /// <param name="useCustomStorage">True if the user provides a custom storage connection.</param>
         /// <param name="credentialType">The type of credentials used to authenticate with Azure.</param>
         /// <param name="duration">How long the action took.</param>
-        public ConnectedToWorkspaceEventArgs(ExecuteStatus status, AzureClientError? error, string location, bool useCustomStorage, CredentialType credentialType, TimeSpan duration)
+        public ConnectToWorkspaceEventArgs(ExecuteStatus status, AzureClientError? error, string location, bool useCustomStorage, CredentialType credentialType, TimeSpan duration)
         {
             this.Status = status;
             this.Error = error;
@@ -79,7 +79,7 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
         /// <summary>
         /// This event is triggered when a user connects to an Azure Quantum Workspace.
         /// </summary>
-        event EventHandler<ConnectedToWorkspaceEventArgs> ConnectedToWorkspace;
+        event EventHandler<ConnectToWorkspaceEventArgs> ConnectToWorkspace;
 
         /// <summary>
         /// Connects to the specified Azure Quantum workspace, first logging into Azure if necessary.

--- a/src/AzureClient/Mocks/MockAzureWorkspace.cs
+++ b/src/AzureClient/Mocks/MockAzureWorkspace.cs
@@ -20,6 +20,8 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
     {
         public const string NameWithMockProviders = "WorkspaceNameWithMockProviders";
 
+        public const string NameForInvalidWorkspace = "WorkspaceNameForInvalidWorkspace";
+
         internal static string[] MockJobIds { get; set; } = Array.Empty<string>();
 
         internal static HashSet<string> MockProviders { get; set; } = new HashSet<string>();
@@ -60,6 +62,11 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
 
         public async IAsyncEnumerable<CloudJob> ListJobsAsync([EnumeratorCancellation] CancellationToken cancellationToken = default)
         {
+            if (WorkspaceName == NameForInvalidWorkspace)
+            {
+                throw new ArgumentException("Calling an Invalid Workspace");
+            }
+
             await Task.Factory.StartNew(() => Thread.Sleep(10));
             foreach (var j in Jobs)
             {
@@ -69,6 +76,11 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
 
         public async IAsyncEnumerable<QuotaInfo> ListQuotasAsync([EnumeratorCancellation] CancellationToken cancellationToken = default)
         {
+            if (WorkspaceName == NameForInvalidWorkspace)
+            {
+                throw new ArgumentException("Calling an Invalid Workspace");
+            }
+
             await Task.Factory.StartNew(() => Thread.Sleep(10));
 
             foreach (var q in Enumerable.Empty<QuotaInfo>())  // No quotas for Mock workspaces.
@@ -79,6 +91,11 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
 
         public async IAsyncEnumerable<ProviderStatusInfo> ListProvidersStatusAsync([EnumeratorCancellation] CancellationToken cancellationToken = default)
         {
+            if (WorkspaceName == NameForInvalidWorkspace)
+            {
+                throw new ArgumentException("Calling an Invalid Workspace");
+            }
+
             await Task.Factory.StartNew(() => Thread.Sleep(10));
 
             foreach (var p in MockProviders)

--- a/src/Tests/AzureClientMagicTests.cs
+++ b/src/Tests/AzureClientMagicTests.cs
@@ -279,7 +279,7 @@ namespace Tests.IQSharp
         internal List<string> SubmittedJobs = new List<string>();
         internal List<string> ExecutedJobs = new List<string>();
 
-        public event EventHandler<ConnectedToWorkspaceEventArgs>? ConnectedToWorkspace;
+        public event EventHandler<ConnectToWorkspaceEventArgs>? ConnectToWorkspace;
 
 #pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
         public async Task<ExecutionResult> SetActiveTargetAsync(IChannel channel, string targetId, CancellationToken? token)
@@ -325,7 +325,7 @@ namespace Tests.IQSharp
             Location = location;
             CredentialType = credentialType;
 
-            ConnectedToWorkspace?.Invoke(this, new ConnectedToWorkspaceEventArgs(ExecuteStatus.Ok, null, location, storageAccountConnectionString != null, credentialType, TimeSpan.FromMilliseconds(1)));
+            ConnectToWorkspace?.Invoke(this, new ConnectToWorkspaceEventArgs(ExecuteStatus.Ok, null, location, storageAccountConnectionString != null, credentialType, TimeSpan.FromMilliseconds(1)));
             return ExecuteStatus.Ok.ToExecutionResult();
         }
 

--- a/src/Tests/AzureClientMagicTests.cs
+++ b/src/Tests/AzureClientMagicTests.cs
@@ -279,6 +279,8 @@ namespace Tests.IQSharp
         internal List<string> SubmittedJobs = new List<string>();
         internal List<string> ExecutedJobs = new List<string>();
 
+        public event EventHandler<ConnectedToWorkspaceEventArgs>? ConnectedToWorkspace;
+
 #pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
         public async Task<ExecutionResult> SetActiveTargetAsync(IChannel channel, string targetId, CancellationToken? token)
         {
@@ -312,7 +314,7 @@ namespace Tests.IQSharp
             string workspaceName,
             string storageAccountConnectionString,
             string location,
-            CredentialType credentialTypes,
+            CredentialType credentialType,
             CancellationToken? cancellationToken = null)
         {
             LastAction = AzureClientAction.Connect;
@@ -321,7 +323,9 @@ namespace Tests.IQSharp
             WorkspaceName = workspaceName;
             ConnectionString = storageAccountConnectionString;
             Location = location;
-            CredentialType = credentialTypes;
+            CredentialType = credentialType;
+
+            ConnectedToWorkspace?.Invoke(this, new ConnectedToWorkspaceEventArgs(ExecuteStatus.Ok, null, location, storageAccountConnectionString != null, credentialType, TimeSpan.FromMilliseconds(1)));
             return ExecuteStatus.Ok.ToExecutionResult();
         }
 

--- a/src/Tests/AzureClientTests.cs
+++ b/src/Tests/AzureClientTests.cs
@@ -319,5 +319,51 @@ namespace Tests.IQSharp
             _ = ExpectSuccess<IEnumerable<TargetStatusInfo>>(ConnectToWorkspaceAsync(azureClient, locationName: "/test/"));
             Assert.AreEqual("westus", azureClient.ActiveWorkspace?.Location);
         }
+
+        [TestMethod]
+        public void TestConnectedEvent()
+        {
+            var services = Startup.CreateServiceProvider("Workspace");
+            var azureClient = (AzureClient)services.GetService<IAzureClient>();
+
+            ConnectedToWorkspaceEventArgs? lastArgs = null;
+
+            // connect
+            azureClient.ConnectedToWorkspace += (object? sender, ConnectedToWorkspaceEventArgs e) =>
+            {
+                lastArgs = e;
+            };
+
+            ExpectError(AzureClientError.WorkspaceNotFound, azureClient.ConnectAsync(
+                new MockChannel(),
+                "TEST_SUBSCRIPTION_ID",
+                "TEST_RESOURCE_GROUP_NAME",
+                MockAzureWorkspace.NameForInvalidWorkspace,
+                string.Empty,
+                "TEST_LOCATION",
+                CredentialType.Default));
+
+            Assert.IsNotNull(lastArgs);
+            if (lastArgs != null)
+            {
+                Assert.AreEqual(ExecuteStatus.Error, lastArgs.Status);
+                Assert.AreEqual(AzureClientError.WorkspaceNotFound, lastArgs.Error);
+                Assert.AreEqual(CredentialType.Default, lastArgs.CredentialType);
+                Assert.AreEqual("TEST_LOCATION", lastArgs.Location);
+                Assert.AreEqual(false, lastArgs.UseCustomStorage);
+            }
+
+            lastArgs = null;
+            _ = ExpectSuccess<IEnumerable<TargetStatusInfo>>(ConnectToWorkspaceAsync(azureClient, locationName: "TEST_LOCATION"));
+            Assert.IsNotNull(lastArgs);
+            if (lastArgs != null)
+            {
+                Assert.AreEqual(ExecuteStatus.Ok, lastArgs.Status);
+                Assert.AreEqual(null, lastArgs.Error);
+                Assert.AreEqual(CredentialType.Environment, lastArgs.CredentialType);
+                Assert.AreEqual("TEST_LOCATION", lastArgs.Location);
+                Assert.AreEqual(true, lastArgs.UseCustomStorage);
+            }
+        }
     }
 }

--- a/src/Tests/AzureClientTests.cs
+++ b/src/Tests/AzureClientTests.cs
@@ -326,10 +326,10 @@ namespace Tests.IQSharp
             var services = Startup.CreateServiceProvider("Workspace");
             var azureClient = (AzureClient)services.GetService<IAzureClient>();
 
-            ConnectedToWorkspaceEventArgs? lastArgs = null;
+            ConnectToWorkspaceEventArgs? lastArgs = null;
 
             // connect
-            azureClient.ConnectedToWorkspace += (object? sender, ConnectedToWorkspaceEventArgs e) =>
+            azureClient.ConnectToWorkspace += (object? sender, ConnectToWorkspaceEventArgs e) =>
             {
                 lastArgs = e;
             };

--- a/src/Tool/Telemetry.cs
+++ b/src/Tool/Telemetry.cs
@@ -15,6 +15,7 @@ using Microsoft.Quantum.QsCompiler.CompilationBuilder;
 using Microsoft.Quantum.Simulation.Simulators;
 using static Microsoft.Jupyter.Core.BaseEngine;
 using Microsoft.Quantum.IQSharp.Kernel;
+using Microsoft.Quantum.IQSharp.AzureClient;
 
 namespace Microsoft.Quantum.IQSharp
 {
@@ -84,6 +85,8 @@ namespace Microsoft.Quantum.IQSharp
                     engine.HelpExecuted += (_, info) => TelemetryLogger.LogEvent(info.AsTelemetryEvent());
                 }
             };
+            eventService.OnServiceInitialized<IAzureClient>().On += (azureClient) =>
+                azureClient.ConnectToWorkspace += (_, info) => TelemetryLogger.LogEvent(info.AsTelemetryEvent());
         }
 
         public Applications.Events.ILogger TelemetryLogger { get; private set; }
@@ -229,9 +232,21 @@ namespace Microsoft.Quantum.IQSharp
 
             return evt;
         }
+
+        public static EventProperties AsTelemetryEvent(this ConnectToWorkspaceEventArgs info)
+        {
+            var evt = new EventProperties() { Name = "ConnectToWorkspace".WithTelemetryNamespace() };
+
+            evt.SetProperty("Status".WithTelemetryNamespace(), info.Status.ToString());
+            evt.SetProperty("Error".WithTelemetryNamespace(), info.Error?.ToString());
+            evt.SetProperty("Location".WithTelemetryNamespace(), info.Location);
+            evt.SetProperty("UseCustomStorage".WithTelemetryNamespace(), info.UseCustomStorage);
+            evt.SetProperty("CredentialType".WithTelemetryNamespace(), info.CredentialType.ToString());
+            evt.SetProperty("Duration".WithTelemetryNamespace(), info.Duration.ToString());
+
+            return evt;
+        }
     }
-
-
 }
 
 #endif


### PR DESCRIPTION
Adding telemetry to %azure.connect so we can keep track of whether the users as using a custom storage and what type of credentials they are using.