### PR TITLE
Fix _repr_qir_ kwargs passthru

### DIFF
--- a/src/Python/qsharp-core/qsharp/loader.py
+++ b/src/Python/qsharp-core/qsharp/loader.py
@@ -167,7 +167,7 @@ class QSharpCallable(object):
         # We need to use the Base64 encoding to be able to transfer
         # the bitcode via the Jupyter protocol
         qir_bitcodeBase64 = self.as_qir(output_format="BitcodeBase64",
-                                        kwargs=kwargs)
+                                        **kwargs)
         import base64
         qir_bitcode = base64.b64decode(qir_bitcodeBase64)
         return qir_bitcode


### PR DESCRIPTION
Fix the `kwargs` parameter passthrough for the ` _repr_qir_` method introduced in #783 