### PR TITLE
Fix rendering of error message link

### DIFF
--- a/src/AzureClient/Resources.cs
+++ b/src/AzureClient/Resources.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
             "No execution target has been configured for Azure Quantum job submission.";
 
         public const string AzureClientErrorInvalidTarget =
-            "The specified target is not enabled in this workspace. Please make sure the target name is valid and that the associated provider is added to your workspace. To add a provider to your quantum workspace in the Azure Portal, see https://aka.ms/AQ/Docs/AddProvider";
+            "The specified target is not enabled in this workspace. Please make sure the target name is valid and that the associated provider is added to your workspace. To add a provider to your quantum workspace in the Azure Portal, see https://aka.ms/AQ/Docs/AddProvider ";
 
         public const string AzureClientErrorJobNotFound =
             "No job with the given ID was found in the current Azure Quantum workspace.";


### PR DESCRIPTION
Adds a space after the link so that ansi-to-react (used by nteract outputs, which is used by Azure Notebooks), correctly linkifies the text (right now, the link is invalid, since it counts surrounding '}. It's a bit hacky, but otherwise, to fix would require three layers of dependencies to address the problem (1. modify ansi-to-react regex, 2. upgrade ansi-to-react in nteract outputs, 3. upgrade nteract outputs in AzNB).

The current error message is causing the following incorrect link:

AzureError: {'error_code': 1003, 'error_name': 'InvalidTarget', 'error_description': 'The specified target is not enabled in this workspace. Please make sure the target name is valid and that the associated provider is added to your workspace. To add a provider to your quantum workspace in the Azure Portal, see [https://aka.ms/AQ/Docs/AddProvider'}](https://aka.ms/AQ/Docs/AddProvider%27%7d)Target microsoft.estimator is not available in the current Azure Quantum workspace.
