### PR TITLE
Add central package management

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -14,7 +14,6 @@
     <ItemGroup>
         <PackageVersion Include="Microsoft.CSharp" Version="4.5.0" />
         <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.0.0" />
-        <PackageVersion Include="Microsoft.Quantum.Compiler" Version="0.24.201332" />
         <PackageVersion Include="Microsoft.Quantum.CSharpGeneration" Version="0.24.201332" />
         <PackageVersion Include="Microsoft.Quantum.Simulators" Version="0.24.201332" />
         <PackageVersion Include="Microsoft.Quantum.QSharp.Core" Version="0.24.201332" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,6 +4,6 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Azure.Quantum.Jobs" Version="1.0.0-beta.3" />
+        <PackageVersion Include="Azure.Quantum.Jobs" Version="1.0.0-beta.3" />
     </ItemGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -16,6 +16,7 @@
         <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.0.0" />
         <PackageVersion Include="Microsoft.Quantum.CSharpGeneration" Version="0.24.201332" />
         <PackageVersion Include="Microsoft.Quantum.QSharp.Core" Version="0.24.201332" />
+        <PackageVersion Include="Microsoft.Quantum.Compiler" Version="0.24.201332" />
         <PackageVersion Include="Microsoft.Windows.Compatibility" Version="5.0.2" />
         <PackageVersion Include="NuGet.Resolver" Version="5.1.0" />
         <PackageVersion Include="System.DirectoryServices.Protocols" Version="5.0.1" />
@@ -57,6 +58,7 @@
     <!-- Tests.Iqsharp.csproj & AzureClient.csproj -->
     <ItemGroup>
         <PackageVersion Include="Microsoft.Extensions.Logging" Version="3.0.0" />
+        <PackageVersion Include="Azure.Quantum.Jobs" Version="1.0.0-beta.3"/>
     </ItemGroup>
 
     <!-- Jupyter.csproj & Kernel.csproj & AzureClient.csproj -->

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,0 +1,9 @@
+<Project>
+    <PropertyGroup>
+        <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Azure.Quantum.Jobs" Version="1.0.0-beta.3" />
+    </ItemGroup>
+</Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,7 +8,6 @@
         <PackageVersion Include="Microsoft.Azure.Quantum.Client" Version="0.24.201332" />
         <PackageVersion Include="Microsoft.Rest.ClientRuntime" Version="2.3.23" />
         <PackageVersion Include="Microsoft.Rest.ClientRuntime.Azure" Version="3.3.19" />
-        <PackageVersion Include="System.Reactive" Version="4.3.2" />
     </ItemGroup>
 
     <!-- Core.csproj -->
@@ -61,11 +60,10 @@
 
     <!-- Tests.Iqsharp.csproj & AzureClient.csproj -->
     <ItemGroup>
-        <PackageVersion Include="Azure.Quantum.Jobs" Version="1.0.0-beta.3" />
         <PackageVersion Include="Microsoft.Extensions.Logging" Version="3.0.0" />
     </ItemGroup>
 
-    <!-- Jupyter.csproj & Kernel.csproj -->
+    <!-- Jupyter.csproj & Kernel.csproj & AzureClient.csproj -->
     <ItemGroup>
         <PackageVersion Include="System.Reactive" Version="4.3.2" />
     </ItemGroup>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,11 +3,75 @@
         <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     </PropertyGroup>
 
+    <!-- AzureClient.csproj -->
     <ItemGroup>
-        <PackageVersion Include="Azure.Quantum.Jobs" Version="1.0.0-beta.3" />
         <PackageVersion Include="Microsoft.Azure.Quantum.Client" Version="0.24.201332" />
         <PackageVersion Include="Microsoft.Rest.ClientRuntime" Version="2.3.23" />
         <PackageVersion Include="Microsoft.Rest.ClientRuntime.Azure" Version="3.3.19" />
         <PackageVersion Include="System.Reactive" Version="4.3.2" />
