### PR TITLE
Pin traitlets to 5.9.0 to avoid test issue in 5.10.0

### DIFF
--- a/src/Python/requirements.txt
+++ b/src/Python/requirements.txt
@@ -10,6 +10,7 @@ pyzmq==25.0.0
 qutip==4.7.2
 selenium==4.2.0
 setuptools==67.7.2
+traitlets==5.9.0    # traitlets==5.10.0 and notebook==6.5.2 are incompatible: https://github.com/jupyter/notebook/issues/7048
 wheel==0.38.1
 Markdown>=3.4.1
 python-markdown-math>=0.8


### PR DESCRIPTION
The `test_selenium` job started failing in main. 

- First seen in [0.18.1627 from `main`](https://dev.azure.com/ms-quantum-public/Microsoft%20Quantum%20(public)/_build/results?buildId=49286&view=results). 
  - This is the first build that the newly released `traitlets==5.10.0` was installed. ([logs](https://dev.azure.com/ms-quantum-public/Microsoft%20Quantum%20(public)/_build/results?buildId=49286&view=logs&j=87bc81da-2cff-5192-98f5-9d25270ba716&t=3279529a-9d43-53cd-8d01-008b51287510&l=84)).  
  - `notebook==6.5.2` and `traitlets==5.10.0` have a known bug that blocks Jupyter Notebooks from starting: https://github.com/jupyter/notebook/issues/7048

The issue has since been fixed in `notebook==6.5.6`. However, instead of upgrading `notebook` I'm choosing the "safer" option of pinning `traitlets==5.9.0`, the last known working version.