### PR TITLE
[Perf] Add extra nuget packages to iqsharp-base container

### DIFF
--- a/build/pack.ps1
+++ b/build/pack.ps1
@@ -84,7 +84,7 @@ function Pack-Image() {
         <# Next, we specify any additional NuGet sources to be used. #> `
         --build-arg EXTRA_NUGET_SOURCES="$extraNugetSources" `
         <# Next, we specify any additional NuGet packages that should be imported. #> `
-        --build-arg EXTRA_NUGET_PACKAGES="" `
+        --build-arg EXTRA_NUGET_PACKAGES=$("microsoft.quantum.providers.ionq", "microsoft.quantum.providers.honeywell", "microsoft.quantum.providers.qci") `
         <# Next, we tell Docker what version of IQ# to install. #> `
         --build-arg IQSHARP_VERSION=$Env:NUGET_VERSION `
         <# Finally, we tag the image with the current build number. #> `


### PR DESCRIPTION
The %azure.target command currently has poor performance:

Looking at the cell duration telemetry, the 95th percentile for %azure.target commands is 50 seconds, and the 99.5 percentile is 2 min 43 seconds.

After the first time it is executed with poor performance, subsequent cells have very good performance (<1s, even after a kernel restart). It looks like this is due to the packages that need to be downloaded or unpacked from Nuget. Executing the %azure.target command for our three providers adds **55 nuget packages** to the container.

By installing them in the base image first, we can improve the performance of this command, so that it is sub-second even for the first time it is run (assuming the user has not explicitly specified a nuget version not in our nuget cache).