### PR TITLE
Unify conda build scripts.

### DIFF
--- a/build/ci.yml
+++ b/build/ci.yml
@@ -47,40 +47,36 @@ jobs:
     vmImage: 'ubuntu-latest'
   steps:
   - template: steps-selfcontained.yml
-  condition: ne(variables['Enable.Conda'], 'false')
+  condition: and(succeeded(), ne(variables['Enable.Conda'], 'false'))
 
 - job: "pack_conda_macos"
   dependsOn: "pack_selfcontained"
+  condition: and(succeeded(), ne(variables['Enable.Conda'], 'false'))
   pool:
     vmImage: 'macOS-latest'
   variables:
-    OS: 'mac'
-    CondaShellHook: "$('/usr/local/bin/conda' 'shell.bash' 'hook')"
+    CondaPath: /usr/local/bin/
   steps:
   - template: steps-conda.yml
-  condition: ne(variables['Enable.Conda'], 'false')
-
+  
 - job: "pack_conda_linux"
   dependsOn: "pack_selfcontained"
+  condition: and(succeeded(), ne(variables['Enable.Conda'], 'false'))
   pool:
     vmImage: 'ubuntu-latest'
-  container: mcr.microsoft.com/quantum/linux-selfcontained:latest
+  container: 'mcr.microsoft.com/quantum/linux-selfcontained:latest'
   variables:
-    OS: 'linux'
-    CondaPath: '/miniconda/bin'
-    CondaShellHook: "$('/miniconda/bin/conda' 'shell.bash' 'hook')"
+    CondaPath:  /miniconda/bin/
   steps:
   - template: steps-conda.yml
-  condition: ne(variables['Enable.Conda'], 'false')
-
+  
 - job: "pack_conda_windows"
   dependsOn: "pack_selfcontained"
+  condition: and(succeeded(), ne(variables['Enable.Conda'], 'false'))
   pool:
     vmImage: 'windows-latest'
-  container: mcr.microsoft.com/quantum/windows-selfcontained:latest
+  container: 'mcr.microsoft.com/quantum/windows-selfcontained:latest'
   variables:
-    OS: 'windows'
-    CondaPath: 'C:\Miniconda3\Scripts'
+    CondaPath: C:\Miniconda3\Scripts
   steps:
   - template: steps-conda.yml
-  condition: ne(variables['Enable.Conda'], 'false')

--- a/build/ci.yml
+++ b/build/ci.yml
@@ -55,7 +55,7 @@ jobs:
   pool:
     vmImage: 'macOS-latest'
   variables:
-    CondaPath: /usr/local/bin/
+    CondaPath: '/usr/local/bin/'
   steps:
   - template: steps-conda.yml
   
@@ -66,7 +66,7 @@ jobs:
     vmImage: 'ubuntu-latest'
   container: 'mcr.microsoft.com/quantum/linux-selfcontained:latest'
   variables:
-    CondaPath:  /miniconda/bin/
+    CondaPath: '/miniconda/bin/'
   steps:
   - template: steps-conda.yml
   
@@ -77,6 +77,6 @@ jobs:
     vmImage: 'windows-latest'
   container: 'mcr.microsoft.com/quantum/windows-selfcontained:latest'
   variables:
-    CondaPath: C:\Miniconda3\Scripts
+    CondaPath: 'C:\Miniconda3\Scripts'
   steps:
   - template: steps-conda.yml

--- a/build/steps-conda.yml
+++ b/build/steps-conda.yml
@@ -14,8 +14,8 @@ steps:
 
 - task: UsePythonVersion@0
   inputs:
-    versionSpec: 3.9
-  displayName: 'Use Python 3.9'
+    versionSpec: 3.7
+  displayName: 'Use Python 3.7'
 
 - pwsh: |
     "CondaPath: $(CondaPath)" | Write-Host
@@ -58,22 +58,9 @@ steps:
     conda create --yes --name $CondaEnvironmentName
 
     "##[info]Installing conda packages" | Write-Host
-    conda install --yes --name $CondaEnvironmentName python=3.9 pip conda-build=3.21.9 conda-package-handling=1.8.1
+    conda install --yes --name $CondaEnvironmentName python=3.7 pip setuptools pytest jupyter numpy conda-build=3.18.8 conda-package-handling=1.3.11
   displayName: Create and setup conda environment
 
-- pwsh: |
-    "##[info]Activating conda environment:  $(CondaEnvironmentName)" | Write-Host
-    $(CondaShellHook)
-    conda activate $(CondaEnvironmentName)
-    conda info
-
-    $requirements = Join-Path 'src' 'Python' 'requirements.txt'
-    "##[info]Install requirements from: $requirements" | Write-Host
-    pip install -r $requirements
-  displayName: Install PyPI packages
-
-##
-# Pack conda packages for each OS
 ##
 # Running pack-conda.ps1 from a new, independent instance of pwsh
 # prevents Azure Pipelines from interpreting the stderr stream from

