### PR TITLE
Remove vscode live share from iqsharp-base

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Note that when building IQ# from source, this repository is configured so that .
 This repository provides a [Dockerfile](./images/iqsharp-base/Dockerfile) that includes the .NET SDK, Python, Jupyter Notebook, and the IQ# kernel.
 
 The image built from this Dockerfile is hosted on the [Microsoft Container Registry](https://github.com/microsoft/ContainerRegistry) as the `quantum/iqsharp-base` repository.
-The `iqsharp-base` image can be used, for instance, to quickly enable using [Binder](https://gke.mybinder.org/) with Q#-language repositories, or as a base image for [Visual Studio Code Development Containers](https://code.visualstudio.com/docs/remote/containers).
+The `iqsharp-base` image can be used, for instance, to quickly enable using [Binder](https://mybinder.org/) with Q#-language repositories, or as a base image for [Visual Studio Code Development Containers](https://code.visualstudio.com/docs/remote/containers).
 
 To use the `iqsharp-base` image in your own Dockerfile, make sure to begin your Dockerfile with a `FROM` line that points to the Microsoft Container Registry:
 

--- a/images/iqsharp-base/Dockerfile
+++ b/images/iqsharp-base/Dockerfile
@@ -57,13 +57,6 @@ RUN wget -qO- https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor 
     apt-get -y install procps && \
     apt-get clean && rm -rf /var/lib/apt/lists/
 
-# Install prerequisites needed for integration with Live Share and VS Online.
-# TODO: Consider splitting this out into a new "extended" IQ# image.
-RUN wget -O /tmp/vsls-reqs https://aka.ms/vsls-linux-prereq-script && \
-    chmod +x /tmp/vsls-reqs && /tmp/vsls-reqs && \
-    rm /tmp/vsls-reqs && \
-    apt-get clean && rm -rf /var/lib/apt/lists/
-
 # create user with a home directory
 # Required for mybinder.org
 ARG NB_USER=jovyan


### PR DESCRIPTION
Remove vscode live share from iqsharp-base, because the script no longer works, and there are no known dependencies on live-share.