### PR TITLE
Add default timeout to `qsharp._execute`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,7 @@
 *.user
 *.userosscache
 *.sln.docstates
-[.]venv/
+*[.]venv/
 
 # User-specific files (MonoDevelop/Xamarin Studio)
 *.userprefs

--- a/src/Python/qsharp-core/qsharp/__init__.py
+++ b/src/Python/qsharp-core/qsharp/__init__.py
@@ -62,7 +62,7 @@ def compile(code : str) -> Union[None, QSharpCallable, List[QSharpCallable]]:
 
     ops = [
         QSharpCallable(op, "snippets")
-        for op in client.compile(code)
+        for op in compiled
     ]
     if len(ops) == 1:
         return ops[0]

--- a/src/Python/qsharp-core/qsharp/clients/iqsharp.py
+++ b/src/Python/qsharp-core/qsharp/clients/iqsharp.py
@@ -168,14 +168,14 @@ class IQSharpClient(object):
         return self._execute("%project", raise_on_stderr=False)
 
     def simulate(self, op, **kwargs) -> Any:
-        kwargs.setdefault('timeout', 180)
+        kwargs.setdefault('timeout', None)
         return self._execute_callable_magic('simulate', op, **kwargs)
 
     def toffoli_simulate(self, op, **kwargs) -> Any:
         return self._execute_callable_magic('toffoli', op, **kwargs)
 
     def estimate(self, op, **kwargs) -> Dict[str, int]:
-        kwargs.setdefault('timeout', 180)
+        kwargs.setdefault('timeout', None)
         raw_counts = self._execute_callable_magic('estimate', op, **kwargs)
         # Note that raw_counts will have the form:
         # [

--- a/src/Python/qsharp-core/qsharp/clients/iqsharp.py
+++ b/src/Python/qsharp-core/qsharp/clients/iqsharp.py
@@ -168,12 +168,14 @@ class IQSharpClient(object):
         return self._execute("%project", raise_on_stderr=False)
 
     def simulate(self, op, **kwargs) -> Any:
+        kwargs.setdefault('timeout', 180)
         return self._execute_callable_magic('simulate', op, **kwargs)
 
     def toffoli_simulate(self, op, **kwargs) -> Any:
         return self._execute_callable_magic('toffoli', op, **kwargs)
 
     def estimate(self, op, **kwargs) -> Dict[str, int]:
+        kwargs.setdefault('timeout', 180)
         raw_counts = self._execute_callable_magic('estimate', op, **kwargs)
         # Note that raw_counts will have the form:
         # [

--- a/src/Python/qsharp-core/qsharp/clients/iqsharp.py
+++ b/src/Python/qsharp-core/qsharp/clients/iqsharp.py
@@ -358,8 +358,8 @@ class IQSharpClient(object):
                 # propagate to a Jupyter protocol error.
                 raise AlreadyExecutingError("Cannot execute through the IQ# client while another execution is completing.")
             self._busy = True
-            timeout = 300
-            reply = self.kernel_client.execute_interactive(input, output_hook=_output_hook, timeout=timeout, **kwargs)
+            kwargs.setdefault('timeout', 120)
+            reply = self.kernel_client.execute_interactive(input, output_hook=_output_hook, **kwargs)
         finally:
             self._busy = False
 

--- a/src/Python/qsharp-core/qsharp/clients/iqsharp.py
+++ b/src/Python/qsharp-core/qsharp/clients/iqsharp.py
@@ -48,6 +48,8 @@ except ImportError:
 import logging
 logger = logging.getLogger(__name__)
 
+DEFAULT_TIMEOUT=120
+
 ## CLASSES ##
 
 class IQSharpError(RuntimeError):
@@ -103,7 +105,7 @@ class IQSharpClient(object):
 
     def is_ready(self):
         try:
-            result = self.component_versions(timeout=6)
+            result = self.component_versions(_timeout_=6)
             logger.info(f"Q# version\n{result}")
         except Exception as ex:
             logger.info('Exception while checking if IQ# is ready.', exc_info=ex)
