### PR TITLE
Gate compiler caching on optional config flag.

### DIFF
--- a/src/Core/Compiler/CompilerService.cs
+++ b/src/Core/Compiler/CompilerService.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Quantum.IQSharp
 
 
             /// <summary>
-            ///     If <c>true</c>, caches compiler dependencies (e.g.: Roslyn
+            ///     If <c>true</c>, loads and caches compiler dependencies (e.g.: Roslyn
             ///     and Q# code generation) on startup.
             ///     This has a significant performance advantage, especially
             ///     when a kernel is started in the background, but can cause

--- a/src/Core/Compiler/CompilerService.cs
+++ b/src/Core/Compiler/CompilerService.cs
@@ -56,12 +56,13 @@ namespace Microsoft.Quantum.IQSharp
 
 
             /// <summary>
-            ///     If <c>true</c>, caches compiler services on startup.
+            ///     If <c>true</c>, caches compiler dependencies (e.g.: Roslyn
+            ///     and Q# code generation) on startup.
             ///     This has a significant performance advantage, especially
             ///     when a kernel is started in the background, but can cause
             ///     more RAM to be used.
             /// </summary>
-            public bool CacheCompilerServices { get; set; } = false;
+            public bool CacheCompilerDependencies { get; set; } = false;
         }
 
         /// <inheritdoc/>
@@ -106,7 +107,7 @@ namespace Microsoft.Quantum.IQSharp
             }
 
             eventService?.TriggerServiceInitialized<ICompilerService>(this);
-            if (options?.Value.CacheCompilerServices ?? false)
+            if (options?.Value.CacheCompilerDependencies ?? false)
             {
                 DependenciesInitialized = InitializeDependencies(serviceProvider.GetRequiredServiceInBackground<IReferences>(logger));
                 Task.Run(async () =>

--- a/src/Core/Compiler/CompilerService.cs
+++ b/src/Core/Compiler/CompilerService.cs
@@ -53,6 +53,15 @@ namespace Microsoft.Quantum.IQSharp
             ///     are opened. Aliases can be provided by using <c>=</c>.
             /// </summary>
             public string? AutoOpenNamespaces { get; set; }
+
+
+            /// <summary>
+            ///     If <c>true</c>, caches compiler services on startup.
+            ///     This has a significant performance advantage, especially
+            ///     when a kernel is started in the background, but can cause
+            ///     more RAM to be used.
+            /// </summary>
+            public bool CacheCompilerServices { get; set; } = false;
         }
 
         /// <inheritdoc/>
@@ -66,9 +75,14 @@ namespace Microsoft.Quantum.IQSharp
         private readonly ILogger? Logger;
 
         // Note to future IQ# developers: This service should start ★fast★.
-        // Please bbe judicious when adding parameters to this constructor, and
+        // Please be judicious when adding parameters to this constructor, and
         // defer those dependencies to tasks if at all possible.
-        public CompilerService(ILogger<CompilerService>? logger, IOptions<Settings>? options, IEventService? eventService, IServiceProvider serviceProvider)
+        public CompilerService(
+            ILogger<CompilerService>? logger,
+            IOptions<Settings>? options,
+            IEventService? eventService,
+            IServiceProvider serviceProvider
+        )
         {
             var stopwatch = new Stopwatch();
             stopwatch.Start();
@@ -92,16 +106,23 @@ namespace Microsoft.Quantum.IQSharp
             }
 
             eventService?.TriggerServiceInitialized<ICompilerService>(this);
-            DependenciesInitialized = InitializeDependencies(serviceProvider.GetRequiredServiceInBackground<IReferences>(logger));
-            Task.Run(async () =>
+            if (options?.Value.CacheCompilerServices ?? false)
             {
-                await DependenciesInitialized;
-                stopwatch.Stop();
-                logger?.LogInformation(
-                    "Initialized dependencies for compiler service {Elapsed} after service start.",
-                    stopwatch.Elapsed
-                );
-            });
+                DependenciesInitialized = InitializeDependencies(serviceProvider.GetRequiredServiceInBackground<IReferences>(logger));
+                Task.Run(async () =>
+                {
+                    await DependenciesInitialized;
+                    stopwatch.Stop();
+                    logger?.LogInformation(
+                        "Initialized dependencies for compiler service {Elapsed} after service start.",
+                        stopwatch.Elapsed
+                    );
+                });
+            }
+            else
+            {
+                DependenciesInitialized = Task.CompletedTask;
+            }
         }
 
         // We take references as a task so that it can load in the background


### PR DESCRIPTION
This PR gates some of the improvements made in #615 on an optional configuration option to reduce memory usage by default while still allowing faster compilation times on systems with more memory.