### PR TITLE
Improve performance of magic discovery.

### DIFF
--- a/src/Kernel/IQSharpEngine.cs
+++ b/src/Kernel/IQSharpEngine.cs
@@ -47,6 +47,32 @@ namespace Microsoft.Quantum.IQSharp.Kernel
 
         private TaskCompletionSource<bool> initializedSource = new TaskCompletionSource<bool>();
 
+        /// <summary>
+        ///     The simple names of those assemblies which do not need to be
+        ///     searched for display encoders or magic commands.
+        /// </summary>
+        internal static readonly IImmutableSet<string> MundaneAssemblies =
+            new string[]
+            {
+                // These assemblies are classical libraries used by IQ#, and
+                // do not contain any quantum code.
+                "NumSharp.Core",
+                "Newtonsoft.Json",
+
+                // These assemblies are part of the Quantum Development Kit
+                // built before IQ# (in dependency ordering), and thus cannot
+                // contain types relevant to IQ#. While it doesn't hurt to scan
+                // these assemblies, we can leave them out for performance.
+                "Microsoft.Quantum.QSharp.Core",
+                "Microsoft.Quantum.QSharp.Foundation",
+                "Microsoft.Quantum.Simulation.QCTraceSimulatorRuntime",
+                "Microsoft.Quantum.Targets.Interfaces",
+                "Microsoft.Quantum.Simulators",
+                "Microsoft.Quantum.Simulation.Common",
+                "Microsoft.Quantum.Runtime.Core",
+            }
+            .ToImmutableHashSet();
+
         /// <inheritdoc />
         public override Task Initialized => initializedSource.Task;
 
