### PR TITLE
Update Certifi and Cryptography Dependencies

### DIFF
--- a/images/test-environments/linux/Dockerfile
+++ b/images/test-environments/linux/Dockerfile
@@ -13,6 +13,9 @@ ARG OS_TYPE
 RUN curl -LO "http://repo.continuum.io/miniconda/Miniconda3-${CONDA_VER}-Linux-${OS_TYPE}.sh" && \
     bash Miniconda3-${CONDA_VER}-Linux-${OS_TYPE}.sh -p /miniconda -b && \
     rm Miniconda3-${CONDA_VER}-Linux-${OS_TYPE}.sh
+	
+RUN ./miniconda/bin/conda update -y certifi
+RUN ./miniconda/bin/conda update -y cryptography
 
 ARG UBUNTU_VER
 # Download the Microsoft repository GPG keys

--- a/images/test-environments/linux/Dockerfile
+++ b/images/test-environments/linux/Dockerfile
@@ -26,16 +26,16 @@ ARG DEBIAN_FRONTEND=noninteractive
 # Update the list of packages after we added packages.microsoft.com
 RUN apt-get update && \
     apt-get -y install \
-    git \
-    powershell \
-    # install the below packages to pick up the latest security patch
-    logsave \
-    libext2fs2 \
-    libss2 \
-    libcom-err2 \
-    e2fsprogs \
-    libssl1.1 \
-    openssl && \
+        git \
+        powershell \
+        # install the below packages to pick up the latest security patch
+        logsave \
+        libext2fs2 \
+        libss2 \
+        libcom-err2 \
+        e2fsprogs \
+        libssl1.1 \
+        openssl && \
     # We clean the apt cache at the end of each apt command so that the caches
     # don't get stored in each layer.
     apt-get clean && rm -rf /var/lib/apt/lists/

--- a/images/test-environments/linux/Dockerfile
+++ b/images/test-environments/linux/Dockerfile
@@ -13,8 +13,7 @@ ARG OS_TYPE
 RUN curl -LO "http://repo.continuum.io/miniconda/Miniconda3-${CONDA_VER}-Linux-${OS_TYPE}.sh" && \
     bash Miniconda3-${CONDA_VER}-Linux-${OS_TYPE}.sh -p /miniconda -b && \
     rm Miniconda3-${CONDA_VER}-Linux-${OS_TYPE}.sh
-	
-RUN ./miniconda/bin/conda update -y certifi
+
 RUN ./miniconda/bin/conda update -y cryptography
 
 ARG UBUNTU_VER

--- a/images/test-environments/linux/Dockerfile
+++ b/images/test-environments/linux/Dockerfile
@@ -14,7 +14,7 @@ RUN curl -LO "http://repo.continuum.io/miniconda/Miniconda3-${CONDA_VER}-Linux-$
     bash Miniconda3-${CONDA_VER}-Linux-${OS_TYPE}.sh -p /miniconda -b && \
     rm Miniconda3-${CONDA_VER}-Linux-${OS_TYPE}.sh
 
-RUN ./miniconda/bin/conda update -y cryptography
+RUN ./miniconda/bin/conda update -y certifi
 
 ARG UBUNTU_VER
 # Download the Microsoft repository GPG keys
@@ -26,16 +26,16 @@ ARG DEBIAN_FRONTEND=noninteractive
 # Update the list of packages after we added packages.microsoft.com
 RUN apt-get update && \
     apt-get -y install \
-        git \
-        powershell \
-        # install the below packages to pick up the latest security patch
-        logsave \
-        libext2fs2 \
-        libss2 \
-        libcom-err2 \
-        e2fsprogs \
-        libssl1.1 \
-        openssl && \
+    git \
+    powershell \
+    # install the below packages to pick up the latest security patch
+    logsave \
+    libext2fs2 \
+    libss2 \
+    libcom-err2 \
+    e2fsprogs \
+    libssl1.1 \
+    openssl && \
     # We clean the apt cache at the end of each apt command so that the caches
     # don't get stored in each layer.
     apt-get clean && rm -rf /var/lib/apt/lists/


### PR DESCRIPTION
Manually call for an updated version of cryptography in the dockerfile for the test-environment. This will also pull in an updated version of certifi.