### PR TITLE
Update source of base image

### DIFF
--- a/images/test-environments/linux/Dockerfile
+++ b/images/test-environments/linux/Dockerfile
@@ -3,7 +3,7 @@ ARG UBUNTU_VER=20.04
 ARG OS_TYPE=x86_64
 ARG PY_VER=3.7
 
-FROM ubuntu:${UBUNTU_VER}
+FROM mcr.microsoft.com/mirror/docker/library/ubuntu:${UBUNTU_VER}
 
 RUN apt-get update && apt-get install -yq curl wget jq
 


### PR DESCRIPTION
Update the source of the linux base image to the Microsoft mirror. This resolves an active compliance alert and brings us further in line with guidance about image sources.