### PR TITLE
Changing C# codegen to happen synch.

### DIFF
--- a/src/Core/Compiler/CompilerService.cs
+++ b/src/Core/Compiler/CompilerService.cs
@@ -483,6 +483,9 @@ namespace Microsoft.Quantum.IQSharp
             }
             catch (Exception e)
             {
+                // Log to the IQ# logger...
+                Logger?.LogError(e, $"Unexpected error compiling assembly.");
+                // ...and to the Q# compiler log.
                 logger.LogError("IQS002", $"Unexpected error compiling assembly: {e.Message}.");
                 return null;
             }

--- a/src/Core/Compiler/CompilerService.cs
+++ b/src/Core/Compiler/CompilerService.cs
@@ -426,8 +426,6 @@ namespace Microsoft.Quantum.IQSharp
                         : CodegenContext.Create(qsCompilation.Namespaces, new Dictionary<string, string>() { { AssemblyConstants.ExecutionTarget, executionTarget } });
                     codeGenTask?.ReportStatus($"Generating C# for file {file}", "generate-one-file");
                     var code = SimulationCode.generate(file, codegenContext);
-                    var filename = Path.Combine(".", "obj", new FileInfo(file).Name + ".cs");
-                    File.WriteAllText(filename, code);
                     codeGenTask?.ReportStatus($"Parsing generated C# for file {file}", "generate-one-file");
                     logger.LogDebug($"Generated the following C# code for {file}:\n=============\n{code}\n=============\n");
                     return CSharpSyntaxTree.ParseText(code, encoding: UTF8Encoding.UTF8);

--- a/src/Core/Compiler/CompilerService.cs
+++ b/src/Core/Compiler/CompilerService.cs
@@ -382,49 +382,12 @@ namespace Microsoft.Quantum.IQSharp
             try
             {
                 using var codeGenTask = perfTask?.BeginSubtask("Code generation", "code-generation");
-                // Generate C# simulation code from Q# syntax tree and convert it into C# syntax trees:
-                var trees = new List<Task<CodeAnalysis.SyntaxTree>>();
-                var allSources = regenerateAll
-                    ? GetSourceFiles.Apply(qsCompilation.Namespaces)
-                    : sources.Keys.Select(
-                        file => CompilationUnitManager.GetFileId(file)
-                      );
-
-                foreach (var file in allSources)
-                {
-                    trees.Add(Task.Run(() =>
-                    {
-                        codeGenTask?.ReportStatus($"Creating codegen context for file {file}", "generate-one-file");
-                        var codegenContext = string.IsNullOrEmpty(executionTarget)
-                            ? CodegenContext.Create(qsCompilation.Namespaces)
-                            : CodegenContext.Create(qsCompilation.Namespaces, new Dictionary<string, string>() { { AssemblyConstants.ExecutionTarget, executionTarget } });
-                        codeGenTask?.ReportStatus($"Generating C# for file {file}", "generate-one-file");
-                        var code = SimulationCode.generate(file, codegenContext);
-                        codeGenTask?.ReportStatus($"Parsing generated C# for file {file}", "generate-one-file");
-                        logger.LogDebug($"Generated the following C# code for {file}:\n=============\n{code}\n=============\n");
-                        return CSharpSyntaxTree.ParseText(code, encoding: UTF8Encoding.UTF8);
-                    }));
-                }
-
-                // Compile the C# syntax trees:
-                var compilation = Task.Run(async () =>
-                {
-                    var options = new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary, optimizationLevel: OptimizationLevel.Debug);
-                    var parsedTrees = await Task.WhenAll(trees);
-                    using var csCompileTask = codeGenTask?.BeginSubtask("Compiling generated C#.", "compile-csharp");
-
-                    return CSharpCompilation.Create(
-                        Path.GetFileNameWithoutExtension(dllName),
-                        parsedTrees,
-                        metadata.RoslynMetadatas,
-                        options);
-                });
 
                 var fromSources = regenerateAll
                                 ? qsCompilation.Namespaces
                                 : qsCompilation.Namespaces.Select(ns => FilterBySourceFile.Apply(ns, s => s.EndsWith(".qs")));
 
-                // In parallel, get manifest resources by writing syntax trees to memory.
+                // Async, get manifest resources by writing syntax trees to memory.
                 var manifestResources = Task.Run(() =>
                 {
                     using var qstTask = codeGenTask?.BeginSubtask("Serializing Q# syntax tree.", "serialize-qs-ast");
@@ -447,10 +410,44 @@ namespace Microsoft.Quantum.IQSharp
                     };
                 });
 