--- a/build/steps-conda.yml
+++ b/build/steps-conda.yml
@@ -6,6 +6,28 @@ steps:
 ##
 # Pre-reqs
 ##
+- task: UseDotNet@2
+  displayName: 'Use .NET SDK'
+  inputs:
+    packageType: sdk
+    useGlobalJson: true
+
+- task: UsePythonVersion@0
+  inputs:
+    versionSpec: 3.9
+  displayName: 'Use Python 3.9'
+
+- pwsh: |
+    "CondaPath: $(CondaPath)" | Write-Host
+    "##vso[task.prependpath]$(CondaPath)" | Write-Host
+  displayName: Add Conda to Path
+
+# On Hosted macOS, the agent user doesn't have ownership of Miniconda's installation directory/
+# We need to take ownership if we want to update conda or install packages globally
+- bash: sudo chown -R $USER $CONDA
+  displayName: Take ownership of conda installation
+  condition: eq(variables['Agent.OS'], 'Darwin')
+  
 - task: DownloadBuildArtifacts@0
   inputs:
     artifactName: iqsharp
@@ -15,47 +37,44 @@ steps:
   displayName: "Move build artifacts to IQ# working directory"
 
 ##
-# Create conda environment
+# Create and prepare conda environment
 ##
-- script: |
-    eval "$(CondaShellHook)"
-    conda create --yes --quiet --name conda_env
-  displayName: Create Anaconda environment
-  condition: or(eq(variables.OS, 'linux'), eq(variables.OS, 'mac'))
+- pwsh: |
+    "##[info]Conda environment variables" | Write-Host
+    Get-ChildItem env:CONDA*, env:*VERSION | Format-Table | Out-String | Write-Host
+
+    $CondaLocation=$(Get-Command conda | Select-Object -ExpandProperty Source)
+    "##[info]CondaLocation: $CondaLocation" | Write-Host
+    "##vso[task.setvariable variable=CondaLocation]$CondaLocation" | Write-Host
+
+    $CondaShellHook="(`& $CondaLocation 'shell.powershell' 'hook') | Out-String | Invoke-Expression"
+    "##[info]CondaShellHook: $CondaShellHook" | Write-Host
+    "##vso[task.setvariable variable=CondaShellHook]$CondaShellHook" | Write-Host
+
+    $CondaEnvironmentName='conda_env'
+    "##vso[task.setvariable variable=CondaEnvironmentName]$CondaEnvironmentName" | Write-Host
+
+    "##[info]Creating conda environment" | Write-Host
+    conda create --yes --name $CondaEnvironmentName
+
+    "##[info]Installing conda packages" | Write-Host
+    conda install --yes --name $CondaEnvironmentName python=3.9 pip conda-build=3.21.9 conda-package-handling=1.8.1
+  displayName: Create and setup conda environment
 
 - pwsh: |
-    $(CondaPath)/conda.exe create --yes --quiet --name conda_env
-  displayName: Create Anaconda environment pwsh
-  condition: eq(variables.OS, 'windows')
+    "##[info]Activating conda environment:  $(CondaEnvironmentName)" | Write-Host
+    $(CondaShellHook)
+    conda activate $(CondaEnvironmentName)
+    conda info
 
-##
-# Install conda packages
-##
-- script: |
-    eval "$(CondaShellHook)"
-    conda install --yes --quiet --name base conda-build=3.18.8
-    conda install --yes --quiet --name conda_env python=3.7 pip setuptools pytest jupyter numpy conda-build=3.18.8 conda-package-handling=1.3.11
-  displayName: Install Anaconda packages
-  condition: or(eq(variables.OS, 'linux'), eq(variables.OS, 'mac'))
-
-- pwsh: |
-    $(CondaPath)/conda.exe install --yes --quiet --name base conda-build=3.18.8
-    $(CondaPath)/conda.exe install --yes --quiet --name conda_env python=3.7 pip setuptools pytest jupyter numpy conda-build=3.18.8 conda-package-handling=1.3.11
-  displayName: Install Anaconda packages
-  condition: eq(variables.OS, 'windows')
+    $requirements = Join-Path 'src' 'Python' 'requirements.txt'
+    "##[info]Install requirements from: $requirements" | Write-Host
+    pip install -r $requirements
+  displayName: Install PyPI packages
 
 ##
 # Pack conda packages for each OS
 ##
-- script: |
-    eval "$(CondaShellHook)"
-    conda activate conda_env
-    conda info
-    pwsh -NoProfile -Command ./pack-conda.ps1
-  displayName: "Packing IQ# packages"
-  workingDirectory: '$(System.DefaultWorkingDirectory)/build'
-  condition: and(succeeded(), ne(variables['Skip.Tests'], 'true'), or(eq(variables.OS, 'linux'), eq(variables.OS, 'mac')))
-
 # Running pack-conda.ps1 from a new, independent instance of pwsh
 # prevents Azure Pipelines from interpreting the stderr stream from
 # conda-build as an exception stream, making it easier to capture
