### PR TITLE
Use environment vars instead of cmdline args for user agent.

### DIFF
--- a/src/Core/Workspace/Workspace.cs
+++ b/src/Core/Workspace/Workspace.cs
@@ -189,7 +189,14 @@ namespace Microsoft.Quantum.IQSharp
             SkipAutoLoadProject = config?.Value.SkipAutoLoadProject ?? false;
             MonitorWorkspace = config?.Value.MonitorWorkspace ?? false;
 
-            logger?.LogInformation($"Starting IQ# Workspace:\n----------------\nRoot: {Root}\nCache folder:{CacheFolder}\nMonitoring changes: {MonitorWorkspace}\nUser agent: {metadata?.UserAgent ?? "<unknown>"}\nHosting environment: {metadata?.HostingEnvironment ?? "<unknown>"}\n----------------");
+            logger?.LogInformation(
+                "Starting IQ# Workspace:\n----------------\nRoot: {Root}\nCache folder:{CacheFolder}\nMonitoring changes: {MonitorWorkspace}\nUser agent: {UserAgent}\nHosting environment: {HostingEnvironment}\n----------------",
+                Root,
+                CacheFolder,
+                MonitorWorkspace,
+                metadata?.UserAgent ?? "<unknown>",
+                metadata?.HostingEnvironment ?? "<unknown>"
+            );
 
             // Initialize the workspace asynchronously
             Task.Run(async () =>

--- a/src/Python/qsharp-core/qsharp/clients/iqsharp.py
+++ b/src/Python/qsharp-core/qsharp/clients/iqsharp.py
@@ -91,7 +91,11 @@ class IQSharpClient(object):
 
     def start(self):
         logger.info("Starting IQ# kernel...")
-        self.kernel_manager.start_kernel(extra_arguments=["--user-agent", f"qsharp.py{_user_agent_extra}"])
+        # Pass along all environment variables except the user agent,
+        # as we'll override that to mark this as a Python session.
+        env = os.environ.copy()
+        env["IQSHARP_USER_AGENT"] = f"qsharp.py{_user_agent_extra}"
+        self.kernel_manager.start_kernel(env=env)
         self.kernel_client = self.kernel_manager.client()
         atexit.register(self.stop)
 


### PR DESCRIPTION
Fixed #649.