### PR TITLE
Fix #515.

### DIFF
--- a/conda-recipes/iqsharp/meta.yaml
+++ b/conda-recipes/iqsharp/meta.yaml
@@ -33,7 +33,7 @@ test:
     - notebook
     - python>=3.6
     # See microsoft/iqsharp#515, jupyter/jupyter_kernel_test#56.
-    - jupyter_client<=7.0.1
+    - jupyter_client==6.1.12
     - pyzmq
     - pip
 

--- a/conda-recipes/iqsharp/meta.yaml
+++ b/conda-recipes/iqsharp/meta.yaml
@@ -32,7 +32,8 @@ test:
   requires:
     - notebook
     - python>=3.6
-    - jupyter_client
+    # See microsoft/iqsharp#515, jupyter/jupyter_kernel_test#56.
+    - jupyter_client<=7.0.1
     - pyzmq
     - pip
 


### PR DESCRIPTION
This PR fixes #515 by locking unit tests within `conda test` to versions of `jupyter_client` known to be compatible with `jupyter_kernel_test`. See jupyter/jupyter_kernel_test#56 for details.

This PR does not change any user-facing requirements, as `jupyter_client` is only upper-bounded in test environments.