@@ -168,14 +170,15 @@ class IQSharpClient(object):
         return self._execute("%project", raise_on_stderr=False)
 
     def simulate(self, op, **kwargs) -> Any:
-        kwargs.setdefault('timeout', None)
+        kwargs.setdefault('_timeout_', None)
         return self._execute_callable_magic('simulate', op, **kwargs)
 
     def toffoli_simulate(self, op, **kwargs) -> Any:
+        kwargs.setdefault('_timeout_', None)
         return self._execute_callable_magic('toffoli', op, **kwargs)
 
     def estimate(self, op, **kwargs) -> Dict[str, int]:
-        kwargs.setdefault('timeout', None)
+        kwargs.setdefault('_timeout_', None)
         raw_counts = self._execute_callable_magic('estimate', op, **kwargs)
         # Note that raw_counts will have the form:
         # [
@@ -238,6 +241,7 @@ class IQSharpClient(object):
     # qsharp.experimental submodule.
 
     def _simulate_noise(self, op, **kwargs) -> Any:
+        kwargs.setdefault('_timeout_', None)
         return self._execute_callable_magic('experimental.simulate_noise', op, **kwargs)
 
     def _get_noise_model(self) -> str:
@@ -270,9 +274,10 @@ class IQSharpClient(object):
         return None
 
     def _execute_magic(self, magic : str, raise_on_stderr : bool = False, _quiet_ : bool = False, **kwargs) -> Any:
+        _timeout_ = kwargs.pop('_timeout_', DEFAULT_TIMEOUT)
         return self._execute(
             f'%{magic} {json.dumps(map_tuples(kwargs))}',
-            raise_on_stderr=raise_on_stderr, _quiet_=_quiet_
+            raise_on_stderr=raise_on_stderr, _quiet_=_quiet_, _timeout_=_timeout_
         )
 
     def _execute_callable_magic(self, magic : str, op,
@@ -301,9 +306,9 @@ class IQSharpClient(object):
             else:
                 fallback_hook(msg)
 
-    def _execute(self, input, return_full_result=False, raise_on_stderr : bool = False, output_hook=None, display_data_handler=None, _quiet_ : bool = False, **kwargs):
-
+    def _execute(self, input, return_full_result=False, raise_on_stderr : bool = False, output_hook=None, display_data_handler=None, _timeout_=DEFAULT_TIMEOUT, _quiet_ : bool = False, **kwargs):
         logger.debug(f"sending:\n{input}")
+        logger.debug(f"timeout: {_timeout_}")
 
         # make sure the server is still running:
         try:
@@ -360,8 +365,7 @@ class IQSharpClient(object):
                 # propagate to a Jupyter protocol error.
                 raise AlreadyExecutingError("Cannot execute through the IQ# client while another execution is completing.")
             self._busy = True
-            kwargs.setdefault('timeout', 120)
-            reply = self.kernel_client.execute_interactive(input, output_hook=_output_hook, **kwargs)
+            reply = self.kernel_client.execute_interactive(input, timeout=_timeout_, output_hook=_output_hook, **kwargs)
         finally:
             self._busy = False
 

--- a/src/Python/qsharp-core/qsharp/clients/iqsharp.py
+++ b/src/Python/qsharp-core/qsharp/clients/iqsharp.py
@@ -358,7 +358,8 @@ class IQSharpClient(object):
                 # propagate to a Jupyter protocol error.
                 raise AlreadyExecutingError("Cannot execute through the IQ# client while another execution is completing.")
             self._busy = True
-            reply = self.kernel_client.execute_interactive(input, output_hook=_output_hook, **kwargs)
+            timeout = 300
+            reply = self.kernel_client.execute_interactive(input, output_hook=_output_hook, timeout=timeout, **kwargs)
         finally:
             self._busy = False
 


### PR DESCRIPTION
Currently, by default there is currently no timeout for call to the IQsharp kernel from the `qsharp` package. In general this has and should not been a problem as most calls will return immediately. However, some of the tests run during conda validation are causing some deadlock and the call never returns.
Changing the default timeout to be 2 min for most operations. Leaving `None` only for `simulate` and `estimate` as those can be long-lived operations.