### PR TITLE
Require locations parameter when using %azure.connect

### DIFF
--- a/src/AzureClient/AzureClient.cs
+++ b/src/AzureClient/AzureClient.cs
@@ -188,6 +188,7 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
         {
             if (string.IsNullOrWhiteSpace(location))
             {
+                channel?.Stderr($"No location provided.");
                 return AzureClientError.NoWorkspaceLocation.ToExecutionResult();
             }
 

--- a/src/AzureClient/AzureClientError.cs
+++ b/src/AzureClient/AzureClientError.cs
@@ -91,6 +91,19 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
         WorkspaceNotFound,
 
         /// <summary>
+        /// A workspace was provided without a location.
+        /// </summary>
+        [Description(Resources.AzureClientErrorNoWorkspaceLocation)]
+        NoWorkspaceLocation,
+
+
+        /// <summary>
+        /// A workspace was provided without an invalid location.
+        /// </summary>
+        [Description(Resources.AzureClientErrorInvalidWorkspaceLocation)]
+        InvalidWorkspaceLocation,
+
+        /// <summary>
         /// The Azure Quantum job failed or was cancelled.
         /// </summary>
         [Description(Resources.AzureClientErrorJobFailedOrCancelled)]

--- a/src/AzureClient/Magic/ConnectMagic.cs
+++ b/src/AzureClient/Magic/ConnectMagic.cs
@@ -119,7 +119,7 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
                         $@"
                             Connect to an Azure Quantum workspace using its resource ID to the 'West Us' region:
                             ```
-                            In []: %azure.connect ""/subscriptions/.../Microsoft.Quantum/Workspaces/WORKSPACE_NAME"" {ParameterNameSubscriptionId}=""West US""
+                            In []: %azure.connect ""/subscriptions/.../Microsoft.Quantum/Workspaces/WORKSPACE_NAME"" {ParameterNameLocation}=""West US""
                             Out[]: Connected to Azure Quantum workspace WORKSPACE_NAME in location westus.
                                     <list of Q# execution targets available in the Azure Quantum workspace>
                             ```

--- a/src/AzureClient/Magic/ConnectMagic.cs
+++ b/src/AzureClient/Magic/ConnectMagic.cs
@@ -3,8 +3,6 @@
 
 #nullable enable
 
-using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading;
@@ -57,8 +55,8 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
                     Summary = "Connects to an Azure Quantum workspace or displays current connection status.",
                     Description = $@"
                         This magic command allows for connecting to an Azure Quantum workspace
-                        as specified by the resource ID of the workspace or by a combination of
-                        subscription ID, resource group name, and workspace name.
+                        as specified by the resource ID and location of the workspace or by a combination of
+                        subscription ID, resource group name, workspace name, and location.
 
                         If the connection is successful, a list of the available Q# execution targets
                         in the Azure Quantum workspace will be displayed.
@@ -77,9 +75,10 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
                         - `{ParameterNameResourceGroupName}=<string>`: The Azure resource group name for the Azure Quantum workspace.
                         - `{ParameterNameWorkspaceName}=<string>`: The name of the Azure Quantum workspace.
                         
+                        Along with the identifiers above, a valid location is required.
+
                         - `{ParameterNameLocation}=<string>`: The Azure region where the Azure Quantum workspace is provisioned.
                         This may be specified as a region name such as `""East US""` or a location name such as `""eastus""`.
-                        If no valid value is specified, defaults to `""westus""`.
 
                         #### Optional parameters
 
@@ -120,7 +119,7 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
                         $@"
                             Connect to an Azure Quantum workspace using its resource ID to the 'West Us' region:
                             ```
-                            In []: %azure.connect ""/subscriptions/.../Microsoft.Quantum/Workspaces/WORKSPACE_NAME""
+                            In []: %azure.connect ""/subscriptions/.../Microsoft.Quantum/Workspaces/WORKSPACE_NAME"" {ParameterNameSubscriptionId}=""West US""
                             Out[]: Connected to Azure Quantum workspace WORKSPACE_NAME in location westus.
                                     <list of Q# execution targets available in the Azure Quantum workspace>
                             ```
@@ -143,6 +142,7 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
                             In []: %azure.connect {ParameterNameSubscriptionId}=""SUBSCRIPTION_ID""
                                                   {ParameterNameResourceGroupName}=""RESOURCE_GROUP_NAME""
                                                   {ParameterNameWorkspaceName}=""WORKSPACE_NAME""
+                                                  {ParameterNameLocation}=""West US""
                                                   {ParameterNameCredential}=""interactive""
                             Out[]: Connected to Azure Quantum workspace WORKSPACE_NAME in location westus.
                                     <list of Q# execution targets available in the Azure Quantum workspace>

--- a/src/AzureClient/Resources.cs
+++ b/src/AzureClient/Resources.cs
@@ -46,6 +46,12 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
         public const string AzureClientErrorWorkspaceNotFound =
             "No Azure Quantum workspace was found that matches the specified criteria.";
 
+        public const string AzureClientErrorNoWorkspaceLocation =
+            "Please specify the location associated with your workspace.";
+
+        public const string AzureClientErrorInvalidWorkspaceLocation =
+            "The location provided is invalid.";
+
         public const string AzureClientErrorJobFailedOrCancelled =
             "The specified Azure Quantum job failed or was cancelled.";
     }

