### PR TITLE
Install .NET6 SDK as well in iqsharp-base Docker image

### DIFF
--- a/images/iqsharp-base/Dockerfile
+++ b/images/iqsharp-base/Dockerfile
@@ -50,8 +50,7 @@ RUN wget -qO- https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor 
     chown root:root /etc/apt/trusted.gpg.d/microsoft.asc.gpg && \
     chown root:root /etc/apt/sources.list.d/microsoft-prod.list && \
     apt-get -y update && \
-    apt-get -y install dotnet-sdk-3.1 && \
-    apt-get -y install dotnet-sdk-6.0 && \
+    apt-get -y install dotnet-sdk-3.1 dotnet-sdk-6.0 && \
     apt-get clean && rm -rf /var/lib/apt/lists/
 
 # Install prerequisites needed for integration with Live Share and VS Online.

--- a/images/iqsharp-base/Dockerfile
+++ b/images/iqsharp-base/Dockerfile
@@ -42,6 +42,7 @@ ENV NUGET_XMLDOC_MODE=skip \
     DOTNET_SKIP_FIRST_TIME_EXPERIENCE=true
 
 # Now that we have all the dependencies in place, we install the .NET Core SDK itself.
+# Notice that we're installing the SDK for both .NET Core 3.1 as well as .NET 6.0 for compatibility.
 RUN wget -qO- https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > microsoft.asc.gpg && \
     mv microsoft.asc.gpg /etc/apt/trusted.gpg.d/ && \
     wget -q https://packages.microsoft.com/config/debian/9/prod.list && \
@@ -50,6 +51,7 @@ RUN wget -qO- https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor 
     chown root:root /etc/apt/sources.list.d/microsoft-prod.list && \
     apt-get -y update && \
     apt-get -y install dotnet-sdk-3.1 && \
+    apt-get -y install dotnet-sdk-6.0 && \
     apt-get clean && rm -rf /var/lib/apt/lists/
 
 # Install prerequisites needed for integration with Live Share and VS Online.


### PR DESCRIPTION
Installing the SDK for .NET 6.0 as part of the iqsharp-docker image in preparation for changes tracked by:
https://github.com/microsoft/qsharp-compiler/issues/1224