+    </ItemGroup>
+
+    <!-- Core.csproj -->
+    <ItemGroup>
+        <PackageVersion Include="Microsoft.CSharp" Version="4.5.0" />
+        <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.0.0" />
+        <PackageVersion Include="Microsoft.Quantum.Compiler" Version="0.24.201332" />
+        <PackageVersion Include="Microsoft.Quantum.CSharpGeneration" Version="0.24.201332" />
+        <PackageVersion Include="Microsoft.Quantum.Simulators" Version="0.24.201332" />
+        <PackageVersion Include="Microsoft.Quantum.QSharp.Core" Version="0.24.201332" />
+        <PackageVersion Include="Microsoft.Windows.Compatibility" Version="5.0.2" />
+        <PackageVersion Include="NuGet.Resolver" Version="5.1.0" />
+        <PackageVersion Include="System.DirectoryServices.Protocols" Version="5.0.1" />
+        <PackageVersion Include="System.Runtime.Loader" Version="4.3.0" />
+    </ItemGroup>
+
+    <!-- Tool.csproj -->
+    <ItemGroup>
+        <PackageVersion Include="Microsoft.Extensions.Logging" Version="3.0.0" />
+        <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="3.0.0" />
+        <PackageVersion Include="Microsoft.NETCore.Portable.Compatibility" Version="1.0.1" />
+        <PackageVersion Include="System.Net.Http" Version="4.3.4" />
+        <PackageVersion Include="System.Text.Json" Version="5.0.1" />
+        <PackageVersion Include="Serilog.Extensions.Logging.File" Version="2.0.0-dev-00039" />
+    </ItemGroup>
+
+    <!-- Web.csproj -->
+    <ItemGroup>
+        <PackageVersion Include="System.Net.Http" Version="4.3.4" />
+    </ItemGroup>
+
+    <!-- Kernel.csproj -->
+    <ItemGroup>
+        <PackageVersion Include="Microsoft.TypeScript.MSBuild" Version="3.9.6">
+    </ItemGroup>
+
+    <!-- Jupyter.csproj -->
+    <ItemGroup>
+        <PackageVersion Include="Microsoft.Jupyter.Core" Version="1.5.157285" />
+    </ItemGroup>
+
+    <!-- Tests.Iqsharp.csproj -->
+    <ItemGroup>
+        <PackageVersion Include="Flurl.Http" Version="2.4.2" />
+        <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="3.0.0" />
+        <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="16.1.1" />
+        <PackageVersion Include="MSTest.TestAdapter" Version="2.2.5" />
+        <PackageVersion Include="MSTest.TestFramework" Version="2.2.5" />
+    </ItemGroup>
+
+    <!-- Tests.Iqsharp.csproj & AzureClient.csproj -->
+    <ItemGroup>
+        <PackageVersion Include="Azure.Quantum.Jobs" Version="1.0.0-beta.3" />
+        <PackageVersion Include="Microsoft.Extensions.Logging" Version="3.0.0" />
+    </ItemGroup>
+
+    <!-- Jupyter.csproj & Kernel.csproj -->
+    <ItemGroup>
+        <PackageVersion Include="System.Reactive" Version="4.3.2" />
+    </ItemGroup>
+
+    <!-- ExecutionPathTracer.csproj & Core.csproj & Mock.Standard.csproj & Mock.Chemistry.csproj -->
+    <ItemGroup>
+        <PackageVersion Include="Microsoft.Quantum.Simulators" Version="0.24.201332" />
     </ItemGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -15,7 +15,6 @@
         <PackageVersion Include="Microsoft.CSharp" Version="4.5.0" />
         <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.0.0" />
         <PackageVersion Include="Microsoft.Quantum.CSharpGeneration" Version="0.24.201332" />
-        <PackageVersion Include="Microsoft.Quantum.Simulators" Version="0.24.201332" />
         <PackageVersion Include="Microsoft.Quantum.QSharp.Core" Version="0.24.201332" />
         <PackageVersion Include="Microsoft.Windows.Compatibility" Version="5.0.2" />
         <PackageVersion Include="NuGet.Resolver" Version="5.1.0" />
@@ -25,22 +24,20 @@
 
     <!-- Tool.csproj -->
     <ItemGroup>
-        <PackageVersion Include="Microsoft.Extensions.Logging" Version="3.0.0" />
         <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="3.0.0" />
         <PackageVersion Include="Microsoft.NETCore.Portable.Compatibility" Version="1.0.1" />
