### PR TITLE
Add additional diagnostics to measure service startup.

### DIFF
--- a/src/AzureClient/AzureClient.cs
+++ b/src/AzureClient/AzureClient.cs
@@ -70,7 +70,6 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
             MetadataController = metadataController;
             AzureFactory = azureFactory;
             Logger = logger;
-            eventService?.TriggerServiceInitialized<IAzureClient>(this);
 
             if (engine is BaseEngine baseEngine)
             {
@@ -85,6 +84,8 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
                 baseEngine.RegisterDisplayEncoder(new DeviceCodeResultToHtmlEncoder());
                 baseEngine.RegisterDisplayEncoder(new DeviceCodeResultToTextEncoder());
             }
+
+            eventService?.TriggerServiceInitialized<IAzureClient>(this);
         }
 
         /// <inheritdoc/>

--- a/src/Core/Compiler/CompilerService.cs
+++ b/src/Core/Compiler/CompilerService.cs
@@ -59,7 +59,7 @@ namespace Microsoft.Quantum.IQSharp
             ["Microsoft.Quantum.Canon"] = null
         };
 
-        public CompilerService(ILogger<CompilerService>? logger, IOptions<Settings>? options)
+        public CompilerService(ILogger<CompilerService>? logger, IOptions<Settings>? options, IEventService? eventService)
         {
             if (options?.Value?.AutoOpenNamespaces is string namespaces)
             {
@@ -78,6 +78,8 @@ namespace Microsoft.Quantum.IQSharp
                           nsParts => nsParts.Length > 1 ? nsParts[1] : null
                       );
             }
+
+            eventService?.TriggerServiceInitialized<ICompilerService>(this);
         }
 
         private CompilationLoader CreateTemporaryLoader(string source)

--- a/src/Core/Events/EventService.cs
+++ b/src/Core/Events/EventService.cs
@@ -78,7 +78,7 @@ namespace Microsoft.Quantum.IQSharp
         public void Trigger<TEvent, TArgs>(TEvent @event)
             where TEvent : Event<TArgs>
         {
-            Logger.LogInformation($"Event Triggered for '{typeof(TEvent).Name}'");
+            Logger.LogInformation($"Event Triggered for '{typeof(TEvent)}'");
             if (_Subscribers.TryGetValue(typeof(TEvent), out var subscribersList))
             {
                 object[] subscribers;
@@ -148,6 +148,7 @@ namespace Microsoft.Quantum.IQSharp
         public EventService(ILogger<EventService> logger)
         {
             EventPubSub = new EventPubSub(logger);
+            this?.TriggerServiceInitialized<IEventService>(this);
         }
 
         /// <summary>

--- a/src/Core/Events/ServiceInitializedEvent.cs
+++ b/src/Core/Events/ServiceInitializedEvent.cs
@@ -36,9 +36,9 @@ namespace Microsoft.Quantum.IQSharp
         /// <typeparam name="TService">The type (usually the interface) of the service</typeparam>
         /// <param name="eventService">The event service where the EventSubPub lives</param>
         /// <returns>The typed EventPubSub for the ServiceInitialized event</returns>
-        public static EventPubSub<ServiceInitializedEvent<TService>,TService> OnServiceInitialized<TService>(this IEventService eventService)
+        public static EventPubSub<ServiceInitializedEvent<TService>, TService> OnServiceInitialized<TService>(this IEventService eventService)
         {
-            return eventService?.Events<ServiceInitializedEvent<TService>,TService>();
+            return eventService?.Events<ServiceInitializedEvent<TService>, TService>();
         }
     }
 }

--- a/src/Core/References/NugetPackages.cs
+++ b/src/Core/References/NugetPackages.cs
@@ -111,7 +111,8 @@ namespace Microsoft.Quantum.IQSharp
 
         public NugetPackages(
             IOptions<Settings> config,
-            ILogger<NugetPackages>? logger
+            ILogger<NugetPackages>? logger,
+            IEventService? eventService
         )
         {
             this.Logger = new NuGetLogger(logger);
@@ -120,6 +121,8 @@ namespace Microsoft.Quantum.IQSharp
             this.DefaultVersions = InitDefaultVersions(config?.Value.DefaultPackageVersions);
             this.Items = Enumerable.Empty<PackageIdentity>();
             this.Assemblies = Enumerable.Empty<AssemblyInfo>();
+
+            eventService?.TriggerServiceInitialized<INugetPackages>(this);
         }
 
         /// <summary>

