### PR TITLE
Freezing jinja2 version

### DIFF
--- a/images/iqsharp-base/Dockerfile
+++ b/images/iqsharp-base/Dockerfile
@@ -3,8 +3,9 @@ FROM python:3.7-slim-buster
 
 # install the notebook package
 # force pyzmq==19.0.2 due to incompatibility of IQ# with pyzmq>=20.0.0
+#       jinja2==3.0.3 due to incompatibility with nbconvert
 RUN pip install --no-cache --upgrade pip && \
-    pip install --no-cache notebook pyzmq==19.0.2
+    pip install --no-cache notebook pyzmq==19.0.2 jinja2==3.0.3
 
 # Install APT prerequisites.
 RUN apt-get update && \


### PR DESCRIPTION
New version of jinja2 is creating errors when running `nbconvert` for our notebooks validation. 

``` 
  File "/usr/local/share/jupyter/nbconvert/templates/lab/index.html.j2", line 37, in block 'notebook_css'
    {{ resources.include_css("static/index.css") }}
  File "/usr/local/lib/python3.7/site-packages/nbconvert/exporters/html.py", line 216, in resources_include_css
    return jinja2.Markup(code)
AttributeError: module 'jinja2' has no attribute 'Markup'
```

This freezes to lkg.