### PR TITLE
Update to 0.22.192090-beta.

### DIFF
--- a/images/iqsharp-base/Dockerfile
+++ b/images/iqsharp-base/Dockerfile
@@ -1,4 +1,4 @@
-0.22.192090-beta0.22.192090-beta# The same image used by mybinder.org
+# The same image used by mybinder.org
 FROM python:3.7-slim-buster
 
 # install the notebook package
@@ -128,7 +128,7 @@ ENV PATH=$PATH:${HOME}/dotnet:${HOME}/.dotnet/tools \
 # Install IQ# and the project templates, using the NuGet packages from the
 # build context.
 ARG IQSHARP_VERSION
-RUN dotnet new -i "Microsoft.Quantum.ProjectTemplates::0.22.186570-alpha" && \
+RUN dotnet new -i "Microsoft.Quantum.ProjectTemplates::0.22.192090-beta" && \
     dotnet tool install \
            --global \
            Microsoft.Quantum.IQSharp \

--- a/images/iqsharp-base/Dockerfile
+++ b/images/iqsharp-base/Dockerfile
@@ -1,4 +1,4 @@
-# The same image used by mybinder.org
+0.22.192090-beta0.22.192090-beta# The same image used by mybinder.org
 FROM python:3.7-slim-buster
 
 # install the notebook package

--- a/src/Core/Core.csproj
+++ b/src/Core/Core.csproj
@@ -1,4 +1,4 @@
-0.22.192090-beta0.22.192090-beta<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
@@ -38,10 +38,10 @@
     <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="3.0.0" />
-    <PackageReference Include="Microsoft.Quantum.Compiler" Version="0.22.186570-alpha" />
-    <PackageReference Include="Microsoft.Quantum.CSharpGeneration" Version="0.22.186570-alpha" />
-    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.22.186570-alpha" />
-    <PackageReference Include="Microsoft.Quantum.QSharp.Core" Version="0.22.186570-alpha" />
+    <PackageReference Include="Microsoft.Quantum.Compiler" Version="0.22.192090-beta" />
+    <PackageReference Include="Microsoft.Quantum.CSharpGeneration" Version="0.22.192090-beta" />
+    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.22.192090-beta" />
+    <PackageReference Include="Microsoft.Quantum.QSharp.Core" Version="0.22.192090-beta" />
     <PackageReference Include="Microsoft.Windows.Compatibility" Version="5.0.2" />
     <PackageReference Include="NuGet.Resolver" Version="5.1.0" />
     <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />

--- a/src/Core/Core.csproj
+++ b/src/Core/Core.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+0.22.192090-beta0.22.192090-beta<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>

--- a/src/ExecutionPathTracer/ExecutionPathTracer.csproj
+++ b/src/ExecutionPathTracer/ExecutionPathTracer.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+0.22.192090-beta0.22.192090-beta<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>

--- a/src/ExecutionPathTracer/ExecutionPathTracer.csproj
+++ b/src/ExecutionPathTracer/ExecutionPathTracer.csproj
@@ -1,4 +1,4 @@
-0.22.192090-beta0.22.192090-beta<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
@@ -32,7 +32,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.22.186570-alpha" />
+    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.22.192090-beta" />
   </ItemGroup>
 
 </Project>

--- a/src/MockLibraries/Mock.Chemistry/Mock.Chemistry.csproj
+++ b/src/MockLibraries/Mock.Chemistry/Mock.Chemistry.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.22.186570-alpha">
+<Project Sdk="Microsoft.Quantum.Sdk/0.22.192090-beta">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
@@ -6,6 +6,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.22.186570-alpha" />
+    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.22.192090-beta" />
   </ItemGroup>
 </Project>

--- a/src/MockLibraries/Mock.Standard/Mock.Standard.csproj
+++ b/src/MockLibraries/Mock.Standard/Mock.Standard.csproj
@@ -1,4 +1,4 @@
-0.22.192090-beta0.22.192090-beta<Project Sdk="Microsoft.Quantum.Sdk/0.22.186570-alpha">
+<Project Sdk="Microsoft.Quantum.Sdk/0.22.192090-beta">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
@@ -6,6 +6,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.22.186570-alpha" />
+    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.22.192090-beta" />
   </ItemGroup>
 </Project>

--- a/src/MockLibraries/Mock.Standard/Mock.Standard.csproj
+++ b/src/MockLibraries/Mock.Standard/Mock.Standard.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.22.186570-alpha">
+0.22.192090-beta0.22.192090-beta<Project Sdk="Microsoft.Quantum.Sdk/0.22.186570-alpha">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>

--- a/src/Tests/Workspace.ProjectReferences.ProjectA/ProjectA.csproj
+++ b/src/Tests/Workspace.ProjectReferences.ProjectA/ProjectA.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.22.186570-alpha">
+0.22.192090-beta0.22.192090-beta<Project Sdk="Microsoft.Quantum.Sdk/0.22.186570-alpha">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>

--- a/src/Tests/Workspace.ProjectReferences.ProjectA/ProjectA.csproj
+++ b/src/Tests/Workspace.ProjectReferences.ProjectA/ProjectA.csproj
@@ -1,4 +1,4 @@
-0.22.192090-beta0.22.192090-beta<Project Sdk="Microsoft.Quantum.Sdk/0.22.186570-alpha">
+<Project Sdk="Microsoft.Quantum.Sdk/0.22.192090-beta">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>

