### PR TITLE
Fix #478.

### DIFF
--- a/src/AzureClient/Magic/ExecuteMagic.cs
+++ b/src/AzureClient/Magic/ExecuteMagic.cs
@@ -38,9 +38,9 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
                         The command waits a specified amount of time for the job to complete before returning.
 
                         The Azure Quantum workspace must have been previously initialized
-                        using the [`%azure.connect` magic command](https://docs.microsoft.com/qsharp/api/iqsharp-magic/azure.connect),
+                        using the [`%azure.connect` magic command]({KnownUris.ReferenceForMagicCommand("azure.connect")}),
                         and an execution target for the job must have been specified using the
-                        [`%azure.target` magic command](https://docs.microsoft.com/qsharp/api/iqsharp-magic/azure.target).
+                        [`%azure.target` magic command]({KnownUris.ReferenceForMagicCommand("azure.target")}).
 
                         #### Required parameters
 

--- a/src/AzureClient/Magic/JobsMagic.cs
+++ b/src/AzureClient/Magic/JobsMagic.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
                         have an ID, name, or target containing the provided filter parameter.
 
                         The Azure Quantum workspace must have been previously initialized
-                        using the [`%azure.connect` magic command](https://docs.microsoft.com/qsharp/api/iqsharp-magic/azure.connect).
+                        using the [`%azure.connect` magic command]({KnownUris.ReferenceForMagicCommand("azure.connect")}).
                         
                         #### Optional parameters
 

--- a/src/AzureClient/Magic/OutputMagic.cs
+++ b/src/AzureClient/Magic/OutputMagic.cs
@@ -42,13 +42,13 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
                         results.
 
                         The Azure Quantum workspace must have been previously initialized
-                        using the [`%azure.connect` magic command](https://docs.microsoft.com/qsharp/api/iqsharp-magic/azure.connect).
+                        using the [`%azure.connect` magic command]({KnownUris.ReferenceForMagicCommand("azure.connect")}.
                         
                         #### Optional parameters
 
                         - The job ID for which to display results. If not specified, the job ID from
-                        the most recent call to [`%azure.submit`](https://docs.microsoft.com/qsharp/api/iqsharp-magic/azure.submit)
-                        or [`%azure.execute`](https://docs.microsoft.com/qsharp/api/iqsharp-magic/azure.execute) will be used.
+                        the most recent call to [`%azure.submit`]({KnownUris.ReferenceForMagicCommand("azure.submit")}
+                        or [`%azure.execute`]({KnownUris.ReferenceForMagicCommand("azure.execute")} will be used.
                         
                         #### Possible errors
 

--- a/src/AzureClient/Magic/QuotaMagic.cs
+++ b/src/AzureClient/Magic/QuotaMagic.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
                         Azure Quantum workspace.
 
                         The Azure Quantum workspace must have been previously initialized
-                        using the [`%azure.connect` magic command](https://docs.microsoft.com/qsharp/api/iqsharp-magic/azure.connect).
+                        using the [`%azure.connect` magic command]({KnownUris.ReferenceForMagicCommand("azure.connect")}).
                                                 
                         #### Possible errors
 

--- a/src/AzureClient/Magic/StatusMagic.cs
+++ b/src/AzureClient/Magic/StatusMagic.cs
@@ -40,13 +40,13 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
                         Azure Quantum workspace.
 
                         The Azure Quantum workspace must have been previously initialized
-                        using the [`%azure.connect` magic command](https://docs.microsoft.com/qsharp/api/iqsharp-magic/azure.connect).
+                        using the [`%azure.connect` magic command]({KnownUris.ReferenceForMagicCommand("azure.connect")}).
                         
                         #### Optional parameters
 
                         - The job ID for which to display status. If not specified, the job ID from
-                        the most recent call to [`%azure.submit`](https://docs.microsoft.com/qsharp/api/iqsharp-magic/azure.submit)
-                        or [`%azure.execute`](https://docs.microsoft.com/qsharp/api/iqsharp-magic/azure.execute) will be used.
+                        the most recent call to [`%azure.submit`]({KnownUris.ReferenceForMagicCommand("azure.submit")})
+                        or [`%azure.execute`]({KnownUris.ReferenceForMagicCommand("azure.execute")}) will be used.
                         
                         #### Possible errors
 

--- a/src/AzureClient/Magic/SubmitMagic.cs
+++ b/src/AzureClient/Magic/SubmitMagic.cs
@@ -37,9 +37,9 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
                         The command returns immediately after the job is submitted.
 
                         The Azure Quantum workspace must have been previously initialized
-                        using the [`%azure.connect` magic command](https://docs.microsoft.com/qsharp/api/iqsharp-magic/azure.connect),
+                        using the [`%azure.connect` magic command]({KnownUris.ReferenceForMagicCommand("azure.connect")}),
                         and an execution target for the job must have been specified using the
-                        [`%azure.target` magic command](https://docs.microsoft.com/qsharp/api/iqsharp-magic/azure.target).
+                        [`%azure.target` magic command]({KnownUris.ReferenceForMagicCommand("azure.target")}).
 
                         #### Required parameters
 

--- a/src/AzureClient/Magic/TargetMagic.cs
+++ b/src/AzureClient/Magic/TargetMagic.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
                         in an Azure Quantum workspace.
 
                         The Azure Quantum workspace must have been previously initialized
-                        using the [`%azure.connect` magic command](https://docs.microsoft.com/qsharp/api/iqsharp-magic/azure.connect)
+                        using the [`%azure.connect` magic command]({KnownUris.ReferenceForMagicCommand("azure.connect")})
                         magic command. The specified execution target must be available in the workspace and support execution of Q# programs.
 
                         #### Optional parameters

--- a/src/Core/Properties/KnownUris.cs
+++ b/src/Core/Properties/KnownUris.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+/// <summary>
+///      URIs of well-known resources used across the IQ# project.
+/// </summary>
+public static class KnownUris
+{
+    /// <summary>
+    ///     The URI for the reference documentation for IQ# magic commands.
+    /// </summary>
+    public const string MagicCommandReference = "https://docs.microsoft.com/qsharp/api/iqsharp-magic/";
+
+    public static string ReferenceForMagicCommand(string commandName) =>
+        MagicCommandReference + commandName;
+}

--- a/src/Kernel/Extensions.cs
+++ b/src/Kernel/Extensions.cs
@@ -177,6 +177,29 @@ namespace Microsoft.Quantum.IQSharp.Kernel
             };
             return Task.Run(() => services.GetRequiredService<T>());
         }
+
+        internal static int EditDistanceFrom(this string s1, string s2)
+        {
+            // Uses the approach at
+            // https://github.com/dotnet/samples/blob/main/csharp/parallel/EditDistance/Program.cs.
+            var dist = new int[s1.Length + 1, s2.Length + 1];
+            for (int i = 0; i <= s1.Length; i++) dist[i, 0] = i;
+            for (int j = 0; j <= s2.Length; j++) dist[0, j] = j;
+
+            for (int i = 1; i <= s1.Length; i++)
+            {
+                for (int j = 1; j <= s2.Length; j++)
+                {
+                    dist[i, j] = (s1[i - 1] == s2[j - 1]) ?
+                        dist[i - 1, j - 1] :
+                        1 + System.Math.Min(dist[i - 1, j],
+                            System.Math.Min(dist[i, j - 1],
+                                            dist[i - 1, j - 1]));
+                }
+            }
+
+            return dist[s1.Length, s2.Length];
+        }
     }
 
 }

--- a/src/Kernel/IQSharpEngine.cs
+++ b/src/Kernel/IQSharpEngine.cs
@@ -358,7 +358,7 @@ namespace Microsoft.Quantum.IQSharp.Kernel
                     if (input.TrimStart().StartsWith("%") && input.Split("\n").Length == 1)
                     {
                         var attemptedMagic = input.Split(" ", 2)[0];
-                        var msg = $"No such magic command {attemptedMagic}.";
+                        channel.Stderr($"No such magic command {attemptedMagic}.");
                         if (MagicResolver is MagicSymbolResolver iqsResolver)
                         {
                             var similarMagic = iqsResolver
@@ -369,9 +369,9 @@ namespace Microsoft.Quantum.IQSharp.Kernel
                                 .OrderBy(pair => pair.Item2)
                                 .Take(3)
                                 .Select(symbol => symbol.Name);
-                            msg += $"\nPossibly similar magic commands:\n\t{string.Join(", ", similarMagic)}";
+                            channel.Stderr($"Possibly similar magic commands:\n{string.Join("\n", similarMagic.Select(m => $"- {m}"))}");
                         }
-                        channel.Stderr(msg + "\nTo get a list of all available magic commands, run %lsmagic, or visit https://docs.microsoft.com/qsharp/api/iqsharp-magic/.");
+                        channel.Stderr("To get a list of all available magic commands, run %lsmagic, or visit https://docs.microsoft.com/qsharp/api/iqsharp-magic/.");
                     }
                     else
                     {

--- a/src/Kernel/IQSharpEngine.cs
+++ b/src/Kernel/IQSharpEngine.cs
@@ -371,7 +371,7 @@ namespace Microsoft.Quantum.IQSharp.Kernel
                                 .Select(symbol => symbol.Name);
                             channel.Stderr($"Possibly similar magic commands:\n{string.Join("\n", similarMagic.Select(m => $"- {m}"))}");
                         }
-                        channel.Stderr("To get a list of all available magic commands, run %lsmagic, or visit https://docs.microsoft.com/qsharp/api/iqsharp-magic/.");
+                        channel.Stderr($"To get a list of all available magic commands, run %lsmagic, or visit {KnownUris.MagicCommandReference}.");
                     }
                     else
                     {

--- a/src/Kernel/Magic/LsMagicMagic.cs
+++ b/src/Kernel/Magic/LsMagicMagic.cs
@@ -37,10 +37,10 @@ namespace Microsoft.Quantum.IQSharp.Kernel
             new Microsoft.Jupyter.Core.Documentation
             {
                 Summary = "Returns a list of all currently available magic commands.",
-                Description = @"
+                Description = $@"
                     This magic command lists all of the magic commands available in the IQ# kernel,
                     as well as those defined in any packages that have been loaded in the current
-                    session via the [`%package` magic command](https://docs.microsoft.com/qsharp/api/iqsharp-magic/package).
+                    session via the [`%package` magic command]({KnownUris.ReferenceForMagicCommand("package")}).
                 ".Dedent(),
                 Examples = new []
                 {

--- a/src/Kernel/Magic/SimulateNoise.cs
+++ b/src/Kernel/Magic/SimulateNoise.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Quantum.Experimental
             new Microsoft.Jupyter.Core.Documentation
             {
                 Summary = "Runs a given function or operation on the OpenSystemsSimulator target machine.",
-                Description = @"
+                Description = $@"
                     > **⚠ WARNING:** This magic command is **experimental**,
                     > is not supported, and may be removed from future versions without notice.
 
@@ -43,8 +43,8 @@ namespace Microsoft.Quantum.Experimental
 
                     #### See also
 
-                    - [`%config`](https://docs.microsoft.com/qsharp/api/iqsharp-magic/config)
-                    - [`%experimental.noise_model`](https://docs.microsoft.com/qsharp/api/iqsharp-magic/experimental.noise_model)
+                    - [`%config`]({KnownUris.ReferenceForMagicCommand("config")})
+                    - [`%experimental.noise_model`]({KnownUris.ReferenceForMagicCommand("experimental.noise_model")})
 
                     #### Required parameters
 

--- a/src/Tests/IQsharpEngineTests.cs
+++ b/src/Tests/IQsharpEngineTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 using System;
@@ -18,10 +18,6 @@ using Microsoft.Quantum.IQSharp.ExecutionPathTracer;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Newtonsoft.Json;
 using Microsoft.Quantum.Experimental;
-using Microsoft.Quantum.IQSharp.AzureClient;
-using System.CodeDom.Compiler;
-using System.IO;
-using System.CodeDom;
 
 
 #pragma warning disable VSTHRD200 // Use "Async" suffix for async methods
@@ -716,7 +712,7 @@ namespace Tests.IQSharp
                 .UsingEngine()
                 .Input("%lsmagi")
                 .ExecutesWithError(containing:
-                    @"
+                    $@"
                         No such magic command %lsmagi.
 
                         Possibly similar magic commands:
@@ -724,7 +720,7 @@ namespace Tests.IQSharp
                         - %lsopen
                         - %debug
 
-                        To get a list of all available magic commands, run %lsmagic, or visit https://docs.microsoft.com/qsharp/api/iqsharp-magic/.
+                        To get a list of all available magic commands, run %lsmagic, or visit {KnownUris.MagicCommandReference}.
                     ".Dedent().Trim());
 
         [TestMethod]

--- a/src/Tests/IQsharpEngineTests.cs
+++ b/src/Tests/IQsharpEngineTests.cs
@@ -19,6 +19,9 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Newtonsoft.Json;
 using Microsoft.Quantum.Experimental;
 using Microsoft.Quantum.IQSharp.AzureClient;
+using System.CodeDom.Compiler;
+using System.IO;
+using System.CodeDom;
 
 
 #pragma warning disable VSTHRD200 // Use "Async" suffix for async methods
@@ -702,6 +705,27 @@ namespace Tests.IQSharp
             Assert.IsNotNull(resolver.Resolve("%azure.output"));
             Assert.IsNotNull(resolver.Resolve("%azure.jobs"));
         }
+
+        /// <summary>
+        ///     Checks that the hint provided to users when a magic command fails
+        ///     to resolve is correct.
+        /// </summary>
+        [TestMethod]
+        public async Task TestHintOnFailedMagic() =>
+            await Assert.That
+                .UsingEngine()
+                .Input("%lsmagi")
+                .ExecutesWithError(containing:
+                    @"
+                        No such magic command %lsmagi.
+
+                        Possibly similar magic commands:
+                        - %lsmagic
+                        - %lsopen
+                        - %debug
+
+                        To get a list of all available magic commands, run %lsmagic, or visit https://docs.microsoft.com/qsharp/api/iqsharp-magic/.
+                    ".Dedent().Trim());
 
         [TestMethod]
         public async Task TestDebugMagic()

--- a/src/Tests/TestExtensions.cs
+++ b/src/Tests/TestExtensions.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Microsoft.Jupyter.Core;
 using Microsoft.Quantum.IQSharp;
@@ -96,9 +97,16 @@ namespace Tests.IQSharp
             return input;
         }
 
-        internal static async Task<T> ExecutesWithError<T>(this Task<T> input, Func<List<string>, bool>? onErrors = null)
+        internal static async Task<T> ExecutesWithError<T>(this Task<T> input, Func<List<string>, bool>? where = null)
         where T: InputAssert =>
-            await (await input).ExecutesWithError(onErrors);
+            await (await input).ExecutesWithError(where);
+
+        internal static async Task<T> ExecutesWithError<T>(this Task<T> input, string containing)
+        where T: InputAssert =>
+            await input.ExecutesWithError(where: errors =>
+                string.Join(Environment.NewLine, errors)
+                      .NormalizeLineEndings()
+                      .Contains(containing.NormalizeLineEndings()));
 
         internal static async Task<T> ExecutesWithError<T>(this T input, Func<List<string>, bool>? onErrors = null)
         where T: InputAssert
@@ -195,6 +203,9 @@ namespace Tests.IQSharp
             );
             return assert;
         }
+
+        internal static string NormalizeLineEndings(this string s) =>
+            Regex.Replace(s, @"\r\n|\n\r|\n|\r", "\r\n");
 
     }
 


### PR DESCRIPTION
This PR fixes #478 by detecting when compilation errors likely came from an invalid magic command (single-line cell starting with `%` that doesn't resolve to a magic command), and providing additional feedback as available.