### PR TITLE
Don't throw exceptions on reference loops in JSON serialization.

### DIFF
--- a/src/Core/Core.csproj
+++ b/src/Core/Core.csproj
@@ -38,14 +38,10 @@
     <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="3.0.0" />
-    <PackageReference Include="Microsoft.Quantum.Compiler" Version="0.18.2106148499-beta" />
-    <PackageReference Include="Microsoft.Quantum.CSharpGeneration" Version="0.18.2106148499-beta" />
-    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.18.2106148499-beta" />
-    <PackageReference Include="Microsoft.Quantum.QSharp.Core" Version="0.18.2106148499-beta" />
-    <PackageReference Include="Microsoft.Quantum.Compiler" Version="0.18.2106148499-beta" />
-    <PackageReference Include="Microsoft.Quantum.CSharpGeneration" Version="0.18.2106148499-beta" />
-    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.18.2106148499-beta" />
-    <PackageReference Include="Microsoft.Quantum.QSharp.Core" Version="0.18.2106148499-beta" />
+    <PackageReference Include="Microsoft.Quantum.Compiler" Version="0.18.210728727-alpha" />
+    <PackageReference Include="Microsoft.Quantum.CSharpGeneration" Version="0.18.210728727-alpha" />
+    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.18.210728727-alpha" />
+    <PackageReference Include="Microsoft.Quantum.QSharp.Core" Version="0.18.210728727-alpha" />
     <PackageReference Include="NuGet.Resolver" Version="5.1.0" />
     <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
   </ItemGroup>

--- a/src/ExecutionPathTracer/ExecutionPathTracer.csproj
+++ b/src/ExecutionPathTracer/ExecutionPathTracer.csproj
@@ -32,7 +32,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.18.2106148499-beta" />
+    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.18.210728727-alpha" />
   </ItemGroup>
 
 </Project>

--- a/src/Kernel/IQSharpEngine.cs
+++ b/src/Kernel/IQSharpEngine.cs
@@ -120,6 +120,12 @@ namespace Microsoft.Quantum.IQSharp.Kernel
                     : "application/json"
                 : "application/x-qsharp-data";
 
+            // Register JSON encoders, and make sure that Newtonsoft.Json
+            // doesn't throw exceptions on reference loops.
+            JsonConvert.DefaultSettings = () => new JsonSerializerSettings
+            {
+                ReferenceLoopHandling = ReferenceLoopHandling.Ignore
+            };
             RegisterJsonEncoder(jsonMimeType,
                 JsonConverters.AllConverters
                 .Concat(AzureClient.JsonConverters.AllConverters)

--- a/src/MockLibraries/Mock.Chemistry/Mock.Chemistry.csproj
+++ b/src/MockLibraries/Mock.Chemistry/Mock.Chemistry.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.18.2106148499-beta">
+<Project Sdk="Microsoft.Quantum.Sdk/0.18.210728727-alpha">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
@@ -6,6 +6,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.18.2106148499-beta" />
+    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.18.210728727-alpha" />
   </ItemGroup>
 </Project>

--- a/src/MockLibraries/Mock.Standard/Mock.Standard.csproj
+++ b/src/MockLibraries/Mock.Standard/Mock.Standard.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.18.2106148499-beta">
+<Project Sdk="Microsoft.Quantum.Sdk/0.18.210728727-alpha">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
@@ -6,6 +6,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.18.2106148499-beta" />
+    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.18.210728727-alpha" />
   </ItemGroup>
 </Project>

--- a/src/Tests/Workspace.ProjectReferences.ProjectA/ProjectA.csproj
+++ b/src/Tests/Workspace.ProjectReferences.ProjectA/ProjectA.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.18.2106148499-beta">
+<Project Sdk="Microsoft.Quantum.Sdk/0.18.210728727-alpha">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>

--- a/src/Tests/Workspace.ProjectReferences.ProjectB/ProjectB.csproj
+++ b/src/Tests/Workspace.ProjectReferences.ProjectB/ProjectB.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.18.2106148499-beta">
+<Project Sdk="Microsoft.Quantum.Sdk/0.18.210728727-alpha">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>

--- a/src/Tests/Workspace.ProjectReferences/Workspace.ProjectReferences.csproj
+++ b/src/Tests/Workspace.ProjectReferences/Workspace.ProjectReferences.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.18.2106148499-beta">
+<Project Sdk="Microsoft.Quantum.Sdk/0.18.210728727-alpha">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.18.2106148499-beta" />
+    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.18.210728727-alpha" />
   </ItemGroup>
     
   <ItemGroup>

--- a/src/Tool/appsettings.json
+++ b/src/Tool/appsettings.json
@@ -5,27 +5,22 @@
         }
     },
     "AllowedHosts": "*",
