### PR TITLE
Add count parameter to %azure.jobs list

### DIFF
--- a/src/AzureClient/AzureClient.cs
+++ b/src/AzureClient/AzureClient.cs
@@ -594,7 +594,11 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
 
                 if (count.HasValue)
                 {
-                    if (jobs.Count >= count) break;
+                    if (jobs.Count >= count)
+                    {
+                        channel?.Stdout($"Showing only the first {count} jobs:");
+                        break;
+                    }
                 }
             }
 

--- a/src/AzureClient/AzureClient.cs
+++ b/src/AzureClient/AzureClient.cs
@@ -570,7 +570,7 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
         }
 
         /// <inheritdoc/>
-        public async Task<ExecutionResult> GetJobListAsync(IChannel channel, string filter, CancellationToken? cancellationToken = default)
+        public async Task<ExecutionResult> GetJobListAsync(IChannel channel, string filter, int? count = default, CancellationToken? cancellationToken = default)
         {
             if (ActiveWorkspace == null)
             {
@@ -590,6 +590,11 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
                 if (job.Matches(filter))
                 {
                     jobs.Add(job);
+                }
+
+                if (count.HasValue)
+                {
+                    if (jobs.Count >= count) break;
                 }
             }
 

--- a/src/AzureClient/IAzureClient.cs
+++ b/src/AzureClient/IAzureClient.cs
@@ -165,7 +165,7 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
         /// to jobs with fields containing <c>filter</c> using a case-insensitive
         /// comparison.
         /// </returns>
-        public Task<ExecutionResult> GetJobListAsync(IChannel channel, string filter, CancellationToken? token);
+        public Task<ExecutionResult> GetJobListAsync(IChannel channel, string filter, int? count, CancellationToken? token);
 
         /// <summary>
         /// Gets a list of all jobs in the current Azure Quantum workspace.

--- a/src/AzureClient/Magic/JobsMagic.cs
+++ b/src/AzureClient/Magic/JobsMagic.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
                         - A string to filter the list of jobs. Jobs which have an ID, name, or target
                         containing the provided filter parameter will be displayed. If not specified,
                         all recent jobs are displayed.
-                        - `{ParameterNameCount}=<integer>` (default={int.MaxValue}): The max number of jobs to return.
+                        - `{ParameterNameCount}=<integer>` (default=30): The max number of jobs to return.
 
                         #### Possible errors
 
@@ -74,10 +74,10 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
                         ".Dedent(),
 
                         @"
-                            Get the list of jobs whose ID, name, or target contains ""My job"", limit it to at most 10 jobs:
+                            Get the list of jobs whose ID, name, or target contains ""My job"", limit it to at most 100 jobs:
                             ```
-                            In []: %azure.jobs ""My job"" count=10
-                            Out[]: <detailed status of at most 10 matching jobs in the workspace>
+                            In []: %azure.jobs ""My job"" count=100
+                            Out[]: <detailed status of at most 100 matching jobs in the workspace>
                             ```
                         ".Dedent(),
                     },
@@ -90,7 +90,7 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
         {
             var inputParameters = ParseInputParameters(input, firstParameterInferredName: ParameterNameFilter);
             var filter = inputParameters.DecodeParameter<string>(ParameterNameFilter, defaultValue: string.Empty);
-            var count = inputParameters.DecodeParameter<int>(ParameterNameCount, defaultValue: int.MaxValue);
+            var count = inputParameters.DecodeParameter<int>(ParameterNameCount, defaultValue: 30);
             return await AzureClient.GetJobListAsync(channel, filter, count, cancellationToken);
         }
     }

