### PR TITLE
Fixing the undesirable dependencies issue for qdk.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ See the [introduction to quantum computing](https://docs.microsoft.com/azure/qua
 
 ## Getting Started ##
 
-The Jupyter kernel provided in this repository is built using [.NET 6.0](https://dotnet.microsoft.com/en-us/download) and the compiler infrastructure provided with the [Quantum Development Kit](https://docs.microsoft.com/azure/quantum).
+The Jupyter kernel provided in this repository is built using [.NET 6.0](https://dotnet.microsoft.com/download) and the compiler infrastructure provided with the [Quantum Development Kit](https://docs.microsoft.com/azure/quantum).
 Please see the [getting started guide](https://docs.microsoft.com/azure/quantum/install-overview-qdk) for how to get up and running.
 
 You may also visit the [**microsoft/quantum**](https://github.com/microsoft/quantum) repository, which offers a wide variety

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This kernel provides Q# support for the Jupyter platform, as well as the backend
 - **[src/Kernel/](./src/Kernel/)**: Assembly used to interoperate between Jupyter and the rest of the IQ# kernel.
 - **[src/Python/](./src/Python)**: Python package for accessing IQ#.
 - **[src/Tests/](./src/Tests/)**: Unit tests for IQ#.
-- **[src/Tool/](./src/Tool/)**: .NET Core Global Tool used to install and launch IQ#.
+- **[src/Tool/](./src/Tool/)**: .NET Global Tool used to install and launch IQ#.
 - **[src/Web/](./src/Web/)**: Provides a RESTful API into IQ#.
 
 ## New to Quantum? ##
@@ -18,7 +18,7 @@ See the [introduction to quantum computing](https://docs.microsoft.com/azure/qua
 
 ## Getting Started ##
 
-The Jupyter kernel provided in this repository is built using [.NET Core](https://docs.microsoft.com/dotnet/core/) (2.2 or later) and the compiler infrastructure provided with the [Quantum Development Kit](https://docs.microsoft.com/azure/quantum).
+The Jupyter kernel provided in this repository is built using [.NET 6.0](https://dotnet.microsoft.com/en-us/download) and the compiler infrastructure provided with the [Quantum Development Kit](https://docs.microsoft.com/azure/quantum).
 Please see the [getting started guide](https://docs.microsoft.com/azure/quantum/install-overview-qdk) for how to get up and running.
 
 You may also visit the [**microsoft/quantum**](https://github.com/microsoft/quantum) repository, which offers a wide variety
@@ -34,7 +34,7 @@ npm install
 ```
 
 To build IQ# from Visual Studio 2017 or later, please use the [`iqsharp.sln`](./iqsharp.sln) solution file.
-To build using the .NET Core SDK, please run `dotnet build iqsharp.sln`.
+To build using the .NET SDK, please run `dotnet build iqsharp.sln`.
 
 In either case, the IQ# kernel can be installed by using `dotnet run`:
 
@@ -52,11 +52,11 @@ dotnet run -- install --develop
 
 This can cause some issues, especially when running multiple instances of IQ#, such that we recommend against using development mode in general usage.
 
-Note that when building IQ# from source, this repository is configured so that .NET Core will automatically look at the [Quantum Development Kit prerelease feed](https://dev.azure.com/ms-quantum-public/Microsoft%20Quantum%20(public)/_packaging?_a=feed&feed=alpha) in addition to any other feeds you may have configured.
+Note that when building IQ# from source, this repository is configured so that .NET will automatically look at the [Quantum Development Kit prerelease feed](https://dev.azure.com/ms-quantum-public/Microsoft%20Quantum%20(public)/_packaging?_a=feed&feed=alpha) in addition to any other feeds you may have configured.
 
 ### Using IQ# as a Container ###
 
-This repository provides a [Dockerfile](./images/iqsharp-base/Dockerfile) that includes the .NET Core SDK, Python, Jupyter Notebook, and the IQ# kernel.
+This repository provides a [Dockerfile](./images/iqsharp-base/Dockerfile) that includes the .NET SDK, Python, Jupyter Notebook, and the IQ# kernel.
 
 The image built from this Dockerfile is hosted on the [Microsoft Container Registry](https://github.com/microsoft/ContainerRegistry) as the `quantum/iqsharp-base` repository.
 The `iqsharp-base` image can be used, for instance, to quickly enable using [Binder](https://gke.mybinder.org/) with Q#-language repositories, or as a base image for [Visual Studio Code Development Containers](https://code.visualstudio.com/docs/remote/containers).

--- a/build/manifest.ps1
+++ b/build/manifest.ps1
@@ -26,11 +26,11 @@ $artifacts = @{
     ) | ForEach-Object { Join-Path $Env:NUGET_OUTDIR "$_.$Env:NUGET_VERSION.nupkg" };
 
     Assemblies = @(
-        "./src/AzureClient/bin/$Env:BUILD_CONFIGURATION/netstandard2.1/Microsoft.Quantum.IQSharp.AzureClient.dll",
-        "./src/Core/bin/$Env:BUILD_CONFIGURATION/netstandard2.1/Microsoft.Quantum.IQSharp.Core.dll",
-        "./src/ExecutionPathTracer/bin/$Env:BUILD_CONFIGURATION/netstandard2.1/Microsoft.Quantum.IQSharp.ExecutionPathTracer.dll",
-        "./src/Jupyter/bin/$Env:BUILD_CONFIGURATION/netstandard2.1/Microsoft.Quantum.IQSharp.Jupyter.dll",
-        "./src/Kernel/bin/$Env:BUILD_CONFIGURATION/netstandard2.1/Microsoft.Quantum.IQSharp.Kernel.dll",
+        "./src/AzureClient/bin/$Env:BUILD_CONFIGURATION/net6.0/Microsoft.Quantum.IQSharp.AzureClient.dll",
+        "./src/Core/bin/$Env:BUILD_CONFIGURATION/net6.0/Microsoft.Quantum.IQSharp.Core.dll",
+        "./src/ExecutionPathTracer/bin/$Env:BUILD_CONFIGURATION/net6.0/Microsoft.Quantum.IQSharp.ExecutionPathTracer.dll",
+        "./src/Jupyter/bin/$Env:BUILD_CONFIGURATION/net6.0/Microsoft.Quantum.IQSharp.Jupyter.dll",
+        "./src/Kernel/bin/$Env:BUILD_CONFIGURATION/net6.0/Microsoft.Quantum.IQSharp.Kernel.dll",
         "./src/Tool/bin/$Env:BUILD_CONFIGURATION/net6.0/Microsoft.Quantum.IQSharp.dll",
         "./src/Web/bin/$Env:BUILD_CONFIGURATION/net6.0/Microsoft.Quantum.IQSharp.Web.dll"
     ) | ForEach-Object { Join-Path $PSScriptRoot (Join-Path ".." $_) };

--- a/src/AzureClient/AzureClient.csproj
+++ b/src/AzureClient/AzureClient.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
     <RootNamespace>Microsoft.Quantum.IQSharp.AzureClient</RootNamespace>
     <AssemblyName>Microsoft.Quantum.IQSharp.AzureClient</AssemblyName>

--- a/src/Core/Core.csproj
+++ b/src/Core/Core.csproj
@@ -47,7 +47,7 @@
     <PackageReference Include="Microsoft.Quantum.QSharp.Core" Version="0.27.253010" />
     <PackageReference Include="Microsoft.Windows.Compatibility" Version="6.0.1" />
     <PackageReference Include="NuGet.Resolver" Version="5.7.3" />
-    <PackageReference Include="System.DirectoryServices.Protocols" Version="5.0.1" />
+    <PackageReference Include="System.DirectoryServices.Protocols" Version="6.0.1" />
     <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
   </ItemGroup>
 

--- a/src/Core/Core.csproj
+++ b/src/Core/Core.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
     <RootNamespace>Microsoft.Quantum.IQSharp</RootNamespace>
     <AssemblyName>Microsoft.Quantum.IQSharp.Core</AssemblyName>

--- a/src/Core/Core.csproj
+++ b/src/Core/Core.csproj
@@ -45,7 +45,7 @@
     <PackageReference Include="Microsoft.Quantum.CSharpGeneration" Version="0.27.253010" />
     <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.27.253010" />
     <PackageReference Include="Microsoft.Quantum.QSharp.Core" Version="0.27.253010" />
-    <PackageReference Include="Microsoft.Windows.Compatibility" Version="5.0.2" />
+    <PackageReference Include="Microsoft.Windows.Compatibility" Version="6.0.1" />
     <PackageReference Include="NuGet.Resolver" Version="5.7.3" />
     <PackageReference Include="System.DirectoryServices.Protocols" Version="5.0.1" />
     <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />

--- a/src/Core/Core.csproj
+++ b/src/Core/Core.csproj
@@ -46,7 +46,7 @@
     <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.27.253010" />
     <PackageReference Include="Microsoft.Quantum.QSharp.Core" Version="0.27.253010" />
     <PackageReference Include="Microsoft.Windows.Compatibility" Version="5.0.2" />
-    <PackageReference Include="NuGet.Resolver" Version="5.1.0" />
+    <PackageReference Include="NuGet.Resolver" Version="5.7.3" />
     <PackageReference Include="System.DirectoryServices.Protocols" Version="5.0.1" />
     <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
   </ItemGroup>

--- a/src/Core/References/NugetPackages.cs
+++ b/src/Core/References/NugetPackages.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Quantum.IQSharp
         }
 
         // The framework used to find packages.
-        public static NuGetFramework NETSTANDARD2_1 = NuGetFramework.ParseFolder("netstandard2.1");
+        public static NuGetFramework NETSTANDARD2_1 = NuGetFramework.ParseFolder("net6.0");
 
         // Nuget's logger.
         public NuGetLogger Logger { get; }

--- a/src/ExecutionPathTracer/ExecutionPathTracer.csproj
+++ b/src/ExecutionPathTracer/ExecutionPathTracer.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
     <RootNamespace>Microsoft.Quantum.IQSharp.ExecutionPathTracer</RootNamespace>
     <AssemblyName>Microsoft.Quantum.IQSharp.ExecutionPathTracer</AssemblyName>

--- a/src/Jupyter/Jupyter.csproj
+++ b/src/Jupyter/Jupyter.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
     <RootNamespace>Microsoft.Quantum.IQSharp.Jupyter</RootNamespace>
     <AssemblyName>Microsoft.Quantum.IQSharp.Jupyter</AssemblyName>

--- a/src/Kernel/Kernel.csproj
+++ b/src/Kernel/Kernel.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
     <RootNamespace>Microsoft.Quantum.IQSharp.Kernel</RootNamespace>
     <AssemblyName>Microsoft.Quantum.IQSharp.Kernel</AssemblyName>

--- a/src/MockLibraries/Mock.Chemistry/Mock.Chemistry.csproj
+++ b/src/MockLibraries/Mock.Chemistry/Mock.Chemistry.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.Quantum.Sdk/0.27.253010">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IncludeQsharpCorePackages>false</IncludeQsharpCorePackages>    <!-- otherwise the standard library is included by the Sdk -->
   </PropertyGroup>
 

--- a/src/MockLibraries/Mock.Standard/Mock.Standard.csproj
+++ b/src/MockLibraries/Mock.Standard/Mock.Standard.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.Quantum.Sdk/0.27.253010">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IncludeQsharpCorePackages>false</IncludeQsharpCorePackages>    <!-- otherwise the standard library is included by the Sdk -->
   </PropertyGroup>
 

--- a/src/Python/qsharp-core/qsharp/tests/test_iqsharp.py
+++ b/src/Python/qsharp-core/qsharp/tests/test_iqsharp.py
@@ -266,7 +266,7 @@ def test_projects(tmp_path):
     temp_project_path.write_text(f'''
         <Project Sdk="Microsoft.Quantum.Sdk/0.12.20072031">
             <PropertyGroup>
-                <TargetFramework>netstandard2.1</TargetFramework>
+                <TargetFramework>net6.0</TargetFramework>
                 <IncludeQsharpCorePackages>false</IncludeQsharpCorePackages>
             </PropertyGroup>
         </Project>

--- a/src/Tests/NugetPackagesTests.cs
+++ b/src/Tests/NugetPackagesTests.cs
@@ -84,7 +84,7 @@ namespace Tests.IQSharp
             using (var context = new SourceCacheContext())
             {
                 await mgr.FindDependencies(pkgId, context);
-                Assert.AreEqual(163, mgr.AvailablePackages.Count());
+                Assert.AreEqual(152, mgr.AvailablePackages.Count());
             }
         }
 
@@ -99,8 +99,8 @@ namespace Tests.IQSharp
                 await mgr.FindDependencies(pkgId, context);
                 var list = mgr.ResolveDependencyGraph(pkgId).ToArray();
 
-                Assert.AreEqual(163, mgr.AvailablePackages.Count());
-                Assert.AreEqual(117, list.Length);
+                Assert.AreEqual(152, mgr.AvailablePackages.Count());
+                Assert.AreEqual(114, list.Length);
             }
         }
 
@@ -115,7 +115,7 @@ namespace Tests.IQSharp
             {
                 var dependencies = await mgr.GetPackageDependencies(pkgId, context);
 
-                Assert.AreEqual(117, dependencies.Count());
+                Assert.AreEqual(114, dependencies.Count());
             }
         }
 

--- a/src/Tests/Tests.IQsharp.csproj
+++ b/src/Tests/Tests.IQsharp.csproj
@@ -9,12 +9,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Remove="Workspace.ProjectReferences.ProjectA\obj\Debug\netstandard2.1\ProjectA.AssemblyInfo.cs" />
-    <Compile Remove="Workspace.ProjectReferences.ProjectA\obj\Release\netstandard2.1\ProjectA.AssemblyInfo.cs" />
-    <Compile Remove="Workspace.ProjectReferences.ProjectB\obj\Debug\netstandard2.1\ProjectB.AssemblyInfo.cs" />
-    <Compile Remove="Workspace.ProjectReferences.ProjectB\obj\Release\netstandard2.1\ProjectB.AssemblyInfo.cs" />
-    <Compile Remove="Workspace.ProjectReferences\obj\Debug\netstandard2.1\Workspace.ProjectReferences.AssemblyInfo.cs" />
-    <Compile Remove="Workspace.ProjectReferences\obj\Release\netstandard2.1\Workspace.ProjectReferences.AssemblyInfo.cs" />
+    <Compile Remove="Workspace.ProjectReferences.ProjectA\obj\Debug\net6.0\ProjectA.AssemblyInfo.cs" />
+    <Compile Remove="Workspace.ProjectReferences.ProjectA\obj\Release\net6.0\ProjectA.AssemblyInfo.cs" />
+    <Compile Remove="Workspace.ProjectReferences.ProjectB\obj\Debug\net6.0\ProjectB.AssemblyInfo.cs" />
+    <Compile Remove="Workspace.ProjectReferences.ProjectB\obj\Release\net6.0\ProjectB.AssemblyInfo.cs" />
+    <Compile Remove="Workspace.ProjectReferences\obj\Debug\net6.0\Workspace.ProjectReferences.AssemblyInfo.cs" />
+    <Compile Remove="Workspace.ProjectReferences\obj\Release\net6.0\Workspace.ProjectReferences.AssemblyInfo.cs" />
   </ItemGroup>
 
   <ItemGroup>
@@ -27,12 +27,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="Workspace.ProjectReferences.ProjectA\obj\Debug\netstandard2.1\ProjectA.AssemblyInfo.cs" />
-    <None Include="Workspace.ProjectReferences.ProjectA\obj\Release\netstandard2.1\ProjectA.AssemblyInfo.cs" />
-    <None Include="Workspace.ProjectReferences.ProjectB\obj\Debug\netstandard2.1\ProjectB.AssemblyInfo.cs" />
-    <None Include="Workspace.ProjectReferences.ProjectB\obj\Release\netstandard2.1\ProjectB.AssemblyInfo.cs" />
-    <None Include="Workspace.ProjectReferences\obj\Debug\netstandard2.1\Workspace.ProjectReferences.AssemblyInfo.cs" />
-    <None Include="Workspace.ProjectReferences\obj\Release\netstandard2.1\Workspace.ProjectReferences.AssemblyInfo.cs" />
+    <None Include="Workspace.ProjectReferences.ProjectA\obj\Debug\net6.0\ProjectA.AssemblyInfo.cs" />
+    <None Include="Workspace.ProjectReferences.ProjectA\obj\Release\net6.0\ProjectA.AssemblyInfo.cs" />
+    <None Include="Workspace.ProjectReferences.ProjectB\obj\Debug\net6.0\ProjectB.AssemblyInfo.cs" />
+    <None Include="Workspace.ProjectReferences.ProjectB\obj\Release\net6.0\ProjectB.AssemblyInfo.cs" />
+    <None Include="Workspace.ProjectReferences\obj\Debug\net6.0\Workspace.ProjectReferences.AssemblyInfo.cs" />
+    <None Include="Workspace.ProjectReferences\obj\Release\net6.0\Workspace.ProjectReferences.AssemblyInfo.cs" />
     <None Include="Workspace.ProjectReferences\Workspace.ProjectReferences.csproj" />
     <None Include="Workspace.ProjectReferences.ProjectA\ProjectA.csproj" />
     <None Include="Workspace.ProjectReferences.ProjectB\ProjectB.csproj" />

--- a/src/Tests/Workspace.ProjectReferences.ProjectA/ProjectA.csproj
+++ b/src/Tests/Workspace.ProjectReferences.ProjectA/ProjectA.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.Quantum.Sdk/0.27.253010">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IncludeQsharpCorePackages>false</IncludeQsharpCorePackages>    <!-- otherwise the standard library is included by the Sdk -->
   </PropertyGroup>
     

--- a/src/Tests/Workspace.ProjectReferences.ProjectB/ProjectB.csproj
+++ b/src/Tests/Workspace.ProjectReferences.ProjectB/ProjectB.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.Quantum.Sdk/0.27.253010">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IncludeQsharpCorePackages>false</IncludeQsharpCorePackages>    <!-- otherwise the standard library is included by the Sdk -->
     <IQSharpLoadAutomatically>false</IQSharpLoadAutomatically>
   </PropertyGroup>

--- a/src/Tests/Workspace.ProjectReferences/Workspace.ProjectReferences.csproj
+++ b/src/Tests/Workspace.ProjectReferences/Workspace.ProjectReferences.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.Quantum.Sdk/0.27.253010">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IncludeQsharpCorePackages>false</IncludeQsharpCorePackages>    <!-- otherwise the standard library is included by the Sdk -->
     <IQSharpLoadAutomatically>true</IQSharpLoadAutomatically>
   </PropertyGroup>


### PR DESCRIPTION
DevOps 48463, 48471.
The `netstandard2.1` target framework has undesirable dependencies, migrating the affected packages to `net6.0`.

Multi-repo PR:
[Q#Compiler](https://github.com/microsoft/qsharp-compiler/pull/1601), [Q#RT](https://github.com/microsoft/qsharp-runtime/pull/1121), [iQ#](https://github.com/microsoft/iqsharp/pull/760), [QuantumLibraries](https://github.com/microsoft/QuantumLibraries/pull/656), [Quantum-NC](https://github.com/microsoft/Quantum-NC/pull/84), [Quantum](https://github.com/microsoft/Quantum/pull/771) (samples), [Katas](https://github.com/microsoft/QuantumKatas/pull/868), QDK, and a private repo.

PR CI build can fail, but overall qdk.release (0.27.254480) has succeeded.