### PR TITLE
Remove deprecated Azure Function access key

### DIFF
--- a/src/Kernel/client/telemetry.ts
+++ b/src/Kernel/client/telemetry.ts
@@ -89,11 +89,6 @@ class CookieConsentHelper {
         });
     }
 
-    private onConsentChanged(categoryPreferences: Record<ConsentCategories, boolean>) {
-        console.log("onConsentChanged", categoryPreferences);
-        this.checkRequiredConsent();
-    }
-
     private checkRequiredConsent() {
         const hasConsent = this.siteConsent.getConsentFor(ConsentCategories.Required);
         console.log(`HasConsent: ${hasConsent}`);
@@ -127,7 +122,12 @@ class CookieConsentHelper {
             } else {
                 console.log("Error initializing WcpConsent: " + err);
             }
-        }, this.onConsentChanged, window.matchMedia('prefers-color-scheme: dark').matches ? Themes.dark : Themes.light);
+        }, 
+        (categoryPreferences: Record<ConsentCategories, boolean>) => {
+            console.log("onConsentChanged", categoryPreferences);
+            this.checkRequiredConsent();
+        },
+        window.matchMedia('prefers-color-scheme: dark').matches ? Themes.dark : Themes.light);
     }
 }
 

--- a/src/Kernel/client/telemetry.ts
+++ b/src/Kernel/client/telemetry.ts
@@ -1,8 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-//[SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine", Justification="This function access is supposed to be public.")]
-const CLIENT_INFO_API_URL = 'https://iqsharp-telemetry.azurewebsites.net/api/GetClientInfo?code=1kIsLwHdwLlH9n5LflhgVlafZaTH122yPK/3xezIjCQqC87MJrkdyQ==';
+const CLIENT_INFO_API_URL = 'https://iqsharp-telemetry.azurewebsites.net/api/GetClientInfo?';
 
 const COOKIE_CONSENT_JS = 'https://wcpstatic.microsoft.com/mscc/lib/v2/wcp-consent.js';
 

--- a/src/Tool/Untitled.ipynb
+++ b/src/Tool/Untitled.ipynb
@@ -1,0 +1,27 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5f3293d1",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Q#",
+   "language": "qsharp",
+   "name": "iqsharp"
+  },
+  "language_info": {
+   "file_extension": ".qs",
+   "mimetype": "text/x-qsharp",
+   "name": "qsharp",
+   "version": "0.26"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Remove the deprecated access key from the telemetry Azure Function endpoint.
The endpoint is public and having a public key was redundant.

Also fixed a small javascript bug in the telemetry library that didn't affect any functionality but was raising an error in the console.

This change along with some backend changes were tested in multiple environments and using VPN to simulate the user being present in countries which require a cookie banner to be displayed (even if only essential cookies are used).