### PR TITLE
Manually update System.DirectoryServices.Protocols version

### DIFF
--- a/src/Core/Core.csproj
+++ b/src/Core/Core.csproj
@@ -44,6 +44,7 @@
     <PackageReference Include="Microsoft.Quantum.QSharp.Core" Version="0.23.195983" />
     <PackageReference Include="Microsoft.Windows.Compatibility" Version="5.0.2" />
     <PackageReference Include="NuGet.Resolver" Version="5.1.0" />
+    <PackageReference Include="System.DirectoryServices.Protocols" Version="5.0.1" />
     <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
   </ItemGroup>
 


### PR DESCRIPTION
Specify version of `System.DirectoryServices.Protocols`, which we take indirectly through `Microsoft.Windows.Compatibility`, to pick up security fix.