--- a/src/Core/References/References.cs
+++ b/src/Core/References/References.cs
@@ -88,8 +88,6 @@ namespace Microsoft.Quantum.IQSharp
             Nugets = packages;
             Logger = logger;
 
-            eventService?.TriggerServiceInitialized<IReferences>(this);
-
             var referencesOptions = options.Value;
             if (referencesOptions?.AutoLoadPackages is string autoLoadPkgs)
             {
@@ -103,6 +101,8 @@ namespace Microsoft.Quantum.IQSharp
             _metadata = new Lazy<CompilerMetadata>(() => new CompilerMetadata(this.Assemblies));
 
             AssemblyLoadContext.Default.Resolving += Resolve;
+
+            eventService?.TriggerServiceInitialized<IReferences>(this);
         }
 
         /// <inheritdoc/>
@@ -173,6 +173,7 @@ namespace Microsoft.Quantum.IQSharp
             AddAssemblies(Nugets.Assemblies.ToArray());
 
             duration.Stop();
+            Logger?.LogInformation("Loaded package {Id}::{Version} in {Time}.", pkg.Id, pkg.Version?.ToNormalizedString() ?? string.Empty, duration.Elapsed);
             PackageLoaded?.Invoke(this, new PackageLoadedEventArgs(pkg.Id, pkg.Version?.ToNormalizedString() ?? string.Empty, duration.Elapsed));
         }
 

--- a/src/Core/Workspace/Workspace.cs
+++ b/src/Core/Workspace/Workspace.cs
@@ -21,6 +21,15 @@ using NuGet.Versioning;
 
 namespace Microsoft.Quantum.IQSharp
 {
+    /// <summary>
+    ///     An event that is fired when the workspace is not just initialized
+    ///     (that is, available for dependency injection), but is also ready
+    ///     to be used (that is, all initialization tasks from the constructor
+    ///     have also finished).
+    /// </summary>
+    public class WorkspaceReadyEvent : Event<IWorkspace>
+    {
+    }
 
     /// <summary>
     /// A Workspace represents a folder in the host with .qs files
@@ -203,13 +212,15 @@ namespace Microsoft.Quantum.IQSharp
                         }
                     }
 
-                    eventService?.TriggerServiceInitialized<IWorkspace>(this);
+                    eventService?.Trigger<WorkspaceReadyEvent, IWorkspace>(this);
                 }
                 finally
                 {
                     initialized.Set();
                 }
             });
+
+            eventService?.TriggerServiceInitialized<IWorkspace>(this);
         }
 
         private void ResolveProjectReferences()

--- a/src/Jupyter/ConfigurationSource/ConfigurationSource.cs
+++ b/src/Jupyter/ConfigurationSource/ConfigurationSource.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Quantum.IQSharp.Jupyter
         ///     configuration options from the file <c>.iqsharp-config.json</c>,
         ///     if that file exists.
         /// </summary>
-        public ConfigurationSource(bool skipLoading = false)
+        public ConfigurationSource(IEventService? eventService = null, bool skipLoading = false)
         {
             // Try loading configuration from a JSON file in the current working
             // directory.
@@ -52,6 +52,8 @@ namespace Microsoft.Quantum.IQSharp.Jupyter
             {
                 _Configuration = new Dictionary<string, JToken>();
             }
+
+            eventService?.TriggerServiceInitialized<IConfigurationSource>(this);
         }
 
         /// <summary>

--- a/src/Kernel/IQSharpEngine.cs
+++ b/src/Kernel/IQSharpEngine.cs
@@ -74,9 +74,20 @@ namespace Microsoft.Quantum.IQSharp.Kernel
         }
 
         /// <inheritdoc />
