### PR TITLE
Fix #484

### DIFF
--- a/src/AzureClient/EntryPoint/EntryPointGenerator.cs
+++ b/src/AzureClient/EntryPoint/EntryPointGenerator.cs
@@ -118,7 +118,7 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
                 if (!workspaceAssemblies.Any() || logger.HasErrors)
                 {
                     Logger?.LogError($"Error compiling workspace.");
-                    throw new CompilationErrorsException(logger.Errors.ToArray());
+                    throw new CompilationErrorsException(logger);
                 }
 
                 WorkspaceAssemblies = workspaceAssemblies.ToArray();
@@ -135,7 +135,7 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
                 if (SnippetsAssemblyInfo == null || logger.HasErrors)
                 {
                     Logger?.LogError($"Error compiling snippets.");
-                    throw new CompilationErrorsException(logger.Errors.ToArray());
+                    throw new CompilationErrorsException(logger);
                 }
 
                 compilerMetadata = compilerMetadata.WithAssemblies(SnippetsAssemblyInfo);
@@ -154,7 +154,7 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
             if (EntryPointAssemblyInfo == null || logger.HasErrors)
             {
                 Logger?.LogError($"Error compiling entry point for operation {operationName}.");
-                throw new CompilationErrorsException(logger.Errors.ToArray());
+                throw new CompilationErrorsException(logger);
             }
 
             if (EntryPointAssemblyInfo.Operations.Count() <= 1)

--- a/src/AzureClient/EntryPoint/EntryPointGenerator.cs
+++ b/src/AzureClient/EntryPoint/EntryPointGenerator.cs
@@ -159,7 +159,14 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
 
             if (EntryPointAssemblyInfo.Operations.Count() <= 1)
             {
-                Logger?.LogWarning("Entry point assembly contained zero or one operations; this may indicate that C# code is not being correctly regenerated. At least two operations (the entry point and the operation called from the entry point) are expected.");
+                // Entry point assembly contained zero or one operations; this
+                // may indicate that C# code is not being correctly
+                // regenerated. At least two operations (the entry point and
+                // the operation called from the entry point) are expected.
+                Logger?.LogWarning(
+                    "Internal error compiling entry point for operation {OperationName}; entry point assembly did not contain the right number of operations. This should never happen, and most likely indicates a bug in IQ#. ",
+                    operationName
+                );
             }
 
             var entryPointOperations = EntryPointAssemblyInfo

--- a/src/AzureClient/Mocks/MockQuantumMachine.cs
+++ b/src/AzureClient/Mocks/MockQuantumMachine.cs
@@ -4,6 +4,7 @@
 #nullable enable
 
 using System;
+using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Quantum.Runtime;

--- a/src/Core/AssemblyInfo.cs
+++ b/src/Core/AssemblyInfo.cs
@@ -70,7 +70,7 @@ namespace Microsoft.Quantum.IQSharp
 
             // Parse the assembly headers to find which types are operation or function types.
             var logger = new QSharpLogger(null); 
-            var refs = ProjectManager.LoadReferencedAssemblies(new[] { Location }, d => logger.Log(d), ex => logger.Log(ex), ignoreDllResources:CompilerMetadata.LoadFromCsharp);
+            var refs = ProjectManager.LoadReferencedAssemblies(new[] { Location }, d => logger.Log(d), ex => logger.Log(ex), ignoreDllResources: false);
 
             var callables = refs.SelectMany(pair => pair.Value.Callables);
 

