### PR TITLE
Switch to use dotnet restore to cache packages in Docker image

### DIFF
--- a/images/iqsharp-base/Dockerfile
+++ b/images/iqsharp-base/Dockerfile
@@ -140,9 +140,10 @@ RUN dotnet iqsharp install --user --path-to-tool="$(which dotnet-iqsharp)"
 # Ensure that the necessary NuGet packages are cached.
 ARG EXTRA_NUGET_PACKAGES=
 RUN echo "Adding standard packages..." && \
-    python -c "import qsharp;" && \
+    dotnet new console -n "foo" -lang Q# && \
     echo "Adding extra packages: ${EXTRA_NUGET_PACKAGES}..." && \
     for p in ${EXTRA_NUGET_PACKAGES}; do \
-        python -c "import qsharp; qsharp.packages.add('$p')" && \
+        dotnet add foo package $p --version ${IQSHARP_VERSION} && \
         echo "Added package: $p"; \
-    done
+    done && \
+    rm -Rdf foo

--- a/images/iqsharp-base/Dockerfile
+++ b/images/iqsharp-base/Dockerfile
@@ -140,7 +140,7 @@ RUN dotnet iqsharp install --user --path-to-tool="$(which dotnet-iqsharp)"
 # Ensure that the necessary NuGet packages are cached.
 ARG EXTRA_NUGET_PACKAGES=
 RUN echo "Adding standard packages..." && \
-    dotnet new console -n "foo" -lang Q# && \
+    dotnet new classlib -n "foo" -lang Q# && \
     echo "Adding extra packages: ${EXTRA_NUGET_PACKAGES}..." && \
     for p in ${EXTRA_NUGET_PACKAGES}; do \
         dotnet add foo package $p --version ${IQSHARP_VERSION} && \


### PR DESCRIPTION
We've noticed that in the qsharp-base image, loading Nuget packages from Python is failing to locally cache some of the dependencies, which is causing a slow startup.
With this change, we create a temp project and add the nuget dependencies via `dotnet`, which we have confirmed does load the dependencies.