### PR TITLE
Deprecating old (C#-based) standalone ResourcesEstimator

### DIFF
--- a/src/Jupyter/Magic/EstimateMagic.cs
+++ b/src/Jupyter/Magic/EstimateMagic.cs
@@ -114,7 +114,7 @@ namespace Microsoft.Quantum.IQSharp.Jupyter
             qsim.OnDisplayableDiagnostic += channel.Display;
             qsim.DisableLogToConsole();
 
-            channel.Stdout("The local Resources Estimator will be removed in the March 2023. Use the new Azure Resource Estimator.");
+            channel.Stdout("The local Resources Estimator will be removed in March 2023. The Resources Estimator is now available through Azure Quantum.");
             await symbol.Operation.RunAsync(qsim, inputParameters);
 
             return qsim.Data.ToExecutionResult();

--- a/src/Jupyter/Magic/EstimateMagic.cs
+++ b/src/Jupyter/Magic/EstimateMagic.cs
@@ -114,7 +114,7 @@ namespace Microsoft.Quantum.IQSharp.Jupyter
             qsim.OnDisplayableDiagnostic += channel.Display;
             qsim.DisableLogToConsole();
 
-            channel.Stdout("The Resources Estimator will be removed in the March 2023 QDK release. Please use the Azure-based version instead.");
+            channel.Stdout("The local Resources Estimator will be removed in the March 2023. Use the new Azure Resource Estimator.");
             await symbol.Operation.RunAsync(qsim, inputParameters);
 
             return qsim.Data.ToExecutionResult();

--- a/src/Jupyter/Magic/EstimateMagic.cs
+++ b/src/Jupyter/Magic/EstimateMagic.cs
@@ -114,6 +114,7 @@ namespace Microsoft.Quantum.IQSharp.Jupyter
             qsim.OnDisplayableDiagnostic += channel.Display;
             qsim.DisableLogToConsole();
 
+            channel.Stdout("The Resources Estimator will be removed in the March 2023 QDK release. Please use the Azure-based version instead.");
             await symbol.Operation.RunAsync(qsim, inputParameters);
 
             return qsim.Data.ToExecutionResult();

--- a/src/Tests/IQsharpEngineTests.cs
+++ b/src/Tests/IQsharpEngineTests.cs
@@ -19,6 +19,8 @@ using Microsoft.Quantum.Simulation.OpenSystems.DataModel;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Newtonsoft.Json;
 using Microsoft.Extensions.DependencyInjection;
+using LlvmBindings.Values;
+using YamlDotNet.Core;
 
 
 #pragma warning disable VSTHRD200 // Use "Async" suffix for async methods
@@ -310,7 +312,10 @@ namespace Tests.IQSharp
             await AssertCompile(engine, SNIPPETS.HelloQ, "HelloQ");
 
             // Try running again:
-            await AssertEstimate(engine, "HelloQ");
+            await AssertEstimate(
+                engine,
+                "HelloQ",
+                "The local Resources Estimator will be removed in the March 2023. Use the new Azure Resource Estimator.");
         }
 
         [TestMethod]

--- a/src/Tests/IQsharpEngineTests.cs
+++ b/src/Tests/IQsharpEngineTests.cs
@@ -315,7 +315,7 @@ namespace Tests.IQSharp
             await AssertEstimate(
                 engine,
                 "HelloQ",
-                "The local Resources Estimator will be removed in the March 2023. Use the new Azure Resource Estimator.");
+                "The local Resources Estimator will be removed in March 2023. The Resources Estimator is now available through Azure Quantum.");
         }
 
         [TestMethod]


### PR DESCRIPTION
Standalone ResourcesEstimator is deprecated in February 2023 release and will be removed in March 2023 release of the QDK. Users are advised to use Azure-based resources estimator.

* Added output message to the %estimate magic command.
