### PR TITLE
Bump qutip 4.7.0 -> 4.7.1

### DIFF
--- a/src/Python/requirements.txt
+++ b/src/Python/requirements.txt
@@ -7,7 +7,7 @@ numpy==1.22.0
 pytest==7.2.0
 pygments==2.12.0    # to avoid high-severity issue.
 pyzmq==25.0.0
-qutip==4.7.0
+qutip==4.7.1
 selenium==4.2.0
 setuptools==62.6.0
 wheel==0.37.1


### PR DESCRIPTION
Building the repo with Python 3.11 causes a failure since a [prebuilt wheel does not exist for QuTip 4.7.0 x Python 3.11](https://github.com/qutip/qutip/releases/tag/v4.7.0). Instead of trying to debug the failure, bumping the dependency so the prebuilt wheel will be fetched instead.