### PR TITLE
Add new %attach magic command to DEBUG builds.

### DIFF
--- a/src/Kernel/Magic/AttachMagic.cs
+++ b/src/Kernel/Magic/AttachMagic.cs
@@ -1,0 +1,51 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Extensions.Logging;
+using Microsoft.Jupyter.Core;
+using Microsoft.Quantum.IQSharp.Jupyter;
+
+#if DEBUG
+
+namespace Microsoft.Quantum.IQSharp.Kernel
+{
+    public class AttachMagic : AbstractMagic
+    {
+        private ISnippets Snippets;
+
+        public AttachMagic(ILogger<AttachMagic> logger) : base(
+            "attach",
+            new Microsoft.Jupyter.Core.Documentation
+            {
+                Summary = "TODO",
+                Description = @"TODO".Dedent(),
+                Examples = new string []
+                {
+                }
+            }, logger)
+        { }
+
+
+        /// <inheritdoc />
+        public override ExecutionResult Run(string? input, IChannel channel)
+        {
+            if (System.Diagnostics.Debugger.IsAttached)
+            {
+                System.Diagnostics.Debugger.Break();
+            }
+            else
+            {
+                System.Diagnostics.Debugger.Launch();
+            }
+
+            return ExecuteStatus.Ok.ToExecutionResult();
+        }
+    }
+}
+
+#endif

--- a/src/Kernel/Magic/AttachMagic.cs
+++ b/src/Kernel/Magic/AttachMagic.cs
@@ -22,10 +22,23 @@ namespace Microsoft.Quantum.IQSharp.Kernel
             "attach",
             new Microsoft.Jupyter.Core.Documentation
             {
-                Summary = "TODO",
-                Description = @"TODO".Dedent(),
+                Summary = "Attaches a debugger to the current IQ# session.",
+                Description = @"
+                    If no debugger is attached to the current IQ# session, launches a new debugger and attaches it, allowing for stepping through IQ# implementation code.
+
+                    If a debugger is already attached, this magic command acts as a breakpoint when executed.
+
+                    > **NOTE:** This command is not included in release versions of the IQ# kernel, and is only intended for use by IQ# contributors.
+                    > If you are interested in debugging Q# code written in IQ#, please see the [`%debug` magic command](https://docs.microsoft.com/qsharp/api/iqsharp-magic/debug) instead.
+                ".Dedent(),
                 Examples = new string []
                 {
+                    @"
+                        Attach a debugger to the current IQ# sessiuon:
+                        ```
+                        %attach
+                        ```
+                    ".Dedent()
                 }
             }, logger)
         { }


### PR DESCRIPTION
This PR adds a new magic command to debug builds (in particular, not in packages shipped from the `Release` configuration) that allows developers working on IQ# to easily attach a debugger to a running session.