### PR TITLE
Update Jupyter Core package to version 3.1.235334

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -12786,7 +12786,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 ---------------------------------------------------------
 
-Microsoft.Jupyter.Core 3.0.233310 - MIT
+Microsoft.Jupyter.Core 3.1.235334 - MIT
 
 
 (c) 2022 GitHub, Inc.

--- a/src/Jupyter/Jupyter.csproj
+++ b/src/Jupyter/Jupyter.csproj
@@ -37,7 +37,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Jupyter.Core" Version="3.0.233310" />
+    <PackageReference Include="Microsoft.Jupyter.Core" Version="3.1.235334" />
     <PackageReference Include="System.Reactive" Version="4.3.2" />
   </ItemGroup>
 


### PR DESCRIPTION
This change updates the dependency on System.Security.Cryptography.Xml to 6.0.1, in order to fix security vulnerability CVE-2022-34716.

See related change in Jupyter Core:
https://github.com/microsoft/jupyter-core/pull/95