### PR TITLE
Upgrade jupyter_kernel_test==0.5.0 (fixes tests)

### DIFF
--- a/conda-recipes/iqsharp/meta.yaml
+++ b/conda-recipes/iqsharp/meta.yaml
@@ -37,7 +37,7 @@ test:
     - src/conda-recipes/iqsharp/test.py
 
   commands:
-    - pip install jupyter_kernel_test==0.4.3
+    - pip install jupyter_kernel_test==0.5.0
     - powershell -NoProfile src/conda-recipes/iqsharp/test.ps1 # [win]
     - pwsh src/conda-recipes/iqsharp/test.ps1 # [not win]
 


### PR DESCRIPTION
Fixes current IQ# unit test failures.

`jupyter_kernel_test` 0.4.3 did not play well with `jupyter_client` 8.1.0, the update which was released a couple of weeks ago. Test was throwing an `AssertionError` from `__init__.py`. Bumping `jupyter_kernel_test` to the latest version makes the error go away.

Test failure: https://ms-quantum.visualstudio.com/Quantum%20Program/_build/results?buildId=264151&view=logs&j=a441add7-9a81-5f20-1dd3-aa188d376c68&t=86232dab-9126-5ce6-0181-9a916ad28dbc&l=527

List of packages from last known successful build: https://ms-quantum.visualstudio.com/Quantum%20Program/_build/results?buildId=263747&view=logs&j=01ad3c71-64d9-5e7b-32ed-837e81a00075&t=32162364-dd3a-57b7-0eaa-ba9491c5da3f&l=448

List of packages from first failing build: https://ms-quantum.visualstudio.com/Quantum%20Program/_build/results?buildId=263850&view=logs&j=8c04ef0c-0fb5-5075-182b-743e210d46d8&t=2dfd5399-7461-508f-f6cf-a93a276ce2dc&l=681