-                // Generate the assembly from the C# compilation once we have
+                // In the meanwhile...
+                // Generate C# simulation code from Q# syntax tree and convert it into C# syntax trees:
+                var allSources = regenerateAll
+                    ? GetSourceFiles.Apply(qsCompilation.Namespaces)
+                    : sources.Keys.Select(
+                        file => CompilationUnitManager.GetFileId(file)
+                      );
+
+                CodeAnalysis.SyntaxTree createTree(string file)
+                {
+                    codeGenTask?.ReportStatus($"Creating codegen context for file {file}", "generate-one-file");
+                    var codegenContext = string.IsNullOrEmpty(executionTarget)
+                        ? CodegenContext.Create(qsCompilation.Namespaces)
+                        : CodegenContext.Create(qsCompilation.Namespaces, new Dictionary<string, string>() { { AssemblyConstants.ExecutionTarget, executionTarget } });
+                    codeGenTask?.ReportStatus($"Generating C# for file {file}", "generate-one-file");
+                    var code = SimulationCode.generate(file, codegenContext);
+                    var filename = Path.Combine(".", "obj", new FileInfo(file).Name + ".cs");
+                    File.WriteAllText(filename, code);
+                    codeGenTask?.ReportStatus($"Parsing generated C# for file {file}", "generate-one-file");
+                    logger.LogDebug($"Generated the following C# code for {file}:\n=============\n{code}\n=============\n");
+                    return CSharpSyntaxTree.ParseText(code, encoding: UTF8Encoding.UTF8);
+                }
+
+                var trees = allSources.Select(createTree).ToImmutableList();
+                var options = new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary, optimizationLevel: OptimizationLevel.Debug);
+                var parsedTrees = trees;
+                using var csCompileTask = codeGenTask?.BeginSubtask("Compiling generated C#.", "compile-csharp");
+
+                var compilation = CSharpCompilation.Create(
+                    Path.GetFileNameWithoutExtension(dllName),
+                    parsedTrees,
+                    metadata.RoslynMetadatas,
+                    options);
+
+                // Generate the assembly from the C# compilation and the manifestResources once we have
                 // both.
                 using var ms = new MemoryStream();
-                var result = (await compilation).Emit(ms, manifestResources: await manifestResources);
+                var result = compilation.Emit(ms, manifestResources: await manifestResources);
 
                 if (!result.Success)
                 {

--- a/src/Tests/ExecutionPathTracerTests.cs
+++ b/src/Tests/ExecutionPathTracerTests.cs
@@ -23,7 +23,7 @@ namespace Tests.IQSharp
             ws.Initialization.Wait();
             ws.GlobalReferences.AddPackage("mock.standard").Wait();
             await ws.Reload();
-            Assert.IsFalse(ws.HasErrors);
+            Assert.That.Workspace(ws).DoesNotHaveErrors();
             return ws;
         }
 

--- a/src/Tests/TestExtensions.cs
+++ b/src/Tests/TestExtensions.cs
@@ -35,6 +35,21 @@ namespace Tests.IQSharp
             return (T)assert.Object;
         }
 
+        internal record class WorkspaceAssert(IWorkspace Workspace);
+
+        internal static WorkspaceAssert Workspace(this Assert assert, IWorkspace workspace) =>
+            new WorkspaceAssert(workspace);
+        internal static WorkspaceAssert DoesNotHaveErrors(this WorkspaceAssert assert)
+        {
+            var ws = assert.Workspace;
+            if (ws.HasErrors)
+            {
+                var msg = "Expected workspace initialization to succeed, but got errors:\n";
+                Assert.Fail(msg + string.Join("\n", ws.ErrorMessages.Select(err => $"- {err}")));
+            }
+            return assert;
+        }
+
         internal class InputAssert : UsingEngineAssert
         {
             internal string Code;

--- a/src/Tests/WorkspaceTests.cs
+++ b/src/Tests/WorkspaceTests.cs
@@ -25,7 +25,7 @@ namespace Tests.IQSharp
             // First time
             ws = Startup.Create<Workspace>("Workspace");
             await ws.Initialization;
-            Assert.IsFalse(ws.HasErrors);
+            Assert.That.Workspace(ws).DoesNotHaveErrors();
 
             var op = ws.AssemblyInfo.Operations.FirstOrDefault(o => o.FullName == "Tests.qss.NoOp");
             Assert.IsNotNull(op);
@@ -33,7 +33,7 @@ namespace Tests.IQSharp
             // On next reload:
             ws = Startup.Create<Workspace>("Workspace");
             await ws.Initialization;
-            Assert.IsFalse(ws.HasErrors);
+            Assert.That.Workspace(ws).DoesNotHaveErrors();
 
             op = ws.AssemblyInfo.Operations.FirstOrDefault(o => o.FullName == "Tests.qss.NoOp");
             Assert.IsNotNull(op);


### PR DESCRIPTION
Fixes #630 by making the c# codegen calls synchronous (as it turns out, codegen is not threadsafe, see https://github.com/microsoft/qsharp-compiler/issues/1393).

I also moved the codegen to happen after we're building the manifests, as that can happen concurrently.