### PR TITLE
Propagate cancellation tokens when refreshing credentials.

### DIFF
--- a/src/AzureClient/AzureClient.cs
+++ b/src/AzureClient/AzureClient.cs
@@ -224,6 +224,8 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
                 ActiveWorkspace = workspace;
                 AvailableProviders = providers;
 
+                Logger.LogDebug("Connected to workspace with {NProviders} available providers.", providers.Count);
+
                 return ExecuteStatus.Ok.ToExecutionResult();
             }
             catch (TaskCanceledException tce)
@@ -248,6 +250,7 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
         //     private method, we make it required here.
         private async Task<ExecutionResult> RefreshConnectionAsync(IChannel? channel, CancellationToken cancellationToken)
         {
+            Logger.LogDebug("Refreshing Azure connection.");
             if (ActiveWorkspace == null || Credential == null)
             {
                 return AzureClientError.NotConnected.ToExecutionResult();
@@ -312,7 +315,7 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
                 return connectionResult;
             }
 
-            var machine =AzureFactory.CreateMachine(this.ActiveWorkspace, this.ActiveTarget.TargetId, this.StorageConnectionString);
+            var machine = AzureFactory.CreateMachine(this.ActiveWorkspace, this.ActiveTarget.TargetId, this.StorageConnectionString);
             if (machine == null)
             {
                 // We should never get here, since ActiveTarget should have already been validated at the time it was set.
@@ -345,6 +348,7 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
 
             try
             {
+                Logger.LogDebug("About to submit entry point for {OperationName}.", submissionContext.OperationName);
                 var job = await entryPoint.SubmitAsync(machine, submissionContext);
                 channel?.Stdout($"Job successfully submitted for {submissionContext.Shots} shots.");
                 channel?.Stdout($"   Job name: {submissionContext.FriendlyName}");

--- a/src/AzureClient/EntryPoint/EntryPointGenerator.cs
+++ b/src/AzureClient/EntryPoint/EntryPointGenerator.cs
@@ -9,6 +9,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.Loader;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Quantum.IQSharp.Common;
 using Microsoft.Quantum.QsCompiler;
@@ -24,6 +25,7 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
         private ILogger<EntryPointGenerator> Logger { get; }
         private IWorkspace Workspace { get; }
         private ISnippets Snippets { get; }
+        private IServiceProvider ServiceProvider { get; }
         public IReferences References { get; }
         public AssemblyInfo[] WorkspaceAssemblies { get; set; } = Array.Empty<AssemblyInfo>();
         public AssemblyInfo? SnippetsAssemblyInfo { get; set; }
@@ -35,6 +37,7 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
             ISnippets snippets,
             IReferences references,
             ILogger<EntryPointGenerator> logger,
+            IServiceProvider serviceProvider,
             IEventService eventService)
         {
             Compiler = compiler;
@@ -42,6 +45,7 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
             Snippets = snippets;
             References = references;
             Logger = logger;
+            ServiceProvider = serviceProvider;
 
             AssemblyLoadContext.Default.Resolving += Resolve;
 
@@ -201,7 +205,10 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
             var entryPointInfo = entryPointInfoType.GetConstructor(new Type[] { typeof(Type) })
                 .Invoke(new object[] { entryPointOperationInfo.RoslynType });
 
-            return new EntryPoint(entryPointInfo, entryPointInputType, entryPointOutputType, entryPointOperationInfo);
+            return new EntryPoint(
+                entryPointInfo, entryPointInputType, entryPointOutputType, entryPointOperationInfo,
+                logger: ServiceProvider.GetService<ILogger<EntryPoint>>()
+            );
         }
     }
 }

--- a/src/AzureClient/EntryPoint/IEntryPoint.cs
+++ b/src/AzureClient/EntryPoint/IEntryPoint.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections.Generic;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Quantum.Runtime;
 
@@ -22,7 +23,8 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
         /// </summary>
         /// <param name="machine">The <see cref="IQuantumMachine"/> object representing the job submission target.</param>
         /// <param name="submissionContext">The <see cref="AzureSubmissionContext"/> object representing the submission context for the job.</param>
+        /// <param name="cancellationToken">Cancellation token used to interrupt this submission.</param>
         /// <returns>The details of the submitted job.</returns>
-        public Task<IQuantumMachineJob> SubmitAsync(IQuantumMachine machine, AzureSubmissionContext submissionContext);
+        public Task<IQuantumMachineJob> SubmitAsync(IQuantumMachine machine, AzureSubmissionContext submissionContext, CancellationToken cancellationToken = default);
     }
 }


### PR DESCRIPTION
This PR fixes a few places where cancellation tokens are not propagated through refreshing of Azure credentials, such that the kernel enters an uninterruptable state.