### PR TITLE
Lock jupyter client to <7.0.

### DIFF
--- a/src/Python/qsharp-core/setup.py
+++ b/src/Python/qsharp-core/setup.py
@@ -61,7 +61,7 @@ setuptools.setup(
         "Operating System :: OS Independent",
     ],
     install_requires=[
-        'jupyter_client',
+        'jupyter_client<7.0',
         'pyzmq<20.0.0'     # due to incompatibility of IQ# with pyzmq>=20.0.0
     ]
 )


### PR DESCRIPTION
This PR fixes intermittent issues with importing Q# and Python interop, especially on Windows. See https://github.com/jupyter/jupyter_client/issues/755 for more discussion of sync APIs in jupyter_client >= 7.0.