### PR TITLE
Add cache task to improve e2e builds.

### DIFF
--- a/build/cache.yml
+++ b/build/cache.yml
@@ -13,6 +13,12 @@ steps:
 
   - script: |
       mkdir -p $(Pipeline.Workspace)/docker
-      docker save -o $(Pipeline.Workspace)/docker/cache.tar cache
-    displayName: Docker save
-    condition: and(not(canceled()), or(failed(), ne(variables.CACHE_RESTORED, 'true')))
+      docker save -o $(Pipeline.Workspace)/docker/cache.tar mcr.microsoft.com/quantum/windows-selfcontained:latest
+    displayName: Docker save windows
+    condition: and(eq(variables.OS, 'windows'), not(canceled()), or(failed(), ne(variables.CACHE_RESTORED, 'true')))
+
+  - script: |
+      mkdir -p $(Pipeline.Workspace)/docker
+      docker save -o $(Pipeline.Workspace)/docker/cache.tar mcr.microsoft.com/quantum/linux-selfcontained:latest
+    displayName: Docker save linux
+    condition: and(eq(variables.OS, 'linux'), not(canceled()), or(failed(), ne(variables.CACHE_RESTORED, 'true')))

--- a/build/cache.yml
+++ b/build/cache.yml
@@ -1,0 +1,18 @@
+steps:
+  - task: Cache@2
+    displayName: Cache task
+    inputs:
+      key: 'docker | "$(Agent.OS)" | cache'
+      path: $(Pipeline.Workspace)/docker
+      cacheHitVar: CACHE_RESTORED                #Variable to set to 'true' when the cache is restored
+    
+  - script: |
+      docker load -i $(Pipeline.Workspace)/docker/cache.tar
+    displayName: Docker restore
+    condition: and(not(canceled()), eq(variables.CACHE_RESTORED, 'true'))
+
+  - script: |
+      mkdir -p $(Pipeline.Workspace)/docker
+      docker save -o $(Pipeline.Workspace)/docker/cache.tar cache
+    displayName: Docker save
+    condition: and(not(canceled()), or(failed(), ne(variables.CACHE_RESTORED, 'true')))

--- a/build/ci.yml
+++ b/build/ci.yml
@@ -29,7 +29,6 @@ jobs:
   pool:
     vmImage: 'ubuntu-latest'
   steps:
-  - template: cache.yml
   - template: steps.yml
   - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
     displayName: 'Component Detection'
@@ -72,6 +71,7 @@ jobs:
     CondaPath: '/miniconda/bin'
     CondaShellHook: "$('/miniconda/bin/conda' 'shell.bash' 'hook')"
   steps:
+  - template: cache.yml
   - template: steps-conda.yml
   condition: ne(variables['Enable.Conda'], 'false')
 
@@ -84,5 +84,6 @@ jobs:
     OS: 'windows'
     CondaPath: 'C:\Miniconda3\Scripts'
   steps:
+  - template: cache.yml
   - template: steps-conda.yml
   condition: ne(variables['Enable.Conda'], 'false')

--- a/build/ci.yml
+++ b/build/ci.yml
@@ -22,12 +22,14 @@ variables:
   Drops.Dir: $(Build.ArtifactStagingDirectory)/drops
   IQSharp.Hosting.Env: 'build-agent-iqsharp'
   agent.preferPowerShellOnContainers: false
+  CACHE_RESTORED: false
 
 jobs:
 - job: "iqsharp"
   pool:
     vmImage: 'ubuntu-latest'
   steps:
+  - template: cache.yml
   - template: steps.yml
   - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
     displayName: 'Component Detection'


### PR DESCRIPTION
In order to improve our build speeds, caching can be used for a variety of tasks including Docker, NuGet and Conda environments. PRs for this effort will thus span multiple repositories as well.