### PR TITLE
Live tests: make sure NUGET_OUTDIR is listed as a nuget source

### DIFF
--- a/tests.live/Install-Artifacts.ps1
+++ b/tests.live/Install-Artifacts.ps1
@@ -55,7 +55,17 @@ function Install-FromBuild() {
     dotnet iqsharp install --user
     if ($LASTEXITCODE -ne 0) { throw "Error installing iqsharp kernel" }
 
-    # Install the qsharp-core wheel:
+    # Make sure the NUGET_OUTDIR is listed as a nuget source, otherwise
+    # IQ# will fail to load when packages are loaded.
+    $SourceName = "build"
+    dotnet nuget add source $Env:NUGET_OUTDIR  --name $SourceName
+    if ($LASTEXITCODE -ne 0) { 
+        "Nuget source $SourceName already exist, will be updated to point to $($Env:NUGET_OUTDIR)" | Write-Warning
+        dotnet nuget update source  $SourceName --source $Env:NUGET_OUTDIR
+        if ($LASTEXITCODE -ne 0) { throw "Failed to update nuget config" }
+    }
+
+    # Install the qsharp-core wheel
     "Installing qsharp-core from $Env:PYTHON_OUTDIR" | Write-Verbose
     pip install qsharp-core==$Env:PYTHON_VERSION --find-links $Env:PYTHON_OUTDIR
     if ($LASTEXITCODE -ne 0) { throw "Error installing qsharp-core wheel" }


### PR DESCRIPTION
Live tests failed for release builds as they failed to find the Standard package for compilation. The reason is that the NUGET_OUTDIR folder where they got installed from was not part of the nuget sources, and release packages are not pushed to public repos until fully validated.