### PR TITLE
Fix `add_project` for paths with whitespaces

### DIFF
--- a/src/Python/qsharp-core/qsharp/clients/iqsharp.py
+++ b/src/Python/qsharp-core/qsharp/clients/iqsharp.py
@@ -162,7 +162,7 @@ class IQSharpClient(object):
         return self._execute("%package", raise_on_stderr=False)
 
     def add_project(self, path : str) -> None:
-        return self._execute(f"%project {path}", raise_on_stderr=True)
+        return self._execute(f'%project "{path}"', raise_on_stderr=True)
 
     def get_projects(self) -> List[str]:
         return self._execute("%project", raise_on_stderr=False)


### PR DESCRIPTION
In `qsharp.projects.add`