-        <PackageVersion Include="System.Net.Http" Version="4.3.4" />
         <PackageVersion Include="System.Text.Json" Version="5.0.1" />
         <PackageVersion Include="Serilog.Extensions.Logging.File" Version="2.0.0-dev-00039" />
     </ItemGroup>
 
-    <!-- Web.csproj -->
+    <!-- Web.csproj & Tool.csproj-->
     <ItemGroup>
         <PackageVersion Include="System.Net.Http" Version="4.3.4" />
     </ItemGroup>
 
     <!-- Kernel.csproj -->
     <ItemGroup>
-        <PackageVersion Include="Microsoft.TypeScript.MSBuild" Version="3.9.6">
+        <PackageVersion Include="Microsoft.TypeScript.MSBuild" Version="3.9.6" />
     </ItemGroup>
 
     <!-- Jupyter.csproj -->

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,5 +5,9 @@
 
     <ItemGroup>
         <PackageVersion Include="Azure.Quantum.Jobs" Version="1.0.0-beta.3" />
+        <PackageVersion Include="Microsoft.Azure.Quantum.Client" Version="0.24.201332" />
+        <PackageVersion Include="Microsoft.Rest.ClientRuntime" Version="2.3.23" />
+        <PackageVersion Include="Microsoft.Rest.ClientRuntime.Azure" Version="3.3.19" />
+        <PackageVersion Include="System.Reactive" Version="4.3.2" />
     </ItemGroup>
 </Project>

--- a/src/AzureClient/AzureClient.csproj
+++ b/src/AzureClient/AzureClient.csproj
@@ -13,11 +13,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Quantum.Jobs"/>
-    <PackageReference Include="Microsoft.Azure.Quantum.Client" Version="0.24.201332" />
-    <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.23" />
-    <PackageReference Include="Microsoft.Rest.ClientRuntime.Azure" Version="3.3.19" />
-    <PackageReference Include="System.Reactive" Version="4.3.2" />
+    <PackageReference Include="Azure.Quantum.Jobs" />
+    <PackageReference Include="Microsoft.Azure.Quantum.Client" />
+    <PackageReference Include="Microsoft.Rest.ClientRuntime" />
+    <PackageReference Include="Microsoft.Rest.ClientRuntime.Azure" />
+    <PackageReference Include="System.Reactive" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AzureClient/AzureClient.csproj
+++ b/src/AzureClient/AzureClient.csproj
@@ -13,7 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <!-- <PackageReference Include="Azure.Quantum.Jobs" Version="1.0.0-beta.3" /> -->
+    <PackageReference Include="Azure.Quantum.Jobs"/>
     <PackageReference Include="Microsoft.Azure.Quantum.Client" Version="0.24.201332" />
     <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.23" />
     <PackageReference Include="Microsoft.Rest.ClientRuntime.Azure" Version="3.3.19" />

--- a/src/AzureClient/AzureClient.csproj
+++ b/src/AzureClient/AzureClient.csproj
@@ -13,7 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Quantum.Jobs" />
+    <PackageReference Include="Azure.Quantum.Jobs" Version="1.0.0-beta.3"/>
     <PackageReference Include="Microsoft.Azure.Quantum.Client" />
     <PackageReference Include="Microsoft.Rest.ClientRuntime" />
     <PackageReference Include="Microsoft.Rest.ClientRuntime.Azure" />

--- a/src/AzureClient/AzureClient.csproj
+++ b/src/AzureClient/AzureClient.csproj
@@ -13,7 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Quantum.Jobs" Version="1.0.0-beta.3" />
+    <!-- <PackageReference Include="Azure.Quantum.Jobs" Version="1.0.0-beta.3" /> -->
     <PackageReference Include="Microsoft.Azure.Quantum.Client" Version="0.24.201332" />
     <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.23" />
     <PackageReference Include="Microsoft.Rest.ClientRuntime.Azure" Version="3.3.19" />

--- a/src/AzureClient/AzureClient.csproj
+++ b/src/AzureClient/AzureClient.csproj
@@ -13,7 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Quantum.Jobs" Version="1.0.0-beta.3"/>
+    <PackageReference Include="Azure.Quantum.Jobs" />
     <PackageReference Include="Microsoft.Azure.Quantum.Client" />
     <PackageReference Include="Microsoft.Rest.ClientRuntime" />
     <PackageReference Include="Microsoft.Rest.ClientRuntime.Azure" />

