### PR TITLE
Add KernelInstanceId to telemetry

### DIFF
--- a/src/Tool/Telemetry.cs
+++ b/src/Tool/Telemetry.cs
@@ -228,6 +228,12 @@ namespace Microsoft.Quantum.IQSharp
 
     public static class TelemetryExtensions
     {
+        // Generate a new UUID to use in identifying a particular instance
+        // of the kernel process.
+        // By making a static property of a non-generic static class, we
+        // ensure that there's one session ID per process.
+        internal static readonly Guid KernelInstanceId = Guid.NewGuid();
+
         public static string WithTelemetryNamespace(this string name) =>
             $"Quantum.IQSharp.{name}";
 
@@ -241,6 +247,7 @@ namespace Microsoft.Quantum.IQSharp
         /// <returns><paramref name="evt"/> for use in fluent chains.</returns>
         public static EventProperties SetCommonProperties(this EventProperties evt)
         {
+            evt.SetProperty("KernelInstanceId".WithTelemetryNamespace(), KernelInstanceId);
             evt.SetProperty("ExecutionCount".WithTelemetryNamespace(), TelemetryService.baseEngine?.ExecutionCount?.ToString());
             evt.SetProperty("CurrentTarget".WithTelemetryNamespace(), TelemetryService.client?.ActiveTargetId);
             evt.SetProperty("CurrentSubscription".WithTelemetryNamespace(), (TelemetryService.client as AzureClient.AzureClient)?.ActiveWorkspace?.SubscriptionId, PiiKind.GenericData);


### PR DESCRIPTION
Currently, telemetry events do not have a correlation id across a kernel session. This guid should be auto-generated each time a kernel is created/restarted.

This is cherry-picked from @cgranade's work in #528