### PR TITLE
Remove deprecated quantinuum targets from test_live.py

### DIFF
--- a/tests.live/Python/test_live.py
+++ b/tests.live/Python/test_live.py
@@ -137,8 +137,6 @@ class TestQuantinuum:
         assert len(targets) > 2
 
         target_ids = [t.id for t in targets]
-        assert 'quantinuum.hqs-lt-s1' in target_ids
-        assert 'quantinuum.hqs-lt-s1-apival' in target_ids
         assert 'quantinuum.qpu.h1-1' in target_ids
         assert 'quantinuum.sim.h1-1sc' in target_ids
 
@@ -160,10 +158,6 @@ class TestQuantinuum:
 
         import qsharp.azure
         connect()
-
-        t = qsharp.azure.target("quantinuum.hqs-lt-s1-apival")
-        assert isinstance(t, qsharp.azure.AzureTarget)
-        assert t.id == "quantinuum.hqs-lt-s1-apival"
 
         t = qsharp.azure.target("quantinuum.sim.h1-1sc")
         assert isinstance(t, qsharp.azure.AzureTarget)


### PR DESCRIPTION
Remove deprecated quantinuum targets from test_live.py, because they are causing e2e tests to fail.