### PR TITLE
Updating jupyter-core to latest version.

### DIFF
--- a/src/Jupyter/Jupyter.csproj
+++ b/src/Jupyter/Jupyter.csproj
@@ -37,7 +37,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Jupyter.Core" Version="1.5.157285" />
+    <PackageReference Include="Microsoft.Jupyter.Core" Version="2.1.226704" />
     <PackageReference Include="System.Reactive" Version="4.3.2" />
   </ItemGroup>
 


### PR DESCRIPTION
Updating jupyter-core to latest version. This package has been updated to the latest NetMQ package and we expect this to fix all current locking issues with Python, including:
* #703 
* #549 
* #510 
* #376 
