### PR TITLE
Remove assertions about Q# error codes from SimulateOnBrokenWorkspace test

### DIFF
--- a/src/Tests/WorkspaceControllerTest.cs
+++ b/src/Tests/WorkspaceControllerTest.cs
@@ -140,9 +140,7 @@ namespace Tests.IQSharp
             var response = await controller.Simulate("Tests.qss.NoOp");
 
             Assert.AreEqual(Status.Error, response.Status);
-            Assert.AreEqual(2, response.Messages.Length);
-            Assert.IsNotNull(response.Messages.First(m => m.Contains("QS6301")));
-            Assert.IsNotNull(response.Messages.First(m => m.Contains("QS5022")));
+            Assert.IsTrue(response.Messages.Length > 0, "No messages.");
         }
 
 


### PR DESCRIPTION
In microsoft/qsharp-compiler#1406, which replaces error QS6301 (TypeMismatchInReturn) with QS0001 (TypeMismatch), this IQ# test fails in the e2e CI. The error message emitted by the compiler is almost identical, just the error number is different. To decrease the fragility of this unit test, I think it would be better to only assert that there is an error, without requiring specific error codes from the Q# compiler.