--- a/src/Tests/Workspace.ProjectReferences.ProjectB/ProjectB.csproj
+++ b/src/Tests/Workspace.ProjectReferences.ProjectB/ProjectB.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.22.186570-alpha">
+0.22.192090-beta0.22.192090-beta<Project Sdk="Microsoft.Quantum.Sdk/0.22.186570-alpha">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>

--- a/src/Tests/Workspace.ProjectReferences.ProjectB/ProjectB.csproj
+++ b/src/Tests/Workspace.ProjectReferences.ProjectB/ProjectB.csproj
@@ -1,4 +1,4 @@
-0.22.192090-beta0.22.192090-beta<Project Sdk="Microsoft.Quantum.Sdk/0.22.186570-alpha">
+<Project Sdk="Microsoft.Quantum.Sdk/0.22.192090-beta">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>

--- a/src/Tests/Workspace.ProjectReferences/Workspace.ProjectReferences.csproj
+++ b/src/Tests/Workspace.ProjectReferences/Workspace.ProjectReferences.csproj
@@ -1,4 +1,4 @@
-0.22.192090-beta0.22.192090-beta<Project Sdk="Microsoft.Quantum.Sdk/0.22.186570-alpha">
+<Project Sdk="Microsoft.Quantum.Sdk/0.22.192090-beta">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.22.186570-alpha" />
+    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.22.192090-beta" />
   </ItemGroup>
     
   <ItemGroup>

--- a/src/Tests/Workspace.ProjectReferences/Workspace.ProjectReferences.csproj
+++ b/src/Tests/Workspace.ProjectReferences/Workspace.ProjectReferences.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.22.186570-alpha">
+0.22.192090-beta0.22.192090-beta<Project Sdk="Microsoft.Quantum.Sdk/0.22.186570-alpha">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>

--- a/src/Tool/appsettings.json
+++ b/src/Tool/appsettings.json
@@ -1,4 +1,4 @@
-{
+0.22.192090-beta0.22.192090-beta{
     "Logging": {
         "LogLevel": {
             "Default": "Warning"

--- a/src/Tool/appsettings.json
+++ b/src/Tool/appsettings.json
@@ -1,4 +1,4 @@
-0.22.192090-beta0.22.192090-beta{
+{
     "Logging": {
         "LogLevel": {
             "Default": "Warning"
@@ -6,21 +6,21 @@
     },
     "AllowedHosts": "*",
     "DefaultPackageVersions": [
-        "Microsoft.Quantum.Compiler::0.22.186570-alpha",
-        "Microsoft.Quantum.CSharpGeneration::0.22.186570-alpha",
-        "Microsoft.Quantum.Development.Kit::0.22.186570-alpha",
-        "Microsoft.Quantum.Simulators::0.22.186570-alpha",
-        "Microsoft.Quantum.Xunit::0.22.186570-alpha",
-        "Microsoft.Quantum.Standard::0.22.186570-alpha",
-        "Microsoft.Quantum.Standard.Visualization::0.22.186570-alpha",
-        "Microsoft.Quantum.Chemistry::0.22.186570-alpha",
-        "Microsoft.Quantum.Chemistry.Jupyter::0.22.186570-alpha",
-        "Microsoft.Quantum.MachineLearning::0.22.186570-alpha",
-        "Microsoft.Quantum.Numerics::0.22.186570-alpha",
-        "Microsoft.Quantum.Katas::0.22.186570-alpha",
-        "Microsoft.Quantum.Research::0.22.186570-alpha",
-        "Microsoft.Quantum.Providers.IonQ::0.22.186570-alpha",
-        "Microsoft.Quantum.Providers.Honeywell::0.22.186570-alpha",
-        "Microsoft.Quantum.Providers.QCI::0.22.186570-alpha"
+        "Microsoft.Quantum.Compiler::0.22.192090-beta",
+        "Microsoft.Quantum.CSharpGeneration::0.22.192090-beta",
+        "Microsoft.Quantum.Development.Kit::0.22.192090-beta",
+        "Microsoft.Quantum.Simulators::0.22.192090-beta",
+        "Microsoft.Quantum.Xunit::0.22.192090-beta",
+        "Microsoft.Quantum.Standard::0.22.192090-beta",
+        "Microsoft.Quantum.Standard.Visualization::0.22.192090-beta",
+        "Microsoft.Quantum.Chemistry::0.22.192090-beta",
+        "Microsoft.Quantum.Chemistry.Jupyter::0.22.192090-beta",
+        "Microsoft.Quantum.MachineLearning::0.22.192090-beta",
+        "Microsoft.Quantum.Numerics::0.22.192090-beta",
+        "Microsoft.Quantum.Katas::0.22.192090-beta",
+        "Microsoft.Quantum.Research::0.22.192090-beta",
+        "Microsoft.Quantum.Providers.IonQ::0.22.192090-beta",
+        "Microsoft.Quantum.Providers.Honeywell::0.22.192090-beta",
+        "Microsoft.Quantum.Providers.QCI::0.22.192090-beta"
     ]
 }


### PR DESCRIPTION
It appears as though some of the packages used during builds have aged out of the alpha feed, breaking the per-repo build (e.g.: #588). This PR updates package versions to 0.22.192090-beta in order to restore the build.