### PR TITLE
Fix image update GitHub Action

### DIFF
--- a/.github/workflows/push-selfcontained.yml
+++ b/.github/workflows/push-selfcontained.yml
@@ -22,7 +22,7 @@ jobs:
       run: az acr login -n qdkimages
     - name: Build and push Docker image
       run: |
-        $ImageTag = "${{ github.sha }}"
+        $ImageTag = "${{ github.sha }}-$( Get-Date -Format FileDateTimeUniversal )"
 
         function Update-Image() {
             param(

--- a/.github/workflows/push-selfcontained.yml
+++ b/.github/workflows/push-selfcontained.yml
@@ -6,6 +6,7 @@ on:
     - main
     paths:
     - 'images/test-environments/**/Dockerfile'
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/push-selfcontained.yml
+++ b/.github/workflows/push-selfcontained.yml
@@ -5,7 +5,7 @@ on:
     branches:
     - main
     paths:
-    - 'images/test-environments/**/Dockerfile`
+    - 'images/test-environments/**/Dockerfile'
 
 jobs:
   build:


### PR DESCRIPTION
- Fixes typo in the path that was blocking the action from running
- Adds the `workflow_dispatch` trigger so the action can be manually run. This is helpful from a compliance standpoint as it lets us rebuild an image with the newest base image, picking up any recent security patches, even when there are no changes to be made in our Dockerfile.
  - Because of this, adds the current timestamp to the image tag. This ensures it's impossible to overwrite an existing tag if the action is manually run without changes to the Dockerfile