--- a/src/Core/Core.csproj
+++ b/src/Core/Core.csproj
@@ -39,7 +39,7 @@
     <PackageReference Include="Microsoft.CSharp" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Logging" />
-    <PackageReference Include="Microsoft.Quantum.Compiler" />
+    <PackageReference Include="Microsoft.Quantum.Compiler" Version="0.24.201332" />
     <PackageReference Include="Microsoft.Quantum.CSharpGeneration" />
     <PackageReference Include="Microsoft.Quantum.Simulators" />
     <PackageReference Include="Microsoft.Quantum.QSharp.Core" />

--- a/src/Core/Core.csproj
+++ b/src/Core/Core.csproj
@@ -36,17 +36,17 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.0.0" />
-    <PackageReference Include="Microsoft.Quantum.Compiler" Version="0.24.201332" />
-    <PackageReference Include="Microsoft.Quantum.CSharpGeneration" Version="0.24.201332" />
-    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.24.201332" />
-    <PackageReference Include="Microsoft.Quantum.QSharp.Core" Version="0.24.201332" />
-    <PackageReference Include="Microsoft.Windows.Compatibility" Version="5.0.2" />
-    <PackageReference Include="NuGet.Resolver" Version="5.1.0" />
-    <PackageReference Include="System.DirectoryServices.Protocols" Version="5.0.1" />
-    <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
+    <PackageReference Include="Microsoft.CSharp" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Logging" />
+    <PackageReference Include="Microsoft.Quantum.Compiler" />
+    <PackageReference Include="Microsoft.Quantum.CSharpGeneration" />
+    <PackageReference Include="Microsoft.Quantum.Simulators" />
+    <PackageReference Include="Microsoft.Quantum.QSharp.Core" />
+    <PackageReference Include="Microsoft.Windows.Compatibility" />
+    <PackageReference Include="NuGet.Resolver" />
+    <PackageReference Include="System.DirectoryServices.Protocols" />
+    <PackageReference Include="System.Runtime.Loader" />
   </ItemGroup>
 
 </Project>

--- a/src/Core/Core.csproj
+++ b/src/Core/Core.csproj
@@ -39,7 +39,7 @@
     <PackageReference Include="Microsoft.CSharp" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Logging" />
-    <PackageReference Include="Microsoft.Quantum.Compiler" Version="0.24.201332" />
+    <PackageReference Include="Microsoft.Quantum.Compiler" />
     <PackageReference Include="Microsoft.Quantum.CSharpGeneration" />
     <PackageReference Include="Microsoft.Quantum.Simulators" />
     <PackageReference Include="Microsoft.Quantum.QSharp.Core" />

--- a/src/ExecutionPathTracer/ExecutionPathTracer.csproj
+++ b/src/ExecutionPathTracer/ExecutionPathTracer.csproj
@@ -32,7 +32,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.24.201332" />
+    <PackageReference Include="Microsoft.Quantum.Simulators" />
   </ItemGroup>
 
 </Project>

--- a/src/Jupyter/Jupyter.csproj
+++ b/src/Jupyter/Jupyter.csproj
@@ -35,8 +35,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Jupyter.Core" Version="1.5.157285" />
-    <PackageReference Include="System.Reactive" Version="4.3.2" />
+    <PackageReference Include="Microsoft.Jupyter.Core" />
+    <PackageReference Include="System.Reactive" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Kernel/Kernel.csproj
+++ b/src/Kernel/Kernel.csproj
@@ -23,7 +23,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Reactive" Version="4.3.2" />
+    <PackageReference Include="System.Reactive" />
   </ItemGroup>
 
   <!-- TypeScript compilation -->
@@ -35,7 +35,7 @@
     <Content Include="tsconfig.json">
       <CopyToOutputDirectory>Never</CopyToOutputDirectory>
     </Content>