--- a/src/AzureClient/Magic/JobsMagic.cs
+++ b/src/AzureClient/Magic/JobsMagic.cs
@@ -20,6 +20,7 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
     public class JobsMagic : AzureClientMagicBase
     {
         private const string ParameterNameFilter = "__filter__";
+        private const string ParameterNameCount = "count";
 
         /// <summary>
         /// Initializes a new instance of the <see cref="JobsMagic"/> class.
@@ -48,7 +49,8 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
                         - A string to filter the list of jobs. Jobs which have an ID, name, or target
                         containing the provided filter parameter will be displayed. If not specified,
                         all recent jobs are displayed.
-                        
+                        - `{ParameterNameCount}=<integer>` (default={int.MaxValue}): The max number of jobs to return.
+
                         #### Possible errors
 
                         - {AzureClientError.NotConnected.ToMarkdown()}
@@ -70,6 +72,14 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
                             Out[]: <detailed status of matching jobs in the workspace>
                             ```
                         ".Dedent(),
+
+                        @"
+                            Get the list of jobs whose ID, name, or target contains ""My job"", limit it to at most 10 jobs:
+                            ```
+                            In []: %azure.jobs ""My job"" count=10
+                            Out[]: <detailed status of at most 10 matching jobs in the workspace>
+                            ```
+                        ".Dedent(),
                     },
                 }, logger) {}
 
@@ -80,7 +90,8 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
         {
             var inputParameters = ParseInputParameters(input, firstParameterInferredName: ParameterNameFilter);
             var filter = inputParameters.DecodeParameter<string>(ParameterNameFilter, defaultValue: string.Empty);
-            return await AzureClient.GetJobListAsync(channel, filter, cancellationToken);
+            var count = inputParameters.DecodeParameter<int>(ParameterNameCount, defaultValue: int.MaxValue);
+            return await AzureClient.GetJobListAsync(channel, filter, count, cancellationToken);
         }
     }
 }

--- a/src/Python/qsharp-core/qsharp/azure.py
+++ b/src/Python/qsharp-core/qsharp/azure.py
@@ -155,7 +155,7 @@ def output(jobId : str = '', **params) -> Dict:
     if "error_code" in result: raise AzureError(result)
     return result
 
-def jobs(filter : str = '', count : int = 2147483647, **params) -> List[AzureJob]:
+def jobs(filter : str = '', count : int = 30, **params) -> List[AzureJob]:
     """
     Displays a list of jobs in the current Azure Quantum workspace.
     See https://docs.microsoft.com/qsharp/api/iqsharp-magic/azure.jobs for more details.

--- a/src/Python/qsharp-core/qsharp/azure.py
+++ b/src/Python/qsharp-core/qsharp/azure.py
@@ -155,11 +155,11 @@ def output(jobId : str = '', **params) -> Dict:
     if "error_code" in result: raise AzureError(result)
     return result
 
-def jobs(filter : str = '', **params) -> List[AzureJob]:
+def jobs(filter : str = '', count : int = 2147483647, **params) -> List[AzureJob]:
     """
     Displays a list of jobs in the current Azure Quantum workspace.
     See https://docs.microsoft.com/qsharp/api/iqsharp-magic/azure.jobs for more details.
     """
-    result = qsharp.client._execute_magic(f"azure.jobs \"{filter}\"", raise_on_stderr=False, **params)
+    result = qsharp.client._execute_magic(f"azure.jobs \"{filter}\" count={count}", raise_on_stderr=False, **params)
     if "error_code" in result: raise AzureError(result)
     return [AzureJob(job) for job in result]

--- a/src/Python/qsharp-core/qsharp/tests/test_azure.py
+++ b/src/Python/qsharp-core/qsharp/tests/test_azure.py
@@ -143,7 +143,12 @@ def _test_workspace_job_execution():
     jobs = qsharp.azure.jobs(jobs[0].id)
     assert isinstance(jobs, list)
     assert len(jobs) == 1
+    
+    # Check that job count works
+    jobs = qsharp.azure.jobs(count=1)
+    assert isinstance(jobs, list)
+    assert len(jobs) == 1
 
-    jobs = qsharp.azure.jobs("invalid")
+    jobs = qsharp.azure.jobs("invalid", count=10)
     assert isinstance(jobs, list)
     assert len(jobs) == 0

--- a/src/Tests/AzureClientMagicTests.cs
+++ b/src/Tests/AzureClientMagicTests.cs
@@ -274,10 +274,22 @@ namespace Tests.IQSharp
             jobsMagic.Test(string.Empty);
             Assert.AreEqual(AzureClientAction.GetJobList, azureClient.LastAction);
 
-            // with arguments - should still print job status
+            // with default argument - should still print job status
             azureClient = new MockAzureClient();
             jobsMagic = new JobsMagic(azureClient, new UnitTestLogger<JobsMagic>());
             jobsMagic.Test($"{jobId}");
+            Assert.AreEqual(AzureClientAction.GetJobList, azureClient.LastAction);
+
+            // with default and count arguments - should still print job status
+            azureClient = new MockAzureClient();
+            jobsMagic = new JobsMagic(azureClient, new UnitTestLogger<JobsMagic>());
+            jobsMagic.Test($"{jobId} count=1");
+            Assert.AreEqual(AzureClientAction.GetJobList, azureClient.LastAction);
+
+            // only with count argument - should still print job status
+            azureClient = new MockAzureClient();
+            jobsMagic = new JobsMagic(azureClient, new UnitTestLogger<JobsMagic>());
+            jobsMagic.Test($"count=1");
             Assert.AreEqual(AzureClientAction.GetJobList, azureClient.LastAction);
         }
 
@@ -390,7 +402,7 @@ namespace Tests.IQSharp
             return ExecuteStatus.Ok.ToExecutionResult();
         }
 
-        public async Task<ExecutionResult> GetJobListAsync(IChannel channel, string filter, CancellationToken? token)
+        public async Task<ExecutionResult> GetJobListAsync(IChannel channel, string filter, int? count = default, CancellationToken? token = default)
         {
             LastAction = AzureClientAction.GetJobList;
             return ExecuteStatus.Ok.ToExecutionResult();

--- a/src/Tests/AzureClientTests.cs
+++ b/src/Tests/AzureClientTests.cs
@@ -112,6 +112,22 @@ namespace Tests.IQSharp
             // jobs list with filter
             jobs = ExpectSuccess<IEnumerable<CloudJob>>(azureClient.GetJobListAsync(new MockChannel(), "JOB_ID_1"));
             Assert.AreEqual(1, jobs.Count());
+
+            // jobs list with count
+            jobs = ExpectSuccess<IEnumerable<CloudJob>>(azureClient.GetJobListAsync(new MockChannel(), string.Empty, 1));
+            Assert.AreEqual(1, jobs.Count());
+
+            // jobs list with invalid filter
+            jobs = ExpectSuccess<IEnumerable<CloudJob>>(azureClient.GetJobListAsync(new MockChannel(), "INVALID_FILTER"));
+            Assert.AreEqual(0, jobs.Count());
+
+            // jobs list with partial filter
+            jobs = ExpectSuccess<IEnumerable<CloudJob>>(azureClient.GetJobListAsync(new MockChannel(), "JOB_ID"));
+            Assert.AreEqual(2, jobs.Count());
+
+            // jobs list with filter and count
+            jobs = ExpectSuccess<IEnumerable<CloudJob>>(azureClient.GetJobListAsync(new MockChannel(), "JOB_ID", 1));
+            Assert.AreEqual(1, jobs.Count());
         }
 
         [TestMethod]


### PR DESCRIPTION
A workspace could have thousands of jobs, and currently the `%azure.jobs` returns all of them with no way to limit how many jobs it should return.
This introduces a new parameter to limit the number of jobs that will be returned. It defaults to 30 (like the Portal).
If reaches the count of jobs, a message is printed to the user.