@@ -64,34 +83,27 @@ steps:
 # Note that any actual failures in conda-build can be detected by examining
 # exit codes and by testing the artifacts produced by pack-conda.ps1.
 - pwsh: |
-    (& "$(CondaPath)/conda.exe" "shell.powershell" "hook") | Out-String | Invoke-Expression
-    conda activate conda_env
+    "##[info]Activating conda environment:  $(CondaEnvironmentName)" | Write-Host
+    $(CondaShellHook)
+    conda activate $(CondaEnvironmentName)
     conda info
     pwsh -NoProfile -Command ./pack-conda.ps1
   displayName: "Packing IQ# packages"
   workingDirectory: '$(System.DefaultWorkingDirectory)/build'
-  condition: eq(variables.OS, 'windows')
+
 
 ##
 # Test conda packages for each OS
 ##
-- script: |
-    eval "$(CondaShellHook)"
-    conda activate conda_env
-    conda info
-    pwsh -NoProfile -Command ./test-conda.ps1
-  displayName: "Testing IQ# packages"
-  workingDirectory: '$(System.DefaultWorkingDirectory)/build'
-  condition: and(succeeded(), ne(variables['Skip.Tests'], 'true'), or(eq(variables.OS, 'linux'), eq(variables.OS, 'mac')))
-
 - pwsh: |
-    (& "$(CondaPath)/conda.exe" "shell.powershell" "hook") | Out-String | Invoke-Expression
-    conda activate conda_env
+    "##[info]Activating conda environment:  $(CondaEnvironmentName)" | Write-Host
+    $(CondaShellHook)
+    conda activate $(CondaEnvironmentName)
     conda info
     pwsh -NoProfile -Command ./test-conda.ps1
   displayName: "Testing IQ# packages"
   workingDirectory: '$(System.DefaultWorkingDirectory)/build'
-  condition: and(succeeded(), ne(variables['Skip.Tests'], 'true'), eq(variables.OS, 'windows'))
+  condition: and(succeeded(), ne(variables['Skip.Tests'], 'true'))
 
 ##
 # Publish build artifacts.

--- a/build/steps-conda.yml
+++ b/build/steps-conda.yml
@@ -12,11 +12,6 @@ steps:
     packageType: sdk
     useGlobalJson: true
 
-- task: UsePythonVersion@0
-  inputs:
-    versionSpec: 3.7
-  displayName: 'Use Python 3.7'
-
 - pwsh: |
     "CondaPath: $(CondaPath)" | Write-Host
     "##vso[task.prependpath]$(CondaPath)" | Write-Host

--- a/build/steps.yml
+++ b/build/steps.yml
@@ -22,12 +22,6 @@ steps:
   displayName: "Bootstrap"
   workingDirectory: '$(System.DefaultWorkingDirectory)'
 
-
-- task: CondaEnvironment@1
-  inputs:
-    packageSpecs: "python=3.7 pip setuptools pytest jupyter numpy"
-  displayName: 'Use conda environment w/ Python 3.'
-
 - pwsh: |
     pip install `
       setuptools `

--- a/build/steps.yml
+++ b/build/steps.yml
@@ -7,24 +7,36 @@ steps:
 ##
 # Pre-reqs
 ##
-- task: CondaEnvironment@1
-  inputs:
-    packageSpecs: "python=3.7 pip setuptools pytest jupyter numpy"
-  displayName: 'Use conda environment w/ Python 3.'
-
-- pwsh: |
-    conda install --yes -c conda-forge qutip
-  displayName: "Add QuTiP to conda environment."
-
 - task: UseDotNet@2
   displayName: 'Use .NET SDK'
   inputs:
     packageType: sdk
     useGlobalJson: true
 
+- task: UsePythonVersion@0
+  inputs:
+    versionSpec: 3.7
+  displayName: 'Use Python 3.7'
+
 - pwsh: .\bootstrap.ps1
   displayName: "Bootstrap"
   workingDirectory: '$(System.DefaultWorkingDirectory)'
+
+
+- task: CondaEnvironment@1
+  inputs:
+    packageSpecs: "python=3.7 pip setuptools pytest jupyter numpy"
+  displayName: 'Use conda environment w/ Python 3.'
+
+- pwsh: |
+    pip install `
+      setuptools `
+      pytest `
+      jupyter `
+      numpy `
+      wheel `
+      qutip
+  displayName: "Install Python tools."
 
 ##
 # Build, test & pack


### PR DESCRIPTION
Conda build scripts had triplicated code, one for each OS that we support (Windows, Linux, Mac) with very small variables.
These changes update the build scripts to use the same code for all environments.