@@ -178,6 +204,7 @@ namespace Microsoft.Quantum.IQSharp.Kernel
                 foreach (var assembly in references.Assemblies
                                                    .Select(asm => asm.Assembly)
                                                    .Where(asm => !knownAssemblies.Contains(asm.GetName()))
+                                                   .Where(asm => !MundaneAssemblies.Contains(asm.GetName().Name))
                 )
                 {
                     // Look for display encoders in the new assembly.

--- a/src/Kernel/Magic/Resolution/MagicResolver.cs
+++ b/src/Kernel/Magic/Resolution/MagicResolver.cs
@@ -1,7 +1,8 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Immutable;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Extensions.Configuration;
@@ -12,6 +13,8 @@ using Microsoft.Quantum.IQSharp.AzureClient;
 using Microsoft.Quantum.IQSharp.Common;
 
 using Newtonsoft.Json;
+using System.Diagnostics;
+using System.Reflection;
 
 namespace Microsoft.Quantum.IQSharp.Kernel
 {
@@ -24,7 +27,7 @@ namespace Microsoft.Quantum.IQSharp.Kernel
     public class MagicSymbolResolver : IMagicSymbolResolver
     {
         private AssemblyInfo[] kernelAssemblies;
-        private Dictionary<AssemblyInfo, MagicSymbol[]> cache;
+        private Dictionary<AssemblyName, MagicSymbol[]> cache;
         private IServiceProvider services;
         private IReferences references;
         private IWorkspace workspace;
@@ -37,7 +40,7 @@ namespace Microsoft.Quantum.IQSharp.Kernel
         /// </summary>
         public MagicSymbolResolver(IServiceProvider services, ILogger<MagicSymbolResolver> logger)
         {
-            this.cache = new Dictionary<AssemblyInfo, MagicSymbol[]>();
+            this.cache = new Dictionary<AssemblyName, MagicSymbol[]>();
             this.logger = logger;
 
             this.kernelAssemblies = new[]
@@ -106,15 +109,23 @@ namespace Microsoft.Quantum.IQSharp.Kernel
         public IEnumerable<MagicSymbol> FindMagic(AssemblyInfo assm)
         {
             var result = new MagicSymbol[0];
+            // If the assembly cannot possibly contain magic symbols, skip it
+            // here.
+            if (IQSharpEngine.MundaneAssemblies.Contains(assm.Assembly.GetName().Name))
+            {
+                return result;
+            }
 
             lock (cache)
             {
-                if (cache.TryGetValue(assm, out result))
+                if (cache.TryGetValue(assm.Assembly.GetName(), out result))
                 {
                     return result;
                 }
 
                 this.logger.LogInformation($"Looking for MagicSymbols in {assm.Assembly.FullName}");
+                var stopwatch = new Stopwatch();
+                stopwatch.Start();
 
                 // If types from an assembly cannot be loaded, log a warning and continue.
                 var allMagic = new List<MagicSymbol>();
@@ -125,14 +136,7 @@ namespace Microsoft.Quantum.IQSharp.Kernel
                         .Where(t =>
                         {
                             if (!t.IsClass && t.IsAbstract) { return false; }
-                            var matched = t.IsSubclassOf(typeof(MagicSymbol));
-
-                            // This logging statement is expensive, so we only run it when we need to for debugging.
-                            #if DEBUG
-                            this.logger.LogDebug("Class {Class} subclass of MagicSymbol? {Matched}", t.FullName, matched);
-                            #endif
-
-                            return matched;
+                            return t.IsSubclassOf(typeof(MagicSymbol));
                         });
 
                     foreach (var t in magicTypes)
@@ -169,8 +173,9 @@ namespace Microsoft.Quantum.IQSharp.Kernel
                     );
                 }
 
+                logger.LogInformation("Took {Elapsed} to scan {Assembly} for magic symbols.", stopwatch.Elapsed, assm.Assembly.FullName);
                 result = allMagic.ToArray();
-                cache[assm] = result;
+                cache[assm.Assembly.GetName()] = result;
             }
 
             return result;
@@ -178,6 +183,9 @@ namespace Microsoft.Quantum.IQSharp.Kernel
 
         /// <inheritdoc />
         public IEnumerable<MagicSymbol> FindAllMagicSymbols() =>
-            RelevantAssemblies().SelectMany(FindMagic);
+            RelevantAssemblies()
+            .AsParallel()
+            .WithExecutionMode(ParallelExecutionMode.ForceParallelism)
+            .SelectMany(FindMagic);
     }
 }

--- a/src/Kernel/Magic/Resolution/MagicResolver.cs
+++ b/src/Kernel/Magic/Resolution/MagicResolver.cs
@@ -136,7 +136,14 @@ namespace Microsoft.Quantum.IQSharp.Kernel
                         .Where(t =>
                         {
                             if (!t.IsClass && t.IsAbstract) { return false; }
-                            return t.IsSubclassOf(typeof(MagicSymbol));
+                            var matched = t.IsSubclassOf(typeof(MagicSymbol));
+
+                            // This logging statement is expensive, so we only run it when we need to for debugging.
+                            #if DEBUG
+                            this.logger.LogDebug("Class {Class} subclass of MagicSymbol? {Matched}", t.FullName, matched);
+                            #endif
+
+                            return matched;
                         });
 
                     foreach (var t in magicTypes)

--- a/src/Tests/TelemetryTests.cs
+++ b/src/Tests/TelemetryTests.cs
@@ -31,23 +31,58 @@ using Microsoft.Quantum.IQSharp.Kernel;
 using Microsoft.Quantum.QsCompiler.CompilationBuilder;
 using Microsoft.Quantum.Simulation.Simulators;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.Quantum.IQSharp.AzureClient;
 
 namespace Tests.IQSharp
 {
+    internal static class TelemetryTestExtensions
+    {
+        internal static void AssertEventCount(
+            this MockTelemetryService.MockAppLogger logger,
+            int count
+        )
+        {
+            var msg = $"Expected {count} telemetry events, got:\n";
+            foreach (var evt in logger.Events)
+            {
+                var evtMsg = $"\tName = {evt.Name}, Type = {evt.Type}, EventId = {evt.EventId}\n";
+                foreach (var prop in evt.Properties)
+                {
+                    evtMsg += $"\t\t{prop.Key} = {prop.Value}\n";
+                }
+                msg += evtMsg;
+            }
+            Assert.AreEqual(count, logger.Events.Count, msg);
+        }
+    }
     [TestClass]
     public class TelemetryTests
     {
         public static readonly Type TelemetryServiceType = typeof(MockTelemetryService);
 
-        public IQSharpEngine Init(IServiceProvider services)
+        public async Task<IQSharpEngine> InitAsync(IServiceProvider services)
         {
-            var engine = services.GetService<IExecutionEngine>() as IQSharpEngine;
-            engine.Start();
-            engine.Initialized.Wait();
-            Assert.IsNotNull(engine.Workspace);
-            engine.Workspace!.Initialization.Wait();
-            return engine;
+            var engine = services.GetService<IExecutionEngine>();
+            if (engine is IQSharpEngine iqsEngine)
+            {
+                iqsEngine.Start();
+                await iqsEngine.Initialized;
+                Assert.IsNotNull(iqsEngine.Workspace);
+                await Task.WhenAll(
+                    iqsEngine.Workspace!.Initialization,
+                    // Wait for any other required services. This keeps the
+                    // service started telemetry events from causing problems
+                    // for later assertions.
+                    services.GetRequiredServiceInBackground<IAzureClient>(),
+                    services.GetRequiredServiceInBackground<IEntryPointGenerator>()
+                );
+                return iqsEngine;
+            }
+            else throw new Exception($"Expected engine to be an IQSharpEngine, but got a {engine?.GetType().ToString() ?? "<null>"} instead.");
         }
+
+        public IQSharpEngine Init(IServiceProvider services) =>
+            InitAsync(services).Result;
 
         [TestMethod]
         public void MockTelemetryService()
@@ -267,21 +302,21 @@ namespace Tests.IQSharp
 
             var count = 0;
             engine.ExecuteMundane(SNIPPETS.HelloQ, channel).Wait();
-            Assert.AreEqual(count + 1, logger.Events.Count);
+            logger.AssertEventCount(count + 1);
             Assert.AreEqual("Quantum.IQSharp.Compile", logger.Events[count].Name);
             Assert.AreEqual("ok", logger.Events[count].Properties["Quantum.IQSharp.Status"]);
             Assert.AreEqual("", logger.Events[0].Properties["Quantum.IQSharp.Errors"]);
 
             count++;
             engine.Execute("%simulate HelloQ", channel).Wait();
-            Assert.AreEqual(count + 1, logger.Events.Count);
+            logger.AssertEventCount(count + 1);
             Assert.AreEqual("Quantum.IQSharp.Action", logger.Events[count].Name);
             Assert.AreEqual("%simulate", logger.Events[count].Properties["Quantum.IQSharp.Command"]);
             Assert.AreEqual("Ok", logger.Events[count].Properties["Quantum.IQSharp.Status"]);
 
             count++;
             engine.Execute("%package Microsoft.Quantum.Standard", channel).Wait();
-            Assert.AreEqual(count + 2, logger.Events.Count);
+            logger.AssertEventCount(count + 2);
             Assert.AreEqual("Quantum.IQSharp.PackageLoad", logger.Events[count].Name);
             Assert.AreEqual("Microsoft.Quantum.Standard", logger.Events[count].Properties["Quantum.IQSharp.PackageId"]);
             Assert.IsTrue(!string.IsNullOrWhiteSpace(logger.Events[count].Properties["Quantum.IQSharp.PackageVersion"]?.ToString()));


### PR DESCRIPTION
This PR improves the performance with which magic commands and display encoders are discovered, reducing kernel startup times and the amount of time before the first cell can be executed. In particular, this PR:

- Completely removes an expensive logging call.
- Uses parallel LINQ to search assemblies in parallel.
- Resolves an issue where some assemblies were getting twice by changing the key type used for caching from `AssemblyInfo` to `AssemblyName`.
- Adds a blocklist of assemblies that never need to be searched for magic commands or display encoders.