--- a/src/AzureClient/Resources.cs
+++ b/src/AzureClient/Resources.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
             "No Azure Quantum workspace was found that matches the specified criteria.";
 
         public const string AzureClientErrorNoWorkspaceLocation =
-            "Please specify the location associated with your workspace.";
+            "The location parameter is missing.";
 
         public const string AzureClientErrorInvalidWorkspaceLocation =
             "The location provided is invalid.";

--- a/src/Tests/AzureClientTests.cs
+++ b/src/Tests/AzureClientTests.cs
@@ -41,7 +41,7 @@ namespace Tests.IQSharp
         private Task<ExecutionResult> ConnectToWorkspaceAsync(
             IAzureClient azureClient,
             string workspaceName = "TEST_WORKSPACE_NAME",
-            string locationName = "")
+            string locationName = "TEST_LOCATION")
         {
             // Reset the global set of jobs and providers everytime we connect to a new workspace:
             MockAzureWorkspace.MockJobIds = new string[] { };
@@ -323,17 +323,17 @@ namespace Tests.IQSharp
             var services = Startup.CreateServiceProvider("Workspace");
             var azureClient = (AzureClient)services.GetService<IAzureClient>();
 
-            // Default location should be westus
-            _ = ExpectSuccess<IEnumerable<TargetStatusInfo>>(ConnectToWorkspaceAsync(azureClient));
-            Assert.AreEqual("westus", azureClient.ActiveWorkspace?.Location);
-
             // Locations with whitespace should be converted correctly
             _ = ExpectSuccess<IEnumerable<TargetStatusInfo>>(ConnectToWorkspaceAsync(azureClient, locationName: "Australia Central 2"));
             Assert.AreEqual("australiacentral2", azureClient.ActiveWorkspace?.Location);
 
-            // Locations with invalid hostname characters should fall back to default westus
-            _ = ExpectSuccess<IEnumerable<TargetStatusInfo>>(ConnectToWorkspaceAsync(azureClient, locationName: "/test/"));
-            Assert.AreEqual("westus", azureClient.ActiveWorkspace?.Location);
+            // No location provided should fail
+            ExpectError(AzureClientError.NoWorkspaceLocation, ConnectToWorkspaceAsync(azureClient, locationName: ""));
+            ExpectError(AzureClientError.NoWorkspaceLocation, ConnectToWorkspaceAsync(azureClient, locationName: "   "));
+
+            // Invalid locations should fail
+            ExpectError(AzureClientError.InvalidWorkspaceLocation, ConnectToWorkspaceAsync(azureClient, locationName: "#"));
+            ExpectError(AzureClientError.InvalidWorkspaceLocation, ConnectToWorkspaceAsync(azureClient, locationName: "/test/"));
         }
 
         [TestMethod]

--- a/src/Tests/TestExtensions.cs
+++ b/src/Tests/TestExtensions.cs
@@ -36,7 +36,7 @@ namespace Tests.IQSharp
         {
             // Start by connecting using the mock connection string.
             await engine
-                .Input("%azure.connect subscription=TEST_SUBSCRIPTION_ID resourceGroup=TEST_RESOURCE_GROUP_NAME workspace=NameWithMockProviders storage=TEST_CONNECTION_STRING")
+                .Input("%azure.connect subscription=TEST_SUBSCRIPTION_ID resourceGroup=TEST_RESOURCE_GROUP_NAME workspace=NameWithMockProviders storage=TEST_CONNECTION_STRING location=TEST_LOCATION")
                 .ExecutesSuccessfully();
             var client = await (await engine).Engine.GetEngineService<IAzureClient>();
             if (client is AzureClient azureClient && azureClient.ActiveWorkspace is MockAzureWorkspace workspace)


### PR DESCRIPTION
Currently, the %azure.connect command defaults to westus location when no location is passed in or when a location with invalid characters is passed in. This can be confusing for users and is not consistent with our other clients.

This PR enforces that the location parameter is passed in as part of %azure.connect (or is available from the existing config).