### PR TITLE
Fix #448.

### DIFF
--- a/src/AzureClient/AzureClient.cs
+++ b/src/AzureClient/AzureClient.cs
@@ -319,7 +319,7 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
             }
             catch (CompilationErrorsException e)
             {
-                channel?.Stderr($"The Q# operation {submissionContext.OperationName} could not be compiled as an entry point for job execution.");
+                e.Log(channel, Logger, $"The Q# operation {submissionContext.OperationName} could not be compiled as an entry point for job execution.");
                 foreach (var message in e.Errors) channel?.Stderr(message);
                 return AzureClientError.InvalidEntryPoint.ToExecutionResult();
             }

--- a/src/AzureClient/EntryPoint/EntryPointGenerator.cs
+++ b/src/AzureClient/EntryPoint/EntryPointGenerator.cs
@@ -131,7 +131,7 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
             {
                 Logger?.LogDebug($"{snippets.Length} items found in snippets. Compiling.");
                 SnippetsAssemblyInfo = Compiler.BuildSnippets(
-                    snippets, compilerMetadata, logger, Path.Combine(Workspace.CacheFolder, "__entrypoint__snippets__.dll"), executionTarget, runtimeCapability);
+                    snippets, compilerMetadata, logger, Path.Combine(Workspace.CacheFolder, "__entrypoint__snippets__.dll"));
                 if (SnippetsAssemblyInfo == null || logger.HasErrors)
                 {
                     Logger?.LogError($"Error compiling snippets.");

--- a/src/AzureClient/Extensions.cs
+++ b/src/AzureClient/Extensions.cs
@@ -10,6 +10,7 @@ using System.ComponentModel;
 using System.Threading.Tasks;
 using Microsoft.Azure.Quantum;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Microsoft.Jupyter.Core;
 
 namespace Microsoft.Quantum.IQSharp.AzureClient
@@ -87,5 +88,12 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
             (job.Id != null && job.Id.Contains(filter, StringComparison.OrdinalIgnoreCase)) ||
             (job.Details.Name != null && job.Details.Name.Contains(filter, StringComparison.OrdinalIgnoreCase)) ||
             (job.Details.Target != null && job.Details.Target.Contains(filter, StringComparison.OrdinalIgnoreCase));
+
+        internal static void Log(this Exception ex, IChannel? channel, ILogger? logger, string msg = "")
+        {
+            logger?.LogError(ex, msg);
+            channel?.Stderr(msg);
+            channel?.Stderr(ex.Message);
+        }
     }
 }


### PR DESCRIPTION
(Co-authored with @anjbur in a Live Share session.)

This PR fixes #448 by making sure that only entry point executables are hardware targeted, allowing for the Q# compiler to ignore code that isn't supported on a given target, so long as that code is not in the transitive closure of the entry point being submitted. This PR also adds new logging in AzureClient.cs to help diagnose any possible regressions.