--- a/src/Core/Compiler/CompilerMetadata.cs
+++ b/src/Core/Compiler/CompilerMetadata.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Quantum.IQSharp
 {
     public class CompilerMetadata
     {
-        internal static readonly bool LoadFromCsharp = true; // todo: we should make this properly configurable
+        internal static readonly bool LoadFromCsharp = false; // todo: we should make this properly configurable
 
         private IEnumerable<String> Paths { get; }
 
@@ -96,7 +96,7 @@ namespace Microsoft.Quantum.IQSharp
         /// Calculates Q# metadata needed for all the Assemblies and their dependencies.
         /// </summary>
         private static QsReferences QsInit(IEnumerable<string> paths) =>
-            new QsReferences(ProjectManager.LoadReferencedAssemblies(paths, ignoreDllResources:CompilerMetadata.LoadFromCsharp));
+            new QsReferences(ProjectManager.LoadReferencedAssemblies(paths, ignoreDllResources: false));
 
         public CompilerMetadata WithAssemblies(params AssemblyInfo[] assemblies)
         {

--- a/src/Core/Compiler/CompilerService.cs
+++ b/src/Core/Compiler/CompilerService.cs
@@ -26,6 +26,7 @@ using Microsoft.Quantum.QsCompiler.SyntaxTokens;
 using Microsoft.Quantum.QsCompiler.SyntaxTree;
 using Microsoft.Quantum.QsCompiler.Transformations.BasicTransformations;
 using Microsoft.Quantum.QsCompiler.Transformations.QsCodeOutput;
+using Microsoft.Quantum.QsCompiler.Transformations.BasicTransformations;
 using Microsoft.Quantum.QsCompiler.Transformations.SyntaxTreeTrimming;
 using Microsoft.Quantum.QsCompiler.Transformations.Targeting;
 using QsReferences = Microsoft.Quantum.QsCompiler.CompilationBuilder.References;
@@ -137,7 +138,7 @@ namespace Microsoft.Quantum.IQSharp
             var loadOptions = new CompilationLoader.Configuration
             {
                 GenerateFunctorSupport = true,
-                LoadReferencesBasedOnGeneratedCsharp = string.IsNullOrEmpty(executionTarget), // deserialization of resources in references is only needed if there is an execution target
+                LoadReferencesBasedOnGeneratedCsharp = false, // deserialization of resources in references is only needed if there is an execution target
                 IsExecutable = compileAsExecutable,
                 AssemblyConstants = new Dictionary<string, string> { [AssemblyConstants.ProcessorArchitecture] = executionTarget ?? string.Empty },
                 RuntimeCapability = runtimeCapability ?? RuntimeCapability.FullComputation
@@ -165,7 +166,7 @@ namespace Microsoft.Quantum.IQSharp
                 }}";
 
             var sources = new Dictionary<Uri, string>() {{ entryPointUri, entryPointSnippet }}.ToImmutableDictionary();
-            return BuildAssembly(sources, metadatas, logger, dllName, compileAsExecutable: true, executionTarget, runtimeCapability);
+            return BuildAssembly(sources, metadatas, logger, dllName, compileAsExecutable: true, executionTarget, runtimeCapability, regenerateAll: true);
         }
 
         /// <summary>
@@ -214,7 +215,7 @@ namespace Microsoft.Quantum.IQSharp
         /// Builds the corresponding .net core assembly from the Q# syntax tree.
         /// </summary>
         private AssemblyInfo? BuildAssembly(ImmutableDictionary<Uri, string> sources, CompilerMetadata metadata, QSharpLogger logger, string dllName, bool compileAsExecutable, string? executionTarget,
-            RuntimeCapability? runtimeCapability = null)
+            RuntimeCapability? runtimeCapability = null, bool regenerateAll = false)
         {
             logger.LogDebug($"Compiling the following Q# files: {string.Join(",", sources.Keys.Select(f => f.LocalPath))}");
 
@@ -229,16 +230,20 @@ namespace Microsoft.Quantum.IQSharp
             {
                 // Generate C# simulation code from Q# syntax tree and convert it into C# syntax trees:
                 var trees = new List<CodeAnalysis.SyntaxTree>();
-                foreach (var file in sources.Keys)
+                var allSources = regenerateAll
+                    ? GetSourceFiles.Apply(qsCompilation.Namespaces)
+                    : sources.Keys.Select(
+                        file => CompilationUnitManager.GetFileId(file)
+                      );
+                foreach (var file in allSources)
                 {
-                    var sourceFile = CompilationUnitManager.GetFileId(file);
                     var codegenContext = string.IsNullOrEmpty(executionTarget)
                         ? CodegenContext.Create(qsCompilation.Namespaces)
                         : CodegenContext.Create(qsCompilation.Namespaces, new Dictionary<string, string>() { { AssemblyConstants.ExecutionTarget, executionTarget } });
-                    var code = SimulationCode.generate(sourceFile, codegenContext);
+                    var code = SimulationCode.generate(file, codegenContext);
                     var tree = CSharpSyntaxTree.ParseText(code, encoding: UTF8Encoding.UTF8);
                     trees.Add(tree);
-                    logger.LogDebug($"Generated the following C# code for {sourceFile}:\n=============\n{code}\n=============\n");
+                    logger.LogDebug($"Generated the following C# code for {file}:\n=============\n{code}\n=============\n");
                 }
 
                 // Compile the C# syntax trees:
@@ -250,30 +255,30 @@ namespace Microsoft.Quantum.IQSharp
                     metadata.RoslynMetadatas,
                     options);
 
-                var fromSources = qsCompilation.Namespaces.Select(ns => FilterBySourceFile.Apply(ns, s => s.EndsWith(".qs")));
+                var fromSources = regenerateAll
+                                  ? qsCompilation.Namespaces
+                                  : qsCompilation.Namespaces.Select(ns => FilterBySourceFile.Apply(ns, s => s.EndsWith(".qs")));
 
                 // Only create the serialization if we aren't compiling for an execution target:
                 List<ResourceDescription>? manifestResources = null;
-                if (string.IsNullOrEmpty(executionTarget))
+                
+                // Generate the assembly from the C# compilation:
+                var syntaxTree = new QsCompilation(fromSources.ToImmutableArray(), qsCompilation.EntryPoints);
+
+                using var serializedCompilation = new MemoryStream();
+                if (!CompilationLoader.WriteBinary(syntaxTree, serializedCompilation))
                 {
-                    // Generate the assembly from the C# compilation:
-                    var syntaxTree = new QsCompilation(fromSources.ToImmutableArray(), qsCompilation.EntryPoints);
-
-                    using var serializedCompilation = new MemoryStream();
-                    if (!CompilationLoader.WriteBinary(syntaxTree, serializedCompilation))
-                    {
-                        logger.LogError("IQS005", "Failed to write compilation to binary stream.");
-                        return null;
-                    }
-
-                    manifestResources = new List<ResourceDescription>() {
-                        new ResourceDescription(
-                            resourceName: DotnetCoreDll.SyntaxTreeResourceName,
-                            dataProvider: () => new MemoryStream(serializedCompilation.ToArray()),
-                            isPublic: true
-                        )
-                    };
+                    logger.LogError("IQS005", "Failed to write compilation to binary stream.");
+                    return null;
                 }
+
+                manifestResources = new List<ResourceDescription>() {
+                    new ResourceDescription(
+                        resourceName: DotnetCoreDll.SyntaxTreeResourceName,
+                        dataProvider: () => new MemoryStream(serializedCompilation.ToArray()),
+                        isPublic: true
+                    )
+                };
 
                 using var ms = new MemoryStream();
                 var result = compilation.Emit(ms, manifestResources: manifestResources);

--- a/src/Core/Compiler/CompilerService.cs
+++ b/src/Core/Compiler/CompilerService.cs
@@ -259,7 +259,6 @@ namespace Microsoft.Quantum.IQSharp
                                   ? qsCompilation.Namespaces
                                   : qsCompilation.Namespaces.Select(ns => FilterBySourceFile.Apply(ns, s => s.EndsWith(".qs")));
 
-                // Only create the serialization if we aren't compiling for an execution target:
                 List<ResourceDescription>? manifestResources = null;
                 
                 // Generate the assembly from the C# compilation:

--- a/src/Core/Compiler/CompilerService.cs
+++ b/src/Core/Compiler/CompilerService.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -25,6 +26,8 @@ using Microsoft.Quantum.QsCompiler.SyntaxTokens;
 using Microsoft.Quantum.QsCompiler.SyntaxTree;
 using Microsoft.Quantum.QsCompiler.Transformations.BasicTransformations;
 using Microsoft.Quantum.QsCompiler.Transformations.QsCodeOutput;
+using Microsoft.Quantum.QsCompiler.Transformations.SyntaxTreeTrimming;
+using Microsoft.Quantum.QsCompiler.Transformations.Targeting;
 using QsReferences = Microsoft.Quantum.QsCompiler.CompilationBuilder.References;
 
 
@@ -249,9 +252,9 @@ namespace Microsoft.Quantum.IQSharp
 
                 var fromSources = qsCompilation.Namespaces.Select(ns => FilterBySourceFile.Apply(ns, s => s.EndsWith(".qs")));
 
-                // Only create the serialization if we are compiling for an execution target:
+                // Only create the serialization if we aren't compiling for an execution target:
                 List<ResourceDescription>? manifestResources = null;
-                if (!string.IsNullOrEmpty(executionTarget))
+                if (string.IsNullOrEmpty(executionTarget))
                 {
                     // Generate the assembly from the C# compilation:
                     var syntaxTree = new QsCompilation(fromSources.ToImmutableArray(), qsCompilation.EntryPoints);
@@ -265,7 +268,7 @@ namespace Microsoft.Quantum.IQSharp
 
                     manifestResources = new List<ResourceDescription>() {
                         new ResourceDescription(
-                            resourceName: DotnetCoreDll.ResourceNameQsDataBondV1,
+                            resourceName: DotnetCoreDll.SyntaxTreeResourceName,
                             dataProvider: () => new MemoryStream(serializedCompilation.ToArray()),
                             isPublic: true
                         )

--- a/src/Core/Exceptions/CompilationErrorsException.cs
+++ b/src/Core/Exceptions/CompilationErrorsException.cs
@@ -3,17 +3,28 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
+using Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.Quantum.IQSharp.Common
 {
     public class CompilationErrorsException : InvalidOperationException
     {
-        public CompilationErrorsException(string[] errors) : base("Invalid snippet code")
+        public CompilationErrorsException(QSharpLogger logger) : this(
+            logger.Errors.ToArray(),
+            logger.Logs.ToArray()
+        )
+        {
+        }
+
+        public CompilationErrorsException(string[] errors, Diagnostic[] diagnostics) : base("Invalid snippet code")
         {
             this.Errors = errors;
+            this.Diagnostics = diagnostics;
         }
 
         public string[] Errors { get; }
+        public Diagnostic[] Diagnostics { get; }
     }
 }

--- a/src/Core/Loggers/QsharpLogger.cs
+++ b/src/Core/Loggers/QsharpLogger.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Quantum.IQSharp.Common
                 .Exists(m => m.Severity == LSP.DiagnosticSeverity.Error);
 
         public System.Func<LSP.Diagnostic, string> Format => 
-            QsCompiler.Diagnostics.Formatting.MsBuildFormat; 
+            QsCompiler.Diagnostics.Formatting.HumanReadableFormat; 
 
         public virtual IEnumerable<string> Messages =>
             this.Logs.Select(Format);
@@ -81,7 +81,7 @@ namespace Microsoft.Quantum.IQSharp.Common
             if (m.IsError() && ErrorCodesToIgnore.Any(code => m.Code == QsCompiler.CompilationBuilder.Errors.Code(code))) return;
             if (m.IsWarning() && WarningCodesToIgnore.Any(code => m.Code == QsCompiler.CompilationBuilder.Warnings.Code(code))) return;
 
-            Logger?.Log(MapLevel(m.Severity), $"{m.Code}: {m.Message}");
+            Logger?.Log(MapLevel(m.Severity), "{Code} ({Source}:{Range}): {Message}", m.Code, m.Source, m.Range, m.Message);
             Logs.Add(m);
         }
 

--- a/src/Core/Snippets/Snippets.cs
+++ b/src/Core/Snippets/Snippets.cs
@@ -157,7 +157,7 @@ namespace Microsoft.Quantum.IQSharp
 
                 if (logger.HasErrors)
                 {
-                    throw new CompilationErrorsException(logger.Errors.ToArray());
+                    throw new CompilationErrorsException(logger);
                 }
 
                 foreach (var entry in Compiler.IdentifyOpenedNamespaces(code))

--- a/src/Kernel/IQSharpEngine.cs
+++ b/src/Kernel/IQSharpEngine.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using System;

--- a/src/Kernel/IQSharpEngine.cs
+++ b/src/Kernel/IQSharpEngine.cs
@@ -74,6 +74,7 @@ namespace Microsoft.Quantum.IQSharp.Kernel
                 // do not contain any quantum code.
                 "NumSharp.Core",
                 "Newtonsoft.Json",
+                "Microsoft.CodeAnalysis.CSharp.resources",
 
                 // These assemblies are part of the Quantum Development Kit
                 // built before IQ# (in dependency ordering), and thus cannot

--- a/src/Kernel/IQSharpEngine.cs
+++ b/src/Kernel/IQSharpEngine.cs
@@ -55,6 +55,15 @@ namespace Microsoft.Quantum.IQSharp.Kernel
         private TaskCompletionSource<bool> initializedSource = new TaskCompletionSource<bool>();
 
         /// <summary>
+        ///     Internal-only method for getting services used by this engine.
+        ///     Mainly useful in unit tests, where internal state of the
+        ///     engine may need to be tested to properly mock communications
+        ///     with Azure services.
+        /// </summary>
+        internal async Task<TService> GetEngineService<TService>() =>
+            await services.GetRequiredServiceInBackground<TService>();
+
+        /// <summary>
         ///     The simple names of those assemblies which do not need to be
         ///     searched for display encoders or magic commands.
         /// </summary>

--- a/src/Kernel/Magic/Resolution/MagicResolver.cs
+++ b/src/Kernel/Magic/Resolution/MagicResolver.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Quantum.IQSharp.Kernel
     public class MagicSymbolResolver : IMagicSymbolResolver
     {
         private AssemblyInfo[] kernelAssemblies;
-        private Dictionary<AssemblyName, MagicSymbol[]> cache;
+        private Dictionary<string, MagicSymbol[]> cache;
         private IServiceProvider services;
         private IReferences references;
         private IWorkspace workspace;
@@ -40,7 +40,7 @@ namespace Microsoft.Quantum.IQSharp.Kernel
         /// </summary>
         public MagicSymbolResolver(IServiceProvider services, ILogger<MagicSymbolResolver> logger, IEventService eventService)
         {
-            this.cache = new Dictionary<AssemblyName, MagicSymbol[]>();
+            this.cache = new Dictionary<string, MagicSymbol[]>();
             this.logger = logger;
 
             this.kernelAssemblies = new[]
@@ -118,14 +118,15 @@ namespace Microsoft.Quantum.IQSharp.Kernel
             var result = new MagicSymbol[0];
             // If the assembly cannot possibly contain magic symbols, skip it
             // here.
-            if (IQSharpEngine.MundaneAssemblies.Contains(assm.Assembly.GetName().Name))
+            var name = assm.Assembly.GetName().Name;
+            if (name.StartsWith("System.") || IQSharpEngine.MundaneAssemblies.Contains(name))
             {
                 return result;
             }
 
             lock (cache)
             {
-                if (cache.TryGetValue(assm.Assembly.GetName(), out result))
+                if (cache.TryGetValue(assm.Assembly.FullName, out result))
                 {
                     return result;
                 }
@@ -189,7 +190,7 @@ namespace Microsoft.Quantum.IQSharp.Kernel
 
                 logger.LogInformation("Took {Elapsed} to scan {Assembly} for magic symbols.", stopwatch.Elapsed, assm.Assembly.FullName);
                 result = allMagic.ToArray();
-                cache[assm.Assembly.GetName()] = result;
+                cache[assm.Assembly.FullName] = result;
             }
 
             return result;

--- a/src/Kernel/Magic/Resolution/MagicResolver.cs
+++ b/src/Kernel/Magic/Resolution/MagicResolver.cs
@@ -142,7 +142,7 @@ namespace Microsoft.Quantum.IQSharp.Kernel
                         .GetTypes()
                         .Where(t =>
                         {
-                            if (!t.IsClass && t.IsAbstract) { return false; }
+                            if (!t.IsClass || t.IsAbstract) { return false; }
                             var matched = t.IsSubclassOf(typeof(MagicSymbol));
 
                             // This logging statement is expensive, so we only run it when we need to for debugging.

--- a/src/Tests/AzureClientEntryPointTests.cs
+++ b/src/Tests/AzureClientEntryPointTests.cs
@@ -14,6 +14,7 @@ using Microsoft.Quantum.IQSharp.Common;
 using Microsoft.Quantum.IQSharp.Jupyter;
 using Microsoft.Quantum.QsCompiler.ReservedKeywords;
 using Microsoft.Quantum.Simulation.Common;
+using Microsoft.Quantum.Simulation.Core;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Tests.IQSharp
@@ -41,9 +42,19 @@ namespace Tests.IQSharp
             var entryPoint = entryPointGenerator.Generate("HelloQ", null);
             // Check that snippets compiled from entry points have the
             // syntax trees that we need to generate classical control from.
+            Assert.That.Assembly(entryPointGenerator.EntryPointAssemblyInfo).HasResource(DotnetCoreDll.SyntaxTreeResourceName);
+            Assert.That.Assembly(entryPointGenerator.SnippetsAssemblyInfo).HasResource(DotnetCoreDll.SyntaxTreeResourceName);
+            foreach (var refAsm in entryPointGenerator.References.Assemblies)
+            {
+                System.Console.WriteLine($"Assembly {refAsm.Assembly.GetName().Name} has {refAsm.Assembly.CustomAttributes.Count(attr => attr.AttributeType == typeof(CallableDeclarationAttribute))} callable declarations...");
+                if (refAsm.Assembly.CustomAttributes.Any(attr => attr.AttributeType == typeof(CallableDeclarationAttribute)))
+                {
+                    Assert.That.Assembly(refAsm).HasResource(DotnetCoreDll.SyntaxTreeResourceName);
+                }
+            }
             foreach (var asm in entryPointGenerator.WorkspaceAssemblies)
             {
-                Assert.That.Assembly(asm.Assembly).HasResource(DotnetCoreDll.SyntaxTreeResourceName);
+                Assert.That.Assembly(asm).HasResource(DotnetCoreDll.SyntaxTreeResourceName);
             }
             Assert.IsNotNull(entryPoint);
 

--- a/src/Tests/AzureClientEntryPointTests.cs
+++ b/src/Tests/AzureClientEntryPointTests.cs
@@ -12,6 +12,7 @@ using Microsoft.Quantum.IQSharp;
 using Microsoft.Quantum.IQSharp.AzureClient;
 using Microsoft.Quantum.IQSharp.Common;
 using Microsoft.Quantum.IQSharp.Jupyter;
+using Microsoft.Quantum.QsCompiler.ReservedKeywords;
 using Microsoft.Quantum.Simulation.Common;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -38,6 +39,12 @@ namespace Tests.IQSharp
         {
             var entryPointGenerator = Init("Workspace", new string[] { SNIPPETS.HelloQ });
             var entryPoint = entryPointGenerator.Generate("HelloQ", null);
+            // Check that snippets compiled from entry points have the
+            // syntax trees that we need to generate classical control from.
+            foreach (var asm in entryPointGenerator.WorkspaceAssemblies)
+            {
+                Assert.That.Assembly(asm.Assembly).HasResource(DotnetCoreDll.SyntaxTreeResourceName);
+            }
             Assert.IsNotNull(entryPoint);
 
             var job = await entryPoint.SubmitAsync(

--- a/src/Tests/AzureClientEntryPointTests.cs
+++ b/src/Tests/AzureClientEntryPointTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 #nullable enable
@@ -40,13 +40,27 @@ namespace Tests.IQSharp
         {
             var entryPointGenerator = Init("Workspace", new string[] { SNIPPETS.HelloQ });
             var entryPoint = entryPointGenerator.Generate("HelloQ", null);
-            // Check that snippets compiled from entry points have the
-            // syntax trees that we need to generate classical control from.
-            Assert.That.Assembly(entryPointGenerator.EntryPointAssemblyInfo).HasResource(DotnetCoreDll.SyntaxTreeResourceName);
+
+            Assert.IsTrue(
+                entryPointGenerator.EntryPointAssemblyInfo.Operations.Count() >= 3,
+                "Generated entry point assembly only had 0, 1, or 2 operations, but we expect at least three when C# code is properly regenerated."
+            );
+
+            Assert.That.Assembly(entryPointGenerator.EntryPointAssemblyInfo)
+                // Check that snippets compiled from entry points have the
+                // syntax trees that we need to generate classical control from.
+                .HasResource(DotnetCoreDll.SyntaxTreeResourceName)
+                // Make sure that the two particular operations we expect are both there.
+                .HasOperation("ENTRYPOINT", "HelloQ")
+                .HasOperation(Snippets.SNIPPETS_NAMESPACE, "HelloQ")
+                // Since HelloQ calls Message, that function should also be regenerated.
+                .HasOperation("Microsoft.Quantum.Intrinsic", "Message");
+
+            // We also want to make sure that all other relevant assemblies
+            // have the right resource attached.
             Assert.That.Assembly(entryPointGenerator.SnippetsAssemblyInfo).HasResource(DotnetCoreDll.SyntaxTreeResourceName);
             foreach (var refAsm in entryPointGenerator.References.Assemblies)
             {
-                System.Console.WriteLine($"Assembly {refAsm.Assembly.GetName().Name} has {refAsm.Assembly.CustomAttributes.Count(attr => attr.AttributeType == typeof(CallableDeclarationAttribute))} callable declarations...");
                 if (refAsm.Assembly.CustomAttributes.Any(attr => attr.AttributeType == typeof(CallableDeclarationAttribute)))
                 {
                     Assert.That.Assembly(refAsm).HasResource(DotnetCoreDll.SyntaxTreeResourceName);
@@ -56,6 +70,8 @@ namespace Tests.IQSharp
             {
                 Assert.That.Assembly(asm).HasResource(DotnetCoreDll.SyntaxTreeResourceName);
             }
+
+
             Assert.IsNotNull(entryPoint);
 
             var job = await entryPoint.SubmitAsync(

--- a/src/Tests/IQsharpEngineTests.cs
+++ b/src/Tests/IQsharpEngineTests.cs
@@ -917,11 +917,17 @@ namespace Tests.IQSharp
                 .Input("%azure.target ionq.mock")
                     .ExecutesSuccessfully()
                 .Input("%azure.submit RunTeleport")
-                    .ExecutesWithError(errors => errors.Contains(
-                        "The Q# operation RunTeleport could not be compiled as an entry point for job execution."
+                    .ExecutesWithError(errors => errors.Any(error =>
+                        // Use StartsWith to avoid mismatching on newlines at
+                        // the end.
+                        error.StartsWith(
+                            "The Q# operation RunTeleport could not be " +
+                            "compiled as an entry point for job execution."
+                        )
                     ));
         }
     }
 }
+
 #pragma warning restore VSTHRD200 // Use "Async" suffix for async methods
 #pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously

--- a/src/Tests/IQsharpEngineTests.cs
+++ b/src/Tests/IQsharpEngineTests.cs
@@ -18,6 +18,7 @@ using Microsoft.Quantum.IQSharp.ExecutionPathTracer;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Newtonsoft.Json;
 using Microsoft.Quantum.Experimental;
+using Microsoft.Quantum.IQSharp.AzureClient;
 
 
 #pragma warning disable VSTHRD200 // Use "Async" suffix for async methods
@@ -25,76 +26,6 @@ using Microsoft.Quantum.Experimental;
 
 namespace Tests.IQSharp
 {
-    internal static class TestExtensions
-    {
-        internal class InputAssert : UsingEngineAssert
-        {
-            internal string Code;
-            internal int? CursorPos;
-        }
-
-        internal class UsingEngineAssert
-        {
-            internal IQSharpEngine Engine;
-        }
-
-        internal static void AssertIsOk(this ExecutionResult response) =>
-            Assert.AreEqual(ExecuteStatus.Ok, response.Status, $"Response was not marked as Ok.\n\tActual status: {response.Status}\n\tResponse output: {response.Output}");
-
-
-        internal async static Task<InputAssert> Input<T>(this Task<T> assert, string code, int? cursorPos = null)
-        where T: UsingEngineAssert =>
-            (await assert).Input(code, cursorPos);
-
-        internal static InputAssert Input(this UsingEngineAssert assert, string code, int? cursorPos = null) =>
-            new InputAssert
-            {
-                Code = code,
-                CursorPos = cursorPos,
-                Engine = assert.Engine
-            };
-
-        internal static UsingEngineAssert UsingEngine(this Assert _, IQSharpEngine engine) =>
-            new UsingEngineAssert
-            {
-                Engine = engine
-            };
-
-        internal static async Task<UsingEngineAssert> UsingEngine(this Assert assert) =>
-            assert.UsingEngine(await IQSharpEngineTests.Init());
-
-        internal static async Task<T> CompletesTo<T>(this Task<T> input, params string[] expectedCompletions)
-        where T: InputAssert =>
-            await (await input).CompletesTo(expectedCompletions);
-
-        internal static async Task<T> CompletesTo<T>(this T input, params string[] expectedCompletions)
-        where T: InputAssert
-        {
-            var actualCompletions = await input.Engine.Complete(input.Code, input.CursorPos ?? 0);
-            Assert.IsNotNull(actualCompletions, "Engine returned null for completions.");
-            Assert.IsNotNull(actualCompletions.Value.Matches, "Engine returned completions with null matches.");
-
-            var actualMatches = actualCompletions.Value.Matches.OrderBy(match => match).ToList();
-            var expectedMatches = expectedCompletions.OrderBy(match => match).ToList();
-
-            try
-            {
-                Assert.AreEqual(actualMatches.Count, expectedMatches.Count);
-                foreach (var (actual, expected) in actualMatches.Zip(expectedMatches))
-                {
-                    Assert.AreEqual(actual, expected);
-                }
-            }
-            catch (AssertFailedException ex)
-            {
-                var message = $"Expected completions [{string.Join(", ", expectedMatches)}], but engine returned completions [{string.Join(", ", actualMatches)}]";
-                throw new AssertFailedException(message, ex);
-            }
-
-            return input;
-        }
-    }
-
     [TestClass]
     public class IQSharpEngineTests
     {
@@ -937,6 +868,58 @@ namespace Tests.IQSharp
                     }
                 }
             ), 2);
+        }
+
+        [TestMethod]
+        public async Task CompileAndSubmitWithClassicalControl()
+        {
+            const string source = @"
+                open Microsoft.Quantum.Measurement;
+
+                operation PrepareBellPair(left : Qubit, right : Qubit) : Unit is Adj + Ctl {
+                    H(left);
+                    CNOT(left, right);
+                }
+
+                operation Teleport(msg : Qubit, target : Qubit) : Unit {
+                    use register = Qubit();
+
+                    PrepareBellPair(register, target);
+                    Adjoint PrepareBellPair(msg, register);
+
+                    if MResetZ(msg) == One      { Z(target); }
+                    if MResetZ(register) == One { X(target); }
+                }
+
+                operation RunTeleport() : Unit {
+                    use left = Qubit();
+                    use right = Qubit();
+
+                    H(left);
+                    Teleport(left, right);
+                    H(right);
+
+                    if M(right) == One {
+                        fail ""Got wrong output from teleportation."";
+                    }
+                }
+            ";
+
+            var engineInput = await Assert.That
+                .UsingEngine()
+                .Input(source)
+                    .ExecutesSuccessfully()
+                .WithMockAzure()
+                .Input("%azure.target honeywell.mock")
+                    .ExecutesSuccessfully()
+                .Input("%azure.submit RunTeleport")
+                    .ExecutesSuccessfully()
+                .Input("%azure.target ionq.mock")
+                    .ExecutesSuccessfully()
+                .Input("%azure.submit RunTeleport")
+                    .ExecutesWithError(errors => errors.Contains(
+                        "The Q# operation RunTeleport could not be compiled as an entry point for job execution."
+                    ));
         }
     }
 }

--- a/src/Tests/TestExtensions.cs
+++ b/src/Tests/TestExtensions.cs
@@ -29,6 +29,7 @@ namespace Tests.IQSharp
         {
             internal IQSharpEngine Engine;
         }
+
         internal static async Task<T> WithMockAzure<T>(this Task<T> engine)
         where T: UsingEngineAssert
         {

--- a/src/Tests/TestExtensions.cs
+++ b/src/Tests/TestExtensions.cs
@@ -1,0 +1,186 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+using Microsoft.Jupyter.Core;
+using Microsoft.Quantum.IQSharp.AzureClient;
+using Microsoft.Quantum.IQSharp.Kernel;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Tests.IQSharp
+{
+    
+    internal static class TestExtensions
+    {
+        internal class InputAssert : UsingEngineAssert
+        {
+            internal string Code;
+            internal int? CursorPos;
+        }
+
+        internal class UsingEngineAssert
+        {
+            internal IQSharpEngine Engine;
+        }
+        internal static async Task<T> WithMockAzure<T>(this Task<T> engine)
+        where T: UsingEngineAssert
+        {
+            // Start by connecting using the mock connection string.
+            await engine
+                .Input("%azure.connect subscription=TEST_SUBSCRIPTION_ID resourceGroup=TEST_RESOURCE_GROUP_NAME workspace=NameWithMockProviders storage=TEST_CONNECTION_STRING")
+                .ExecutesSuccessfully();
+            var client = await (await engine).Engine.GetEngineService<IAzureClient>();
+            if (client is AzureClient azureClient && azureClient.ActiveWorkspace is MockAzureWorkspace workspace)
+            {
+                workspace.AddProviders("ionq", "honeywell");
+            }
+            else
+            {
+                throw new Exception("Expected a mock workspace to be set as the active Azure workspace.");
+            }
+            return await engine;
+        }
+
+        internal static void AssertIsOk(this ExecutionResult response) =>
+            Assert.AreEqual(ExecuteStatus.Ok, response.Status, $"Response was not marked as Ok.\n\tActual status: {response.Status}\n\tResponse output: {response.Output}");
+
+
+        internal async static Task<InputAssert> Input<T>(this Task<T> assert, string code, int? cursorPos = null)
+        where T: UsingEngineAssert =>
+            (await assert).Input(code, cursorPos);
+
+        internal static InputAssert Input(this UsingEngineAssert assert, string code, int? cursorPos = null) =>
+            new InputAssert
+            {
+                Code = code,
+                CursorPos = cursorPos,
+                Engine = assert.Engine
+            };
+
+        internal static UsingEngineAssert UsingEngine(this Assert _, IQSharpEngine engine) =>
+            new UsingEngineAssert
+            {
+                Engine = engine
+            };
+
+        internal static async Task<UsingEngineAssert> UsingEngine(this Assert assert) =>
+            assert.UsingEngine(await IQSharpEngineTests.Init());
+
+        internal static async Task<T> ExecutesSuccessfully<T>(this Task<T> input)
+        where T: InputAssert =>
+            await (await input).ExecutesSuccessfully();
+
+        internal static async Task<T> ExecutesSuccessfully<T>(this T input)
+        where T: InputAssert
+        {
+            var channel = new MockChannel();
+            var result = await input.Engine.Execute(input.Code, channel);
+            try
+            {
+                Assert.AreEqual(result.Status, ExecuteStatus.Ok);
+            }
+            catch (AssertFailedException ex)
+            {
+                var msg = $"Cell did not execute successfully.\nOutput: \n{result.Output}\nStatus: {result.Status}\nException:\n{ex}\nCode:\n{input.Code}\n\nErrors:\n{string.Join("\n", channel.errors)}";
+                throw new AssertFailedException(msg, ex);
+            }
+
+            return input;
+        }
+
+        internal static async Task<T> ExecutesWithError<T>(this Task<T> input, Func<List<string>, bool>? onErrors = null)
+        where T: InputAssert =>
+            await (await input).ExecutesWithError(onErrors);
+
+        internal static async Task<T> ExecutesWithError<T>(this T input, Func<List<string>, bool>? onErrors = null)
+        where T: InputAssert
+        {
+            var channel = new MockChannel();
+            var result = await input.Engine.Execute(input.Code, channel);
+            try
+            {
+                Assert.AreEqual(result.Status, ExecuteStatus.Error);
+            }
+            catch (AssertFailedException ex)
+            {
+                var msg = $"Cell did not result in an error.\nOutput: \n{result.Output}\nStatus: {result.Status}\nException:\n{ex}\nCode:\n{input.Code}\n\nErrors:\n{string.Join("\n", channel.errors)}";
+                throw new AssertFailedException(msg, ex);
+            }
+
+            if (onErrors != null)
+            {
+                try
+                {
+                    Assert.IsTrue(onErrors(channel.errors));
+                }
+                catch (AssertFailedException ex)
+                {
+                    var msg = $"Cell errors did not meet conditions specified by `onErrors`.\nOutput: \n{result.Output}\nStatus: {result.Status}\nException:\n{ex}\nCode:\n{input.Code}\n\nErrors:\n{string.Join("\n", channel.errors)}";
+                    throw new AssertFailedException(msg, ex);
+                }
+            }
+
+            return input;
+        }
+
+        internal static async Task<T> CompletesTo<T>(this Task<T> input, params string[] expectedCompletions)
+        where T: InputAssert =>
+            await (await input).CompletesTo(expectedCompletions);
+
+        internal static async Task<T> CompletesTo<T>(this T input, params string[] expectedCompletions)
+        where T: InputAssert
+        {
+            var actualCompletions = await input.Engine.Complete(input.Code, input.CursorPos ?? 0);
+            Assert.IsNotNull(actualCompletions, "Engine returned null for completions.");
+            Assert.IsNotNull(actualCompletions.Value.Matches, "Engine returned completions with null matches.");
+
+            var actualMatches = actualCompletions.Value.Matches.OrderBy(match => match).ToList();
+            var expectedMatches = expectedCompletions.OrderBy(match => match).ToList();
+
+            try
+            {
+                Assert.AreEqual(actualMatches.Count, expectedMatches.Count);
+                foreach (var (actual, expected) in actualMatches.Zip(expectedMatches))
+                {
+                    Assert.AreEqual(actual, expected);
+                }
+            }
+            catch (AssertFailedException ex)
+            {
+                var message = $"Expected completions [{string.Join(", ", expectedMatches)}], but engine returned completions [{string.Join(", ", actualMatches)}]";
+                throw new AssertFailedException(message, ex);
+            }
+
+            return input;
+        }
+
+        internal class AssemblyAssert
+        {
+            internal Assembly Assembly;
+        }
+
+        internal static AssemblyAssert Assembly(this Assert assert, Assembly assembly) =>
+            new AssemblyAssert
+            {
+                Assembly = assembly
+            };
+
+        internal static T HasResource<T>(this T assert, string resourceName)
+        where T: AssemblyAssert
+        {
+            Assert.IsTrue(
+                assert.Assembly.GetManifestResourceNames().Contains(resourceName),
+                $"Assembly {assert.Assembly} did not contain a resource with name {resourceName}."
+            );
+            return assert;
+        }
+
+    }
+
+}

--- a/src/Tests/TestExtensions.cs
+++ b/src/Tests/TestExtensions.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
 using Microsoft.Jupyter.Core;
+using Microsoft.Quantum.IQSharp;
 using Microsoft.Quantum.IQSharp.AzureClient;
 using Microsoft.Quantum.IQSharp.Kernel;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -170,6 +171,9 @@ namespace Tests.IQSharp
             {
                 Assembly = assembly
             };
+
+        internal static AssemblyAssert Assembly(this Assert assert, AssemblyInfo info) =>
+            assert.Assembly(info.Assembly);
 
         internal static T HasResource<T>(this T assert, string resourceName)
         where T: AssemblyAssert

--- a/src/Tests/TestExtensions.cs
+++ b/src/Tests/TestExtensions.cs
@@ -163,24 +163,34 @@ namespace Tests.IQSharp
 
         internal class AssemblyAssert
         {
-            internal Assembly Assembly;
+            internal AssemblyInfo AssemblyInfo;
         }
 
-        internal static AssemblyAssert Assembly(this Assert assert, Assembly assembly) =>
+        internal static AssemblyAssert Assembly(this Assert assert, AssemblyInfo info) =>
             new AssemblyAssert
             {
-                Assembly = assembly
+                AssemblyInfo = info
             };
-
-        internal static AssemblyAssert Assembly(this Assert assert, AssemblyInfo info) =>
-            assert.Assembly(info.Assembly);
 
         internal static T HasResource<T>(this T assert, string resourceName)
         where T: AssemblyAssert
         {
             Assert.IsTrue(
-                assert.Assembly.GetManifestResourceNames().Contains(resourceName),
-                $"Assembly {assert.Assembly} did not contain a resource with name {resourceName}."
+                assert.AssemblyInfo.Assembly.GetManifestResourceNames().Contains(resourceName),
+                $"Assembly {assert.AssemblyInfo.Assembly.GetName()} did not contain a resource with name {resourceName}."
+            );
+            return assert;
+        }
+
+        internal static T HasOperation<T>(this T assert, string namespaceName, string name)
+        where T: AssemblyAssert
+        {
+            Assert.IsTrue(
+                assert.AssemblyInfo.Operations.Any(opInfo =>
+                    opInfo.Header.QualifiedName.Namespace == namespaceName &&
+                    opInfo.Header.QualifiedName.Name == name
+                ),
+                $"Assembly {assert.AssemblyInfo.Assembly.GetName()} did not contain an operation with name {namespaceName}.{name}."
             );
             return assert;
         }


### PR DESCRIPTION
This PR was collaboratively developed with @bettinaheim and fixes #484. This PR also improves unit test coverage to prevent regressions, slightly improves logging functionality to help identify causes of similar issues in the future, and addresses a small performance issue in magic command resolution discovered in the process of developing the fix for #484.

The main change needed to fix #484 is to regenerate C# code produced from library references when targeting for Azure Quantum service submission, allowing for Q# code in references to be transformed by compiler rewrite steps for that target.