### PR TITLE
Lock version of jupyter_kernel_test used in conda test.

### DIFF
--- a/conda-recipes/iqsharp/meta.yaml
+++ b/conda-recipes/iqsharp/meta.yaml
@@ -42,7 +42,7 @@ test:
     - src/conda-recipes/iqsharp/test.py
 
   commands:
-    - pip install jupyter_kernel_test
+    - pip install jupyter_kernel_test==0.3
     - powershell -NoProfile src/conda-recipes/iqsharp/test.ps1 # [win]
     - pwsh src/conda-recipes/iqsharp/test.ps1 # [not win]
 


### PR DESCRIPTION
This PR fixes an issue caused by an incompatibility between the new `jupyter_kernel_test` package version 0.4 and `jupyter_client` versions earlier than 7.0.

Note that this incompatibility **only** affects test-time requirements, and has zero effect on any packages built by IQ# CI.