### PR TITLE
Update npm packages

### DIFF
--- a/src/Kernel/package-lock.json
+++ b/src/Kernel/package-lock.json
@@ -4,6 +4,7 @@
     "requires": true,
     "packages": {
         "": {
+            "name": "Kernel",
             "dependencies": {
                 "@microsoft/quantum-viz.js": "^1.0.2",
                 "chart.js": "2.9.4",
@@ -506,12 +507,23 @@
             "dev": true
         },
         "node_modules/node-fetch": {
-            "version": "2.6.1",
-            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-            "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
+            "version": "2.6.7",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+            "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
             "dev": true,
+            "dependencies": {
+                "whatwg-url": "^5.0.0"
+            },
             "engines": {
                 "node": "4.x || >=6.0.0"
+            },
+            "peerDependencies": {
+                "encoding": "^0.1.0"
+            },
+            "peerDependenciesMeta": {
+                "encoding": {
+                    "optional": true
+                }
             }
         },
         "node_modules/nopt": {
@@ -638,9 +650,9 @@
             "dev": true
         },
         "node_modules/simple-get": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-3.1.0.tgz",
-            "integrity": "sha512-bCR6cP+aTdScaQCnQKbPKtJOKDp/hj9EDLJo3Nw4y1QksqaovlW/bnptB6/c1e+qmNIDHRK+oXFDdEqBT8WzUA==",
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-3.1.1.tgz",
+            "integrity": "sha512-CQ5LTKGfCpvE1K0n2us+kuMPbk/q0EKl82s4aheV9oXjFEz6W/Y7oQFVJuU6QG77hRT4Ghb5RURteF5vnWjupA==",
             "dev": true,
             "dependencies": {
                 "decompress-response": "^4.2.0",
@@ -709,6 +721,12 @@
                 "node": ">= 10"
             }
         },
+        "node_modules/tr46": {
+            "version": "0.0.3",
+            "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+            "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
+            "dev": true
+        },
         "node_modules/typescript": {
             "version": "3.9.7",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
@@ -727,6 +745,22 @@
             "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
             "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
             "dev": true
+        },
+        "node_modules/webidl-conversions": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+            "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
+            "dev": true
+        },
+        "node_modules/whatwg-url": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+            "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+            "dev": true,
+            "dependencies": {
+                "tr46": "~0.0.3",
+                "webidl-conversions": "^3.0.0"
+            }
         },
         "node_modules/wide-align": {
             "version": "1.1.3",
@@ -1141,10 +1175,13 @@
             "dev": true
         },
         "node-fetch": {
-            "version": "2.6.1",
-            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-            "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
-            "dev": true
+            "version": "2.6.7",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+            "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+            "dev": true,
+            "requires": {
+                "whatwg-url": "^5.0.0"
+            }
         },
         "nopt": {
             "version": "5.0.0",
@@ -1249,9 +1286,9 @@
             "dev": true
         },
         "simple-get": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-3.1.0.tgz",
-            "integrity": "sha512-bCR6cP+aTdScaQCnQKbPKtJOKDp/hj9EDLJo3Nw4y1QksqaovlW/bnptB6/c1e+qmNIDHRK+oXFDdEqBT8WzUA==",
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-3.1.1.tgz",
+            "integrity": "sha512-CQ5LTKGfCpvE1K0n2us+kuMPbk/q0EKl82s4aheV9oXjFEz6W/Y7oQFVJuU6QG77hRT4Ghb5RURteF5vnWjupA==",
             "dev": true,
             "requires": {
                 "decompress-response": "^4.2.0",
@@ -1310,6 +1347,12 @@
                 "yallist": "^4.0.0"
             }
         },
+        "tr46": {
+            "version": "0.0.3",
+            "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+            "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
+            "dev": true
+        },
         "typescript": {
             "version": "3.9.7",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
@@ -1321,6 +1364,22 @@
             "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
             "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
             "dev": true
+        },
+        "webidl-conversions": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+            "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
+            "dev": true
+        },
+        "whatwg-url": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+            "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+            "dev": true,
+            "requires": {
+                "tr46": "~0.0.3",
+                "webidl-conversions": "^3.0.0"
+            }
         },
         "wide-align": {
             "version": "1.1.3",


### PR DESCRIPTION
Updates `simple-get` and `node-fetch`. Makes #580 obsolete.