-    <PackageReference Include="Microsoft.TypeScript.MSBuild" Version="3.9.6">
+    <PackageReference Include="Microsoft.TypeScript.MSBuild">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/src/MockLibraries/Mock.Chemistry/Mock.Chemistry.csproj
+++ b/src/MockLibraries/Mock.Chemistry/Mock.Chemistry.csproj
@@ -6,6 +6,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.24.201332" />
+    <PackageReference Include="Microsoft.Quantum.Simulators" />
   </ItemGroup>
 </Project>

--- a/src/MockLibraries/Mock.Chemistry/Mock.Chemistry.csproj
+++ b/src/MockLibraries/Mock.Chemistry/Mock.Chemistry.csproj
@@ -7,5 +7,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Quantum.Simulators" />
+    <PackageReference Include="Microsoft.Quantum.CSharpGeneration" />
   </ItemGroup>
 </Project>

--- a/src/MockLibraries/Mock.Standard/Mock.Standard.csproj
+++ b/src/MockLibraries/Mock.Standard/Mock.Standard.csproj
@@ -6,6 +6,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.24.201332" />
+    <PackageReference Include="Microsoft.Quantum.Simulators" />
   </ItemGroup>
 </Project>

--- a/src/MockLibraries/Mock.Standard/Mock.Standard.csproj
+++ b/src/MockLibraries/Mock.Standard/Mock.Standard.csproj
@@ -7,5 +7,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Quantum.Simulators" />
+    <PackageReference Include="Microsoft.Quantum.CSharpGeneration" />
   </ItemGroup>
 </Project>

--- a/src/Tests/Tests.IQsharp.csproj
+++ b/src/Tests/Tests.IQsharp.csproj
@@ -23,7 +23,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Quantum.Jobs" />
+    <PackageReference Include="Azure.Quantum.Jobs" Version="1.0.0-beta.3"/>
     <PackageReference Include="Flurl.Http" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" />
     <PackageReference Include="Microsoft.Extensions.Logging" />

--- a/src/Tests/Tests.IQsharp.csproj
+++ b/src/Tests/Tests.IQsharp.csproj
@@ -23,13 +23,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Quantum.Jobs" Version="1.0.0-beta.3" />
-    <PackageReference Include="Flurl.Http" Version="2.4.2" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.5" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.5" />
+    <PackageReference Include="Azure.Quantum.Jobs" />
+    <PackageReference Include="Flurl.Http" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" />
+    <PackageReference Include="Microsoft.Extensions.Logging" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="MSTest.TestAdapter" />
+    <PackageReference Include="MSTest.TestFramework" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Tests/Tests.IQsharp.csproj
+++ b/src/Tests/Tests.IQsharp.csproj
@@ -23,7 +23,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Quantum.Jobs" Version="1.0.0-beta.3"/>
+    <PackageReference Include="Azure.Quantum.Jobs"/>
     <PackageReference Include="Flurl.Http" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" />
     <PackageReference Include="Microsoft.Extensions.Logging" />

--- a/src/Tool/Tool.csproj
+++ b/src/Tool/Tool.csproj
@@ -49,12 +49,12 @@
 
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.0.0" />
-    <PackageReference Include="Microsoft.NETCore.Portable.Compatibility" Version="1.0.1" />
-    <PackageReference Include="System.Net.Http" Version="4.3.4" />
-    <PackageReference Include="System.Text.Json" Version="5.0.1" />
-    <PackageReference Include="Serilog.Extensions.Logging.File" Version="2.0.0-dev-00039" />
+    <PackageReference Include="Microsoft.Extensions.Logging" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+    <PackageReference Include="Microsoft.NETCore.Portable.Compatibility" />
+    <PackageReference Include="System.Net.Http" />
+    <PackageReference Include="System.Text.Json" />
+    <PackageReference Include="Serilog.Extensions.Logging.File" />
   </ItemGroup>
 
 </Project>

--- a/src/Web/Web.csproj
+++ b/src/Web/Web.csproj
@@ -13,7 +13,7 @@
   
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="System.Net.Http" Version="4.3.4" />
+    <PackageReference Include="System.Net.Http" />
   </ItemGroup>
   
   <ItemGroup>


### PR DESCRIPTION
Adding central package management via `Directory.Packages.props` files will simplify how we manage nuget dependencies. This will further allow us to use lockfiles with NuGet for pipeline caching.