### PR TITLE
Remove references to Microsoft.Simulator

### DIFF
--- a/src/AzureClient/AzureClient.cs
+++ b/src/AzureClient/AzureClient.cs
@@ -39,8 +39,6 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
     /// <inheritdoc/>
     public class AzureClient : IAzureClient
     {
-        private const string MicrosoftSimulator = "microsoft.simulator";
-
         internal const string MicrosoftEstimator = "microsoft.estimator";
 
         // ToDo: Use API provided by the Service, GitHub Issue: https://github.com/microsoft/iqsharp/issues/681 
@@ -48,11 +46,10 @@ namespace Microsoft.Quantum.IQSharp.AzureClient
         /// Returns whether a target ID is meant for quantum execution since not all targets
         /// exposed by providers are meant for that, such as QIO targets. More
         /// specifically, the Microsoft provider exposes targets that are not meant for
-        /// quantum execution and the only ones meant for that start with "microsoft.simulator".
+        /// quantum execution and the only ones meant for that start with "microsoft.estimator".
         /// </summary>
         private static bool IsQuantumExecutionTarget(string targetId) =>
             AzureExecutionTarget.GetProvider(targetId) != AzureProvider.Microsoft
-            || targetId.StartsWith(MicrosoftSimulator)
             || targetId.StartsWith(MicrosoftEstimator);
 
         /// <inheritdoc />

--- a/src/Tests/AzureClientTests.cs
+++ b/src/Tests/AzureClientTests.cs
@@ -326,35 +326,6 @@ namespace Tests.IQSharp
         }
 
         [TestMethod]
-        public void TestJobOutputFormats()
-        {
-            var services = Startup.CreateServiceProvider("Workspace");
-            var azureClient = (AzureClient)services.GetRequiredService<IAzureClient>();
-
-            // connect
-            var targets = ExpectSuccess<IEnumerable<TargetStatusInfo>>(ConnectToWorkspaceAsync(azureClient));
-            Assert.IsFalse(targets.Any());
-
-            // add a target
-            var azureWorkspace = azureClient.ActiveWorkspace as MockAzureWorkspace;
-            Assert.IsNotNull(azureWorkspace);
-            azureWorkspace?.AddProviders("microsoft");
-
-            // set the active target
-            var target = ExpectSuccess<TargetStatusInfo>(azureClient.SetActiveTargetAsync(new MockChannel(), "microsoft.estimator"));
-            Assert.AreEqual("microsoft.estimator", target.TargetId);
-
-            var qirResultsJob = new MockCloudJob(null, OutputFormat.QirResultsV1);
-            var quantumResultsJob = new MockCloudJob(null, OutputFormat.QuantumResultsV1);
-
-            var histogram = ExpectSuccess<Histogram>(azureClient.CreateOutput(quantumResultsJob, new MockChannel(), CancellationToken.None));
-            Assert.IsNotNull(histogram);
-
-            var stringOutput = ExpectSuccess<string>(azureClient.CreateOutput(qirResultsJob, new MockChannel(), CancellationToken.None));
-            Assert.IsNotNull(stringOutput);
-        }
-
-        [TestMethod]
         public void TestJobExecutionWithArrayInput()
         {
             var services = Startup.CreateServiceProvider("Workspace");

--- a/src/Tests/AzureClientTests.cs
+++ b/src/Tests/AzureClientTests.cs
@@ -341,8 +341,8 @@ namespace Tests.IQSharp
             azureWorkspace?.AddProviders("microsoft");
 
             // set the active target
-            var target = ExpectSuccess<TargetStatusInfo>(azureClient.SetActiveTargetAsync(new MockChannel(), "microsoft.simulator"));
-            Assert.AreEqual("microsoft.simulator", target.TargetId);
+            var target = ExpectSuccess<TargetStatusInfo>(azureClient.SetActiveTargetAsync(new MockChannel(), "microsoft.estimator"));
+            Assert.AreEqual("microsoft.estimator", target.TargetId);
 
             var qirResultsJob = new MockCloudJob(null, OutputFormat.QirResultsV1);
             var quantumResultsJob = new MockCloudJob(null, OutputFormat.QuantumResultsV1);

--- a/src/Tests/AzureClientTests.cs
+++ b/src/Tests/AzureClientTests.cs
@@ -244,7 +244,7 @@ namespace Tests.IQSharp
 
             // We subtract two due to microsoft not having a mock target. See:
             // GitHub Issue: https://github.com/microsoft/iqsharp/issues/609
-            Assert.That.Enumerable(targets).HasCount(3 * Enum.GetNames(typeof(AzureProvider)).Length - 2);
+            Assert.That.Enumerable(targets).HasCount(3 * Enum.GetNames(typeof(AzureProvider)).Length - 3);
 
             // set each target, which will load the corresponding package
             foreach (var target in targets)


### PR DESCRIPTION
Microsoft.Simulator target is being deprecated in the service. Removing references from this project.