-  "DefaultPackageVersions": [
-    "Microsoft.Quantum.Compiler::0.18.2106148499-beta",
-
-    "Microsoft.Quantum.CSharpGeneration::0.18.2106148499-beta",
-    "Microsoft.Quantum.Development.Kit::0.18.2106148499-beta",
-    "Microsoft.Quantum.Simulators::0.18.2106148499-beta",
-    "Microsoft.Quantum.Xunit::0.18.2106148499-beta",
-
-    "Microsoft.Quantum.Standard::0.18.2106148499-beta",
-    "Microsoft.Quantum.Standard.Visualization::0.18.2106148499-beta",
-    "Microsoft.Quantum.Chemistry::0.18.2106148499-beta",
-    "Microsoft.Quantum.Chemistry.Jupyter::0.18.2106148499-beta",
-    "Microsoft.Quantum.MachineLearning::0.18.2106148499-beta",
-    "Microsoft.Quantum.Numerics::0.18.2106148499-beta",
-
-    "Microsoft.Quantum.Katas::0.18.2106148499-beta",
-
-    "Microsoft.Quantum.Research::0.18.2106148499-beta",
-
-    "Microsoft.Quantum.Providers.IonQ::0.18.2106148499-beta",
-    "Microsoft.Quantum.Providers.Honeywell::0.18.2106148499-beta",
-    "Microsoft.Quantum.Providers.QCI::0.18.2106148499-beta"
-  ]
+    "DefaultPackageVersions": [
+        "Microsoft.Quantum.Compiler::0.18.210728727-alpha",
+        "Microsoft.Quantum.CSharpGeneration::0.18.210728727-alpha",
+        "Microsoft.Quantum.Development.Kit::0.18.210728727-alpha",
+        "Microsoft.Quantum.Simulators::0.18.210728727-alpha",
+        "Microsoft.Quantum.Xunit::0.18.210728727-alpha",
+        "Microsoft.Quantum.Standard::0.18.210728727-alpha",
+        "Microsoft.Quantum.Standard.Visualization::0.18.210728727-alpha",
+        "Microsoft.Quantum.Chemistry::0.18.210728727-alpha",
+        "Microsoft.Quantum.Chemistry.Jupyter::0.18.210728727-alpha",
+        "Microsoft.Quantum.MachineLearning::0.18.210728727-alpha",
+        "Microsoft.Quantum.Numerics::0.18.210728727-alpha",
+        "Microsoft.Quantum.Katas::0.18.210728727-alpha",
+        "Microsoft.Quantum.Research::0.18.210728727-alpha",
+        "Microsoft.Quantum.Providers.IonQ::0.18.210728727-alpha",
+        "Microsoft.Quantum.Providers.Honeywell::0.18.210728727-alpha",
+        "Microsoft.Quantum.Providers.QCI::0.18.210728727-alpha"
+    ]
 }


### PR DESCRIPTION
This PR changes default JSON serialization settings to prevent exceptions due to circular references from propagating out through to display data serialization. See https://github.com/microsoft/qsharp-runtime/pull/764 for related issue on qsharp-runtime.