### PR TITLE
Reduce memory usage in overlapping load of references.

### DIFF
--- a/src/Core/Compat.cs
+++ b/src/Core/Compat.cs
@@ -1,0 +1,7 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace System.Runtime.CompilerServices;
+/// Allows using init-only properties in netstandard2.1 project. Note that
+/// init-only is only enforced for net5.0 and later callers.
+public class IsExternalInit {}

--- a/src/Core/Compiler/CompilerMetadata.cs
+++ b/src/Core/Compiler/CompilerMetadata.cs
@@ -12,6 +12,7 @@ using Microsoft.Quantum.QsCompiler.CompilationBuilder;
 using Microsoft.Quantum.IQSharp.Common;
 
 using QsReferences = Microsoft.Quantum.QsCompiler.CompilationBuilder.References;
+using System.Collections.Concurrent;
 
 namespace Microsoft.Quantum.IQSharp
 {
@@ -19,17 +20,17 @@ namespace Microsoft.Quantum.IQSharp
     {
         internal static readonly bool LoadFromCsharp = false; // todo: we should make this properly configurable
 
-        private IEnumerable<String> Paths { get; }
+        private IEnumerable<String> Paths { get; init; }
 
         /// <summary>
         /// The list of Assemblies and their dependencies in the format the C# compiler (Roslyn) expects them.
         /// </summary>
-        public IEnumerable<MetadataReference> RoslynMetadatas { get; }
+        public IEnumerable<MetadataReference> RoslynMetadatas { get; init; }
 
         /// <summary>
         ///  The list of Assemblies and their dependencies in the format the Q# compiler expects them.
         /// </summary>
-        public QsReferences QsMetadatas { get; }
+        public QsReferences QsMetadatas { get; init; }
 
         public CompilerMetadata(IEnumerable<AssemblyInfo> assemblies)
         {
@@ -83,14 +84,27 @@ namespace Microsoft.Quantum.IQSharp
             }
         }
 
+        private static readonly IDictionary<string, MetadataReference> metadataReferenceCache
+            = new ConcurrentDictionary<string, MetadataReference>();
+
         /// <summary>
         /// Calculates Roslyn's MetadataReference for all the Assemblies and their dependencies.
         /// </summary>
-        private static ImmutableArray<MetadataReference> RoslynInit(IEnumerable<string> paths)
-        {
-            var mds = paths.Select(p => MetadataReference.CreateFromFile(p));
-            return mds.Select(a => a as MetadataReference).ToImmutableArray();
-        }
+        private static ImmutableArray<MetadataReference> RoslynInit(IEnumerable<string> paths) =>
+            paths.Select(p =>
+            {
+                if (metadataReferenceCache.TryGetValue(p, out var cached))
+                {
+                    return cached;
+                }
+                else
+                {
+                    var mdRef = MetadataReference.CreateFromFile(p);
+                    metadataReferenceCache[p] = mdRef;
+                    return mdRef;
+                }
+            })
+            .ToImmutableArray();
 
         /// <summary>
         /// Calculates Q# metadata needed for all the Assemblies and their dependencies.

--- a/src/Core/Core.csproj
+++ b/src/Core/Core.csproj
@@ -5,6 +5,7 @@
     <PlatformTarget>x64</PlatformTarget>
     <RootNamespace>Microsoft.Quantum.IQSharp</RootNamespace>
     <AssemblyName>Microsoft.Quantum.IQSharp.Core</AssemblyName>
+    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Core/References/References.cs
+++ b/src/Core/References/References.cs
@@ -185,10 +185,13 @@ namespace Microsoft.Quantum.IQSharp
 
         private void Reset()
         {
+            var oldMetadata = _metadata;
             // Begin loading metadata in the background.
             _metadata = Task.Run(
-                () =>
+                async () =>
                 {
+                    // Don't run multiple assembly reference loads at a time.
+                    await oldMetadata;
                     using var perfTask = performanceMonitor.BeginTask("Resetting reference metadata.", "reset-refs-meta");
                     var result = new CompilerMetadata(this.Assemblies);
                     return result;

--- a/src/Core/References/References.cs
+++ b/src/Core/References/References.cs
@@ -191,7 +191,10 @@ namespace Microsoft.Quantum.IQSharp
                 async () =>
                 {
                     // Don't run multiple assembly reference loads at a time.
-                    await oldMetadata;
+                    if (oldMetadata != null)
+                    {
+                        await oldMetadata;
+                    }
                     using var perfTask = performanceMonitor.BeginTask("Resetting reference metadata.", "reset-refs-meta");
                     var result = new CompilerMetadata(this.Assemblies);
                     return result;


### PR DESCRIPTION
This PR reduces memory usage when reference loads overlap (e.g.: in unit tests, or when rapidly adding several packages).