-        public override void Start()
+        public override void Start() =>
+            this.StartAsync().Wait();
+
+        private async Task StartAsync()
         {
             base.Start();
+            var eventService = services.GetRequiredService<IEventService>();
+            eventService.Events<WorkspaceReadyEvent, IWorkspace>().On += (workspace) =>
+            {
+                logger?.LogInformation(
+                    "Workspace ready {Time} after startup.",
+                    DateTime.UtcNow - System.Diagnostics.Process.GetCurrentProcess().StartTime.ToUniversalTime()
+                );
+            };
 
             // Before anything else, make sure to start the right background
             // thread on the Q# compilation loader to initialize serializers
@@ -91,12 +102,20 @@ namespace Microsoft.Quantum.IQSharp.Kernel
             Protocols.Initialize();
 
             logger.LogDebug("Getting services required to start IQ# engine.");
-            this.Snippets = services.GetService<ISnippets>();
-            this.SymbolsResolver = services.GetService<ISymbolResolver>();
-            this.MagicResolver = services.GetService<IMagicSymbolResolver>();
-            this.Workspace = services.GetService<IWorkspace>();
-            var references = services.GetService<IReferences>();
-            var eventService = services.GetService<IEventService>();
+            var serviceTasks = new
+            {
+                Snippets = services.GetRequiredServiceInBackground<ISnippets>(logger),
+                SymbolsResolver = services.GetRequiredServiceInBackground<ISymbolResolver>(logger),
+                MagicResolver = services.GetRequiredServiceInBackground<IMagicSymbolResolver>(logger),
+                Workspace = services.GetRequiredServiceInBackground<IWorkspace>(logger),
+                References = services.GetRequiredServiceInBackground<IReferences>(logger)
+            };
+
+            this.Snippets = await serviceTasks.Snippets;
+            this.SymbolsResolver = await serviceTasks.SymbolsResolver;
+            this.MagicResolver = await serviceTasks.MagicResolver;
+            this.Workspace = await serviceTasks.Workspace;
+            var references = await serviceTasks.References;
 
             logger.LogDebug("Registering IQ# display and JSON encoders.");
             RegisterDisplayEncoder(new IQSharpSymbolToHtmlResultEncoder());

--- a/src/Kernel/Magic/Resolution/MagicResolver.cs
+++ b/src/Kernel/Magic/Resolution/MagicResolver.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Quantum.IQSharp.Kernel
         ///     services to search assembly references for subclasses of
         ///     <see cref="Microsoft.Jupyter.Core.MagicSymbol" />.
         /// </summary>
-        public MagicSymbolResolver(IServiceProvider services, ILogger<MagicSymbolResolver> logger)
+        public MagicSymbolResolver(IServiceProvider services, ILogger<MagicSymbolResolver> logger, IEventService eventService)
         {
             this.cache = new Dictionary<AssemblyInfo, MagicSymbol[]>();
             this.logger = logger;
@@ -48,6 +48,8 @@ namespace Microsoft.Quantum.IQSharp.Kernel
             this.services = services;
             this.references = services.GetService<IReferences>();
             this.workspace = services.GetService<IWorkspace>();
+
+            eventService?.TriggerServiceInitialized<IMagicSymbolResolver>(this);
         }
 
 

--- a/src/Kernel/SymbolResolver.cs
+++ b/src/Kernel/SymbolResolver.cs
@@ -118,9 +118,15 @@ namespace Microsoft.Quantum.IQSharp.Kernel
         /// <param name="opsResolver">
         ///     An object to be used to resolve operation names to symbols.
         /// </param>
-        public SymbolResolver(IOperationResolver opsResolver)
+        /// <param name="eventService">
+        ///     The event service used to signal the successful start of this
+        ///     resolver service.
+        /// </param>
+        public SymbolResolver(IOperationResolver opsResolver, IEventService eventService)
         {
             this.opsResolver = opsResolver;
+
+            eventService?.TriggerServiceInitialized<ISymbolResolver>(this);
         }
 
         /// <summary>

--- a/src/Tests/IQsharpEngineTests.cs
+++ b/src/Tests/IQsharpEngineTests.cs
@@ -80,7 +80,7 @@ namespace Tests.IQSharp
         public static async Task<string?> AssertSimulate(IQSharpEngine engine, string snippetName, params string[] messages)
         {
             await engine.Initialized;
-            var configSource = new ConfigurationSource(skipLoading: true);
+            var configSource = new ConfigurationSource(skipLoading: true, eventService: null);
 
             var simMagic = new SimulateMagic(engine.SymbolsResolver!, configSource,
                 new UnitTestLogger<SimulateMagic>());

--- a/src/Tests/NugetPackagesTests.cs
+++ b/src/Tests/NugetPackagesTests.cs
@@ -70,7 +70,7 @@ namespace Tests.IQSharp
                 $"Microsoft.Quantum.Chemistry::{version}"
             };
 
-            var mgr = new NugetPackages(new MockNugetOptions(versions), null);
+            var mgr = new NugetPackages(new MockNugetOptions(versions), null, eventService: null);
 
             Assert.AreEqual(nuVersion, await mgr.GetLatestVersion("Microsoft.Quantum.Standard"));
             Assert.AreEqual(nuVersion, await mgr.GetLatestVersion("Microsoft.Quantum.Chemistry"));

--- a/src/Tests/SnippetsControllerTests.cs
+++ b/src/Tests/SnippetsControllerTests.cs
@@ -180,7 +180,7 @@ namespace Tests.IQSharp
         [TestMethod]
         public void IdentifyOperations()
         {
-            var compiler = new CompilerService(null, null);
+            var compiler = new CompilerService(null, null, eventService: null);
 
             var elements = compiler.IdentifyElements(SNIPPETS.Op1_Op2).Select(Extensions.ToFullName).ToArray();
 

--- a/src/Tool/Telemetry.cs
+++ b/src/Tool/Telemetry.cs
@@ -24,12 +24,25 @@ namespace Microsoft.Quantum.IQSharp
     {
         private const string TOKEN = "55aee962ee9445f3a86af864fc0fa766-48882422-3439-40de-8030-228042bd9089-7794";
 
+        private void OnServiceInitialized<T>()
+        {
+            EventService.OnServiceInitialized<T>().On += (service) =>
+            {
+                var evt = "ServiceInitialized"
+                    .AsTelemetryEvent()
+                    .WithTimeSinceStart();
+                evt.SetProperty("Service", $"{typeof(T).Namespace}.{typeof(T).Name}");
+                TelemetryLogger.LogEvent(evt);
+            };
+        }
+
         public TelemetryService(
             ILogger<TelemetryService> logger,
             IEventService eventService)
         {
             var config = Program.Configuration;
             Logger = logger;
+            EventService = eventService;
             Logger.LogInformation("Starting Telemetry.");
             Logger.LogDebug($"DeviceId: {GetDeviceId()}.");
 
@@ -51,6 +64,28 @@ namespace Microsoft.Quantum.IQSharp
                 LogManager.UploadNow();
                 LogManager.Teardown();
             };
+
+            // Send telemetry that identifies how long after startup each
+            // service is ready.
+            this.OnServiceInitialized<ISnippets>();
+            this.OnServiceInitialized<ISymbolResolver>();
+            this.OnServiceInitialized<IMagicSymbolResolver>();
+            this.OnServiceInitialized<IWorkspace>();
+            eventService.Events<WorkspaceReadyEvent, IWorkspace>().On += (workspace) =>
+            {
+                var evt = "WorkspaceReady"
+                    .AsTelemetryEvent()
+                    .WithTimeSinceStart();
+                TelemetryLogger.LogEvent(evt);
+            };
+            this.OnServiceInitialized<IReferences>();
+            this.OnServiceInitialized<IConfigurationSource>();
+            this.OnServiceInitialized<IMetadataController>();
+            this.OnServiceInitialized<INugetPackages>();
+            this.OnServiceInitialized<IAzureClient>();
+            this.OnServiceInitialized<IEntryPointGenerator>();
+            this.OnServiceInitialized<IExecutionEngine>();
+            this.OnServiceInitialized<ICompilerService>();
 
             eventService.Events<ExperimentalFeatureEnabledEvent, ExperimentalFeatureContent>().On += (content) =>
             {
@@ -106,6 +141,7 @@ namespace Microsoft.Quantum.IQSharp
 
         public Applications.Events.ILogger TelemetryLogger { get; private set; }
         public ILogger<TelemetryService> Logger { get; }
+        public IEventService EventService { get; }
 
         public virtual Applications.Events.ILogger CreateLogManager(IConfiguration config)
         {


### PR DESCRIPTION
This PR adds new diagnostics and logging calls to report when different DI services are ready for use by the rest of the IQ# kernel. This will make it easier to diagnose and troubleshoot performance issues with kernel startup.