### PR TITLE
Update .NET Core SDK 3.1 in Docker image

### DIFF
--- a/images/iqsharp-base/Dockerfile
+++ b/images/iqsharp-base/Dockerfile
@@ -49,7 +49,7 @@ RUN wget -qO- https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor 
     chown root:root /etc/apt/trusted.gpg.d/microsoft.asc.gpg && \
     chown root:root /etc/apt/sources.list.d/microsoft-prod.list && \
     apt-get -y update && \
-    apt-get -y install dotnet-sdk-3.1 && \
+    apt-get -y install dotnet-sdk-3.1=3.1.416-1 && \
     apt-get clean && rm -rf /var/lib/apt/lists/
 
 # Install prerequisites needed for integration with Live Share and VS Online.


### PR DESCRIPTION
This PR updates the version of the .NET SDK used in the iqsharp-base Docker image to use the latest